### PR TITLE
Issue #154 Corrected handling of temporary file creation

### DIFF
--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -124,7 +124,8 @@ public interface Environment {
          */
         public Mock() throws IOException {
             final File temp = File.createTempFile(
-                System.getProperty("java.io.tmpdir"), ".qulice"
+                "mock", ".qulice",
+                new File(System.getProperty("java.io.tmpdir"))
             );
             if (!temp.delete()) {
                 throw new IllegalStateException("files collision");


### PR DESCRIPTION
I changed the code to invoke the method 
`createTempFile(String prefix, String suffix, File directory)`
 instead of 
`createTempFile(String prefix, String suffix)`.

In the former method, the `File` class (or whatever native API call it's invoking in the background) is expecting a valid _file_ name for `prefix`. As a result, under some file systems or temp directory configurations it fails, since the `java.io.tmpdir` usually points to a _directory_ location. The latter version is the one that explicitly allows a directory to be defined.

With this fix, `com.qulice.spi.EnvironmentTest` should work regardless of the temp directory location or file system.
