### PR TITLE
Issue #165 Removed redundant puzzle format check

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -110,16 +110,6 @@
         <property name="message" value="Two consecutive empty lines"/>
     </module>
 
-
-    <!--
-    Regexp for PDD todo tags formatting.
-    -->
-    <module name="RegexpMultiline">
-        <property name="format" value="^ +\* @todo A#[\w\d:\-]+!?(:[0-9]+hrs?)? [A-Z][^\n]+$\n(^ +\*  [^ ][^\n]*$\n)*\n"/>
-        <property name="fileExtensions" value="java"/>
-        <property name="message" value="Wrong format of @todo tag"/>
-    </module>
-
     <!--
     JavaDoc regexp checks
     -->


### PR DESCRIPTION
The `RegexpMultiline` check removed here is covered more comprehensively in `PuzzleFormatCheck`.
