### PR TITLE
#295 XmlValidator normalizes line endings when checking formatting

### DIFF
--- a/qulice-xml/src/main/java/com/qulice/xml/XmlValidator.java
+++ b/qulice-xml/src/main/java/com/qulice/xml/XmlValidator.java
@@ -126,8 +126,10 @@ public final class XmlValidator implements Validator {
      */
     private void formatting(final String name, final String before)
         throws ValidationException {
-        final String after = new Prettifier().prettify(before);
-        if (!before.equals(after)) {
+        // @checkstyle MultipleStringLiterals (3 lines)
+        final String after = new Prettifier().prettify(before)
+            .replace("\r\n", "\n");
+        if (!before.replace("\r\n", "\n").equals(after)) {
             throw new ValidationException(
                 // @checkstyle LineLength (1 line)
                 "The provided XML %s is not well formatted, it should look like this:\n%s",


### PR DESCRIPTION
Note that this change means that `XmlValidator` will only check for formatting while ignoring line endings, since it converts everything to Unix-style internally. Thus, it won't matter what the line endings of the actual XML are or which platform you're running Qulice on.

For the line ending checks, we have Checkstyle, so I think it would be redundant to check for that in `XmlValidator`.
