### PR TITLE
For #1004: Enforce since tag in inner classes

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -63,10 +63,6 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @see <a href="http://svnbook.red-bean.com/en/1.4/svn.advanced.props.special.keywords.html">Keywords substitution in Subversion</a>
  * @since 0.3
- * @todo #743:30min Nested classes should have since tag. Implement check to
- *  validate if nested classes javadoc have a valid since tag. After the
- *  implementation add JavadocTagsCheck to checks.xml and ChecksTest (removed
- *  because now the test fails).
  */
 public final class JavadocTagsCheck extends AbstractCheck {
 
@@ -111,21 +107,19 @@ public final class JavadocTagsCheck extends AbstractCheck {
 
     @Override
     public void visitToken(final DetailAST ast) {
-        if (ast.getParent() == null) {
-            final String[] lines = this.getLines();
-            final int start = ast.getLineNo();
-            final int cstart = JavadocTagsCheck.findCommentStart(lines, start);
-            final int cend = JavadocTagsCheck.findCommentEnd(lines, start);
-            if (cend > cstart && cstart >= 0) {
-                for (final String tag : this.prohibited) {
-                    this.findProhibited(lines, start, cstart, cend, tag);
-                }
-                for (final String tag : this.tags.keySet()) {
-                    this.matchTagFormat(lines, cstart, cend, tag);
-                }
-            } else {
-                this.log(0, "Problem finding class/interface comment");
+        final String[] lines = this.getLines();
+        final int start = ast.getLineNo();
+        final int cstart = JavadocTagsCheck.findCommentStart(lines, start);
+        final int cend = JavadocTagsCheck.findCommentEnd(lines, start);
+        if (cend > cstart && cstart >= 0) {
+            for (final String tag : this.prohibited) {
+                this.findProhibited(lines, start, cstart, cend, tag);
             }
+            for (final String tag : this.tags.keySet()) {
+                this.matchTagFormat(lines, cstart, cend, tag);
+            }
+        } else {
+            this.log(0, "Problem finding class/interface comment");
         }
     }
 
@@ -252,7 +246,7 @@ public final class JavadocTagsCheck extends AbstractCheck {
         for (int pos = start; pos <= end; pos += 1) {
             final String line = lines[pos];
             if (line.contains(String.format("@%s ", tag))) {
-                if (!line.startsWith(prefix)) {
+                if (!line.trim().startsWith(prefix.trim())) {
                     this.log(
                         start + pos + 1,
                         "Line with ''@{0}'' does not start with a ''{1}''",

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -418,6 +418,7 @@
         <module name="com.qulice.checkstyle.FinalSemicolonInTryWithResourcesCheck"/>
         <module name="com.qulice.checkstyle.JavadocEmptyLineCheck"/>
         <module name="com.qulice.checkstyle.DiamondOperatorCheck"/>
+        <module name="com.qulice.checkstyle.JavadocTagsCheck"/>
     </module>
 
     <!--

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -79,6 +79,7 @@ public final class ChecksTest {
         "NonStaticMethodCheck",
         "ConstantUsageCheck",
         "JavadocEmptyLineCheck",
+        "JavadocTagsCheck",
     };
 
     /**

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
@@ -24,6 +24,7 @@ public class ValidAbbreviationAsWordInName extends SomeClass {
 
     /**
      * ValidInnerHtml example class having the abbreviation in camelcase.
+     * @since 1.0
      */
     public class ValidInnerHtml {
     }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
@@ -10,6 +10,7 @@ package foo;
 public class ValidAbbreviationAsWordInNameIT {
     /**
      * Valid name on inner class, because the IT abbreviation is allowed.
+     * @since 1.0
      */
     class ValidInnerIT {
     }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidDiamondsUsage.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidDiamondsUsage.java
@@ -35,12 +35,14 @@ public final class ValidDiamondsUsage {
 
     /**
      * Simple interface, used as wrapper.
+     * @since 1.0
      */
     interface SimpleInterface {
 
         /**
          * Inner class with generic parameter.
          * @param <E> generic parameter
+         * @since 1.0
          */
         final class InnerClass<E> implements SimpleInterface {
 


### PR DESCRIPTION
For #1004: Enforce since tag in inner classes
- Corrected `JavadocTagsCheck.java`
- Added check execution to tests and validation
- Corrected sample classes for other tests