### PR TITLE
For #1085 Update Copyright notice to 2021

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/LICENSE.txt
+++ b/qulice-ant/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/LICENSE.txt
+++ b/qulice-ant/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/pom.xml
+++ b/qulice-ant/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/pom.xml
+++ b/qulice-ant/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/LICENSE.txt
+++ b/qulice-ant/src/it/findbugs-violations/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/LICENSE.txt
+++ b/qulice-ant/src/it/findbugs-violations/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/build.xml
+++ b/qulice-ant/src/it/findbugs-violations/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/build.xml
+++ b/qulice-ant/src/it/findbugs-violations/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/pom.xml
+++ b/qulice-ant/src/it/findbugs-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/pom.xml
+++ b/qulice-ant/src/it/findbugs-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/src/main/java/com/qulice/foo/Main.java
+++ b/qulice-ant/src/it/findbugs-violations/src/main/java/com/qulice/foo/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/src/main/java/com/qulice/foo/Main.java
+++ b/qulice-ant/src/it/findbugs-violations/src/main/java/com/qulice/foo/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-ant/src/it/findbugs-violations/src/main/java/com/qulice/foo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/findbugs-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-ant/src/it/findbugs-violations/src/main/java/com/qulice/foo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/settings.xml
+++ b/qulice-ant/src/it/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/it/settings.xml
+++ b/qulice-ant/src/it/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/main/java/com/qulice/ant/package-info.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/main/java/com/qulice/ant/package-info.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/site/apt/index.apt.vm
+++ b/qulice-ant/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/site/apt/index.apt.vm
+++ b/qulice-ant/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/site/site.xml
+++ b/qulice-ant/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/site/site.xml
+++ b/qulice-ant/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
+++ b/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
+++ b/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/test/java/com/qulice/ant/package-info.java
+++ b/qulice-ant/src/test/java/com/qulice/ant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-ant/src/test/java/com/qulice/ant/package-info.java
+++ b/qulice-ant/src/test/java/com/qulice/ant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/LICENSE.txt
+++ b/qulice-checkstyle/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/LICENSE.txt
+++ b/qulice-checkstyle/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocEmptyLineCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocEmptyLineCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocEmptyLineCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocEmptyLineCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRange.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRange.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRanges.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRanges.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/package-info.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/package-info.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/TypeParameters.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/TypeParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/TypeParameters.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/TypeParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/package-info.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/package-info.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/suppressions.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/suppressions.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/site/apt/index.apt.vm
+++ b/qulice-checkstyle/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/site/apt/index.apt.vm
+++ b/qulice-checkstyle/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/site/site.xml
+++ b/qulice-checkstyle/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/site/site.xml
+++ b/qulice-checkstyle/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/package-info.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/package-info.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/BracketsStructureCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/BracketsStructureCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/BracketsStructureCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/BracketsStructureCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ConstantUsageCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ConstantUsageCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ConstantUsageCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ConstantUsageCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CurlyBracketsStructureCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CurlyBracketsStructureCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CurlyBracketsStructureCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CurlyBracketsStructureCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/EmptyLinesCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/EmptyLinesCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/EmptyLinesCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/EmptyLinesCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ImportCohesionCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ImportCohesionCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ImportCohesionCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ImportCohesionCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocLocationCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocLocationCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocLocationCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocLocationCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodsOrderCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodsOrderCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodsOrderCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodsOrderCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MultilineJavadocTagsCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MultilineJavadocTagsCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MultilineJavadocTagsCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MultilineJavadocTagsCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForOverriddenMethodsCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForOverriddenMethodsCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForOverriddenMethodsCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForOverriddenMethodsCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitNonFinalClassesCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitNonFinalClassesCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitNonFinalClassesCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitNonFinalClassesCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/QualifyInnerClassCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/QualifyInnerClassCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/QualifyInnerClassCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/QualifyInnerClassCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/RequireThisCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/RequireThisCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/RequireThisCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/RequireThisCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/StringLiteralsConcatenationCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/StringLiteralsConcatenationCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/StringLiteralsConcatenationCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/StringLiteralsConcatenationCheck/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/log4j.properties
+++ b/qulice-checkstyle/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2019, Qulice.com
+# Copyright (c) 2011-2020, Qulice.com
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/log4j.properties
+++ b/qulice-checkstyle/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2020, Qulice.com
+# Copyright (c) 2011-2021, Qulice.com
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/LICENSE.txt
+++ b/qulice-findbugs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/LICENSE.txt
+++ b/qulice-findbugs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/pom.xml
+++ b/qulice-findbugs/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/pom.xml
+++ b/qulice-findbugs/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
+++ b/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
+++ b/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/mock/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/mock/java/com/qulice/findbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/mock/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/mock/java/com/qulice/findbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/site/apt/index.apt.vm
+++ b/qulice-findbugs/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/site/apt/index.apt.vm
+++ b/qulice-findbugs/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/site/site.xml
+++ b/qulice-findbugs/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/site/site.xml
+++ b/qulice-findbugs/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/test/java/com/qulice/findbugs/FindBugsValidatorTest.java
+++ b/qulice-findbugs/src/test/java/com/qulice/findbugs/FindBugsValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/test/java/com/qulice/findbugs/FindBugsValidatorTest.java
+++ b/qulice-findbugs/src/test/java/com/qulice/findbugs/FindBugsValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/test/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/test/java/com/qulice/findbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/test/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/test/java/com/qulice/findbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/test/resources/log4j.properties
+++ b/qulice-findbugs/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2019, Qulice.com
+# Copyright (c) 2011-2020, Qulice.com
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/qulice-findbugs/src/test/resources/log4j.properties
+++ b/qulice-findbugs/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2020, Qulice.com
+# Copyright (c) 2011-2021, Qulice.com
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/LICENSE.txt
+++ b/qulice-gradle-plugin/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/LICENSE.txt
+++ b/qulice-gradle-plugin/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/build.gradle
+++ b/qulice-gradle-plugin/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/build.gradle
+++ b/qulice-gradle-plugin/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/pom.xml
+++ b/qulice-gradle-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/pom.xml
+++ b/qulice-gradle-plugin/pom.xml
@@ -44,7 +44,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
   <repositories>
     <repository>
       <id>Spring Source Libs</id>
-      <url>http://repo.springsource.org/libs-release-remote/</url>
+      <url>https://repo.springsource.org/libs-release-remote/</url>
     </repository>
   </repositories>
   <dependencies>

--- a/qulice-gradle-plugin/pom.xml
+++ b/qulice-gradle-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/src/main/java/com/qulice/gradle/QulicePlugin.java
+++ b/qulice-gradle-plugin/src/main/java/com/qulice/gradle/QulicePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/src/main/java/com/qulice/gradle/QulicePlugin.java
+++ b/qulice-gradle-plugin/src/main/java/com/qulice/gradle/QulicePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/src/main/java/com/qulice/gradle/package-info.java
+++ b/qulice-gradle-plugin/src/main/java/com/qulice/gradle/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-gradle-plugin/src/main/java/com/qulice/gradle/package-info.java
+++ b/qulice-gradle-plugin/src/main/java/com/qulice/gradle/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/LICENSE.txt
+++ b/qulice-maven-plugin/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/LICENSE.txt
+++ b/qulice-maven-plugin/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-locale/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/checkstyle-locale/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-locale/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/checkstyle-locale/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-locale/pom.xml
+++ b/qulice-maven-plugin/src/it/checkstyle-locale/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-locale/pom.xml
+++ b/qulice-maven-plugin/src/it/checkstyle-locale/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-newlines/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/checkstyle-newlines/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-newlines/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/checkstyle-newlines/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-newlines/pom.xml
+++ b/qulice-maven-plugin/src/it/checkstyle-newlines/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-newlines/pom.xml
+++ b/qulice-maven-plugin/src/it/checkstyle-newlines/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-violations/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-violations/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Brackets.java
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Brackets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Brackets.java
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Brackets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Constants.java
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Constants.java
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-not-matches-exclude/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/dependency-not-matches-exclude/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-not-matches-exclude/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/dependency-not-matches-exclude/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-not-matches-exclude/pom.xml
+++ b/qulice-maven-plugin/src/it/dependency-not-matches-exclude/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-not-matches-exclude/pom.xml
+++ b/qulice-maven-plugin/src/it/dependency-not-matches-exclude/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/hibernate.cfg.xml
+++ b/qulice-maven-plugin/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/hibernate.cfg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/hibernate.cfg.xml
+++ b/qulice-maven-plugin/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/hibernate.cfg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/model/package-info.java
+++ b/qulice-maven-plugin/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/model/package-info.java
+++ b/qulice-maven-plugin/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/pom.xml
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/pom.xml
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/verify.groovy
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/verify.groovy
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/verify.groovy
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/verify.groovy
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/dependency-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/dependency-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/duplicate-finder-ignore-deps/pom.xml
+++ b/qulice-maven-plugin/src/it/duplicate-finder-ignore-deps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/duplicate-finder-ignore-deps/pom.xml
+++ b/qulice-maven-plugin/src/it/duplicate-finder-ignore-deps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/duplicate-finder-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/duplicate-finder-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/duplicate-finder-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/duplicate-finder-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/pom.xml
+++ b/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/pom.xml
+++ b/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/src/main/java/com/qulice/foo/TestSocket.java
+++ b/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/src/main/java/com/qulice/foo/TestSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/src/main/java/com/qulice/foo/TestSocket.java
+++ b/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/src/main/java/com/qulice/foo/TestSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/src/main/java/com/qulice/foo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-maven-plugin/src/it/findbugs-bed-bogus-exception-declaration/src/main/java/com/qulice/foo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-exclude/pom.xml
+++ b/qulice-maven-plugin/src/it/findbugs-exclude/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-exclude/pom.xml
+++ b/qulice-maven-plugin/src/it/findbugs-exclude/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/findbugs-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/findbugs-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/findbugs-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/hibernate-validator-check/pom.xml
+++ b/qulice-maven-plugin/src/it/hibernate-validator-check/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/hibernate-validator-check/pom.xml
+++ b/qulice-maven-plugin/src/it/hibernate-validator-check/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/log-check/pom.xml
+++ b/qulice-maven-plugin/src/it/log-check/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/log-check/pom.xml
+++ b/qulice-maven-plugin/src/it/log-check/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/pom.xml
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/pom.xml
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/Main.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/Main.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/package-info.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/package-info.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/MainTest.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/MainTest.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/package-info.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/package-info.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-tk/pom.xml
+++ b/qulice-maven-plugin/src/it/multi-module/mod-tk/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-tk/pom.xml
+++ b/qulice-maven-plugin/src/it/multi-module/mod-tk/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-tk/src/main/resources/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/multi-module/mod-tk/src/main/resources/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/mod-tk/src/main/resources/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/multi-module/mod-tk/src/main/resources/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/pom.xml
+++ b/qulice-maven-plugin/src/it/multi-module/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-module/pom.xml
+++ b/qulice-maven-plugin/src/it/multi-module/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-run/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/multi-run/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-run/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/multi-run/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-run/pom.xml
+++ b/qulice-maven-plugin/src/it/multi-run/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/multi-run/pom.xml
+++ b/qulice-maven-plugin/src/it/multi-run/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/FourDuplicateStringLiterals.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/FourDuplicateStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/FourDuplicateStringLiterals.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/FourDuplicateStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/SuppressDuplicateStringLiterals.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/SuppressDuplicateStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/SuppressDuplicateStringLiterals.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/SuppressDuplicateStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/TwoDuplicateStringLiterals.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/TwoDuplicateStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/TwoDuplicateStringLiterals.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/TwoDuplicateStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/WithoutDuplicateStringLiterals.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/WithoutDuplicateStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/WithoutDuplicateStringLiterals.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/WithoutDuplicateStringLiterals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-maven-plugin/src/it/pmd-duplicate-string-literals-violations/src/main/java/com/qulice/foo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-violations/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/pmd-violations/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-violations/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/pmd-violations/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/pmd-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/pmd-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/Violations.java
+++ b/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/Violations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/Violations.java
+++ b/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/Violations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pom-xpath-validator-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/pom-xpath-validator-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/pom-xpath-validator-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/pom-xpath-validator-violations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/relocation/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/relocation/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/relocation/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/relocation/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/relocation/pom.xml
+++ b/qulice-maven-plugin/src/it/relocation/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/relocation/pom.xml
+++ b/qulice-maven-plugin/src/it/relocation/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/settings.xml
+++ b/qulice-maven-plugin/src/it/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/settings.xml
+++ b/qulice-maven-plugin/src/it/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/snapshots/pom.xml
+++ b/qulice-maven-plugin/src/it/snapshots/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/snapshots/pom.xml
+++ b/qulice-maven-plugin/src/it/snapshots/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/EnforcerValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/EnforcerValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/EnforcerValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/EnforcerValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SnapshotsValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SnapshotsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SnapshotsValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SnapshotsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/ValidatorsProvider.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/ValidatorsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/ValidatorsProvider.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/ValidatorsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/package-info.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/package-info.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/site/apt/index.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/site/apt/index.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/site/apt/usage.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/usage.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without
@@ -74,7 +74,7 @@ Usage
   this is your <<<LICENSE.txt>>>:
 
 +--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -85,7 +85,7 @@ are met: no conditions.
 
 +--
 /**
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/qulice-maven-plugin/src/site/apt/usage.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/usage.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without
@@ -74,7 +74,7 @@ Usage
   this is your <<<LICENSE.txt>>>:
 
 +--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -85,7 +85,7 @@ are met: no conditions.
 
 +--
 /**
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/qulice-maven-plugin/src/site/fml/faq.fml
+++ b/qulice-maven-plugin/src/site/fml/faq.fml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
  *
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/site/fml/faq.fml
+++ b/qulice-maven-plugin/src/site/fml/faq.fml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
  *
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/site/site.xml
+++ b/qulice-maven-plugin/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/site/site.xml
+++ b/qulice-maven-plugin/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultValidatorsProviderTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultValidatorsProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultValidatorsProviderTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultValidatorsProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenProjectMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenProjectMocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenProjectMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenProjectMocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/SvnPropertiesValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/SvnPropertiesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/SvnPropertiesValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/SvnPropertiesValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/package-info.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/package-info.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/resources/com/qulice/maven/PomXpathValidator/pom.xml
+++ b/qulice-maven-plugin/src/test/resources/com/qulice/maven/PomXpathValidator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/test/resources/com/qulice/maven/PomXpathValidator/pom.xml
+++ b/qulice-maven-plugin/src/test/resources/com/qulice/maven/PomXpathValidator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/LICENSE.txt
+++ b/qulice-pmd/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/LICENSE.txt
+++ b/qulice-pmd/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/pom.xml
+++ b/qulice-pmd/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/pom.xml
+++ b/qulice-pmd/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/package-info.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/package-info.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/ProhibitPlainJunitAssertionsRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/ProhibitPlainJunitAssertionsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/ProhibitPlainJunitAssertionsRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/ProhibitPlainJunitAssertionsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/package-info.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/package-info.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/site/apt/index.apt.vm
+++ b/qulice-pmd/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/site/apt/index.apt.vm
+++ b/qulice-pmd/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/site/site.xml
+++ b/qulice-pmd/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/site/site.xml
+++ b/qulice-pmd/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/LocalVariableCouldBeFinalRuleTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/LocalVariableCouldBeFinalRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/LocalVariableCouldBeFinalRuleTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/LocalVariableCouldBeFinalRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdEmptyTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdEmptyTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/UnusedImportsRuleTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/UnusedImportsRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/UnusedImportsRuleTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/UnusedImportsRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/package-info.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/java/com/qulice/pmd/package-info.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/resources/log4j.properties
+++ b/qulice-pmd/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2019, Qulice.com
+# Copyright (c) 2011-2020, Qulice.com
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/qulice-pmd/src/test/resources/log4j.properties
+++ b/qulice-pmd/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2020, Qulice.com
+# Copyright (c) 2011-2021, Qulice.com
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/LICENSE.txt
+++ b/qulice-spi/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/LICENSE.txt
+++ b/qulice-spi/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/pom.xml
+++ b/qulice-spi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/pom.xml
+++ b/qulice-spi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/ResourceValidator.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/ResourceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/ResourceValidator.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/ResourceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/ValidationException.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/ValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/ValidationException.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/ValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/Validator.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Validator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/Validator.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Validator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/Violation.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Violation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/Violation.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Violation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/package-info.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/main/java/com/qulice/spi/package-info.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/site/apt/index.apt.vm
+++ b/qulice-spi/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/site/apt/index.apt.vm
+++ b/qulice-spi/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/site/site.xml
+++ b/qulice-spi/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/site/site.xml
+++ b/qulice-spi/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/test/java/com/qulice/spi/EnvironmentTest.java
+++ b/qulice-spi/src/test/java/com/qulice/spi/EnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/test/java/com/qulice/spi/EnvironmentTest.java
+++ b/qulice-spi/src/test/java/com/qulice/spi/EnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/test/java/com/qulice/spi/package-info.java
+++ b/qulice-spi/src/test/java/com/qulice/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spi/src/test/java/com/qulice/spi/package-info.java
+++ b/qulice-spi/src/test/java/com/qulice/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/LICENSE.txt
+++ b/qulice-spotbugs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/LICENSE.txt
+++ b/qulice-spotbugs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/pom.xml
+++ b/qulice-spotbugs/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/pom.xml
+++ b/qulice-spotbugs/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/package-info.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/package-info.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/package-info.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019, Qulice.com
+ * Copyright (c) 2011-2020, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/package-info.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020, Qulice.com
+ * Copyright (c) 2011-2021, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/src/site/apt/quality.apt.vm
+++ b/src/site/apt/quality.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2019, Qulice.com
+~~ Copyright (c) 2011-2020, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/src/site/apt/quality.apt.vm
+++ b/src/site/apt/quality.apt.vm
@@ -7,7 +7,7 @@
  ------
 
 ~~
-~~ Copyright (c) 2011-2020, Qulice.com
+~~ Copyright (c) 2011-2021, Qulice.com
 ~~ All rights reserved.
 ~~
 ~~ Redistribution and use in source and binary forms, with or without

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2019, Qulice.com
+Copyright (c) 2011-2020, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2011-2020, Qulice.com
+Copyright (c) 2011-2021, Qulice.com
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
For #1085

* Update Copyright notice to 2020
* Copy changes from https://github.com/teamed/qulice/pull/1069 to pass a build