### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - JAVA_OPTS="-Xmx4g"
 install:
   - set -e
-  - travis_retry sudo apt-get install -y --fix-missing libmagic1 libmagic-dev
+  - sudo apt-get install -y --fix-missing libmagic1 libmagic-dev
   - gem install --no-document pdd
   - gem install --no-document est
   - gem install --no-document xcop


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
