### PR TITLE
#1062, ignore overridden methods for parameter number check

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -329,6 +329,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     <module name="MethodLength"/>
     <module name="ParameterNumber">
       <property name="max" value="3"/>
+      <property name="ignoreOverriddenMethods" value="true"/>
     </module>
     <module name="OuterTypeNumber"/>
     <module name="MethodCount"/>


### PR DESCRIPTION
I enabled ignoreOverriddenMethods for ParameterNumberCheck. As this option is already unit tested in checkstyle https://github.com/checkstyle/checkstyle/blob/master/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java#L99, I think no unit test is needed in qulice. But I built a snapshot of qulice and ran mvn qulice:check in one of my own java projects. Violation is now only tagged at the place where the method is defined originally, but not where it is being overridden. 