### PR TITLE
Excluding files from PMD checking

### DIFF
--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -66,7 +66,7 @@ public final class PmdValidator implements ResourceValidator {
         final Collection<DataSource> sources = new LinkedList<>();
         for (final File file : files) {
             final String name = file.getPath().substring(
-                    this.env.basedir().toString().length()
+                this.env.basedir().toString().length()
             );
             if (!this.env.exclude("pmd", name)) {
                 sources.add(new FileDataSource(file));

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -65,7 +65,12 @@ public final class PmdValidator implements ResourceValidator {
         final SourceValidator validator = new SourceValidator(this.env);
         final Collection<DataSource> sources = new LinkedList<>();
         for (final File file : files) {
-            sources.add(new FileDataSource(file));
+            final String name = file.getPath().substring(
+                    this.env.basedir().toString().length()
+            );
+            if (!this.env.exclude("pmd", name)) {
+                sources.add(new FileDataSource(file));
+            }
         }
         final Collection<RuleViolation> breaches = validator.validate(
             sources, this.env.basedir().getPath()


### PR DESCRIPTION
PMD check is performed also for files (folders) specified in the exclusion list, which takes time. 
This commit excludes such files.
