### PR TITLE
Excluding files from Checkstyle validation

### DIFF
--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -40,6 +40,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
   <name>qulice-maven-plugin</name>
   <properties>
     <maven.version>3.0.5</maven.version>
+    <pmd.version>6.10.0</pmd.version>
   </properties>
   <dependencies>
     <dependency>
@@ -224,6 +225,11 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <version>5.0.0.Final</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-core</artifactId>
+      <version>${pmd.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -343,6 +349,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
                 <exclude>findbugs:com.qulice.maven.HelpMojo</exclude>
                 <exclude>checkstyle:/src/it/.*</exclude>
                 <exclude>pmd:.*/src/it/.*</exclude>
+                <exclude>pmd:.*/src/test/resources/com/qulice/maven/ValidationExclusion/.*</exclude>
                 <exclude>xml:/src/it/.*</exclude>
                 <exclude>duplicatefinder:.*</exclude>
               </excludes>

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidationExclusionTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidationExclusionTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2011-2022 Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.maven;
+
+import com.qulice.checkstyle.CheckstyleValidator;
+import com.qulice.pmd.PmdValidator;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import net.sourceforge.pmd.util.datasource.DataSource;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.TextOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test case for {@link DefaultMavenEnvironment} class methods that
+ * exclude files from validation.
+ * @since 0.19
+ */
+public class ValidationExclusionTest {
+    /**
+     * Temporary directory for the project source folder.
+     */
+    private static final String TEMP_DIR = "src";
+
+    /**
+     * Temporary directory for the project subfolder to be excluded.
+     */
+    private static final String TEMP_SUB = "excl";
+
+    /**
+     * Java files extension.
+     */
+    private static final String JAVA_EXT = ".java";
+
+    /**
+     * DefaultMavenEnvironment can exclude a path from PMD validation.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public final void excludePathFromPmdValidation() throws Exception {
+        final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
+        final MavenProject project = Mockito.mock(MavenProject.class);
+        final Path dir = Files.createTempDirectory(ValidationExclusionTest.TEMP_DIR);
+        final Path subdir = Files.createTempDirectory(dir, ValidationExclusionTest.TEMP_SUB);
+        final File file = File.createTempFile(
+            "PmdExample", ValidationExclusionTest.JAVA_EXT,
+            subdir.toFile()
+        );
+        Mockito.when(project.getBasedir())
+            .thenReturn(
+                dir.toFile()
+            );
+        env.setProject(project);
+        Assertions.assertNotNull(project.getBasedir());
+        final String source = new TextOf(
+            new ResourceOf("com/qulice/maven/ValidationExclusion/PmdExample.txt")
+        ).asString();
+        FileUtils.forceDeleteOnExit(file);
+        FileUtils.writeStringToFile(
+            file,
+            source,
+            StandardCharsets.UTF_8
+        );
+        env.setExcludes(
+            Collections.singletonList(
+                String.format("pmd:/%s/.*", subdir.getFileName())
+            )
+        );
+        final PmdValidator validator = new PmdValidator(env);
+        final Collection<DataSource> files = validator.getNonExcludedFiles(
+            Collections.singletonList(file)
+        );
+        Assertions.assertTrue(files.isEmpty());
+    }
+
+    /**
+     * DefaultMavenEnvironment can exclude a path from Checkstyle validation.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public final void excludePathFromCheckstyleValidation() throws Exception {
+        final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
+        final MavenProject project = Mockito.mock(MavenProject.class);
+        final Path dir = Files.createTempDirectory(ValidationExclusionTest.TEMP_DIR);
+        final Path subdir = Files.createTempDirectory(dir, ValidationExclusionTest.TEMP_SUB);
+        final File file = File.createTempFile(
+            "CheckstyleExample", ValidationExclusionTest.JAVA_EXT,
+            subdir.toFile()
+        );
+        env.setProject(project);
+        Mockito.when(project.getBasedir()).thenReturn(dir.toFile());
+        final Build build = new Build();
+        build.setOutputDirectory(dir.toString());
+        Mockito.when(project.getBuild()).thenReturn(build);
+        Assertions.assertNotNull(project.getBasedir());
+        Assertions.assertNotNull(env.tempdir());
+        final String source = new TextOf(
+            new ResourceOf("com/qulice/maven/ValidationExclusion/CheckstyleExample.txt")
+        ).asString();
+        FileUtils.forceDeleteOnExit(file);
+        FileUtils.writeStringToFile(
+            file,
+            source,
+            StandardCharsets.UTF_8
+        );
+        env.setExcludes(
+            Collections.singletonList(
+                String.format("checkstyle:/%s/.*", subdir.getFileName())
+            )
+        );
+        final CheckstyleValidator validator = new CheckstyleValidator(env);
+        final List<File> files = validator.getNonExcludedFiles(Collections.singletonList(file));
+        Assertions.assertTrue(files.isEmpty());
+    }
+}

--- a/qulice-maven-plugin/src/test/resources/com/qulice/maven/ValidationExclusion/CheckstyleExample.txt
+++ b/qulice-maven-plugin/src/test/resources/com/qulice/maven/ValidationExclusion/CheckstyleExample.txt
@@ -1,0 +1,14 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @since 1.0
+ */
+public class MissingJavadoc {
+    public String testSomething() {
+        return "something";
+    }
+}

--- a/qulice-maven-plugin/src/test/resources/com/qulice/maven/ValidationExclusion/PmdExample.txt
+++ b/qulice-maven-plugin/src/test/resources/com/qulice/maven/ValidationExclusion/PmdExample.txt
@@ -1,0 +1,9 @@
+package foo;
+
+public final class LocalVariableCouldBeFinal {
+
+    public int method() {
+        int nonfinal = 0;
+        return nonfinal;
+    }
+}

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -63,15 +63,7 @@ public final class PmdValidator implements ResourceValidator {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public Collection<Violation> validate(final Collection<File> files) {
         final SourceValidator validator = new SourceValidator(this.env);
-        final Collection<DataSource> sources = new LinkedList<>();
-        for (final File file : files) {
-            final String name = file.getPath().substring(
-                this.env.basedir().toString().length()
-            );
-            if (!this.env.exclude("pmd", name)) {
-                sources.add(new FileDataSource(file));
-            }
-        }
+        final Collection<DataSource> sources = this.getNonExcludedFiles(files);
         final Collection<RuleViolation> breaches = validator.validate(
             sources, this.env.basedir().getPath()
         );
@@ -98,4 +90,21 @@ public final class PmdValidator implements ResourceValidator {
         return "PMD";
     }
 
+    /**
+     * Filters out excluded files from further validation.
+     * @param files Files to validate
+     * @return Relevant source files
+     */
+    public Collection<DataSource> getNonExcludedFiles(final Collection<File> files) {
+        final Collection<DataSource> sources = new LinkedList<>();
+        for (final File file : files) {
+            final String name = file.getPath().substring(
+                this.env.basedir().toString().length()
+            );
+            if (!this.env.exclude("pmd", name)) {
+                sources.add(new FileDataSource(file));
+            }
+        }
+        return sources;
+    }
 }


### PR DESCRIPTION
Checkstyle validation is performed also for files (folders) specified in the exclusion lists in POM. Only violations are filtered out in PMD and Checkstyle validators.
Excessive processing consumes a lot of time.

This commit excludes specified files from validation.

Also tests for the current changes and changes in  #1103  were added.