### PR TITLE
added integration test with unicode characters

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -30,6 +30,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
+  <property name="charset" value="UTF-8"/>
   <!--
     Enforces English locale to be independent from the
     default locale which may vary between environments.

--- a/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Юникод.java
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Юникод.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2011-2022 Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.plugin.violations;
+
+/**
+ * Validation of unicode characters in class name check.
+ */
+public final class Юникод {
+
+    /**
+     * Simple method with unicode name.
+     */
+    public void метод() {
+    }
+}


### PR DESCRIPTION
This PR is for reproducing this issue: https://github.com/objectionary/eo-hamcrest/issues/87

Note that this is only half of the problem and may help reproduce the issue with parsing Unicode characters in class names.
