### PR TITLE
added JUnit5TestShouldBePackagePrivate to qulice pmd ruleset

### DIFF
--- a/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/MainTest.java
+++ b/qulice-maven-plugin/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/MainTest.java
@@ -31,19 +31,19 @@ package com.qulice.plugin.alpha;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Simple test of the Main class.
  * @since 1.0
  */
-public final class MainTest {
+final class MainTest {
 
     /**
      * Simple testing.
      */
     @Test
-    public void testSquare() {
+    void testSquare() {
         MatcherAssert.assertThat(1, Matchers.is(Main.square(1)));
         MatcherAssert.assertThat(4, Matchers.is(Main.square(2)));
     }

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -219,11 +219,14 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     </properties>
   </rule>
   <rule name="JUnit5TestShouldBePackagePrivate" language="java" class="net.sourceforge.pmd.lang.rule.XPathRule" message="JUnit 5 tests should be package-private">
-    <description>
+    <description><![CDATA[
       Reports JUnit 5 test classes and methods that are not package-private.
       Contrary to JUnit 4 tests, which required public visibility to be run by the engine,
-      JUnit 5 tests can also be run if they’re package-private.
-      Marking them as such is a good practice to limit their visibility.
+      JUnit 5 tests can also be run if they're package-private. Marking them as such
+      is a good practice to limit their visibility.
+      Test methods are identified as those which use `@Test`, `@RepeatedTest`,
+      `@TestFactory`, `@TestTemplate` or `@ParameterizedTest`.
+    ]]>
     </description>
     <priority>3</priority>
     <properties>

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -218,4 +218,41 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       </property>
     </properties>
   </rule>
+  <rule name="JUnit5TestShouldBePackagePrivate" language="java" class="net.sourceforge.pmd.lang.rule.XPathRule" message="JUnit 5 tests should be package-private">
+    <description>
+      Reports JUnit 5 test classes and methods that are not package-private.
+      Contrary to JUnit 4 tests, which required public visibility to be run by the engine,
+      JUnit 5 tests can also be run if they’re package-private.
+      Marking them as such is a good practice to limit their visibility.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="version" value="2.0"/>
+      <!--Solve priority confict-->
+      <property name="xpath">
+        <value><![CDATA[
+          //ClassOrInterfaceDeclaration[
+          (: a Junit 5 test class, ie, it has methods with the annotation :)
+            @Interface=false() and
+            ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+              [Annotation//Name[
+                pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
+                or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
+                or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
+              ]]
+              [MethodDeclaration]
+          ]/(
+            self::*[@Abstract=false() and (@Public=true() or @Protected=true())]
+            | ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+              [Annotation//Name[
+                pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
+                or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
+                or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
+              ]]
+          /MethodDeclaration[@Public=true() or @Protected=true()]
+          )
+        ]]></value>
+      </property>
+    </properties>
+  </rule>
 </ruleset>

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -226,8 +226,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       is a good practice to limit their visibility.
       Test methods are identified as those which use `@Test`, `@RepeatedTest`,
       `@TestFactory`, `@TestTemplate` or `@ParameterizedTest`.
-    ]]>
-    </description>
+    ]]></description>
     <priority>3</priority>
     <properties>
       <property name="version" value="2.0"/>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -613,4 +613,18 @@ public final class PmdValidatorTest {
             )
         ).validate();
     }
+
+    /**
+     * PmdValidator can allow only package private methods,
+     * annotated @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void testShouldBePackagePrivate() throws Exception {
+        new PmdAssert(
+            "TestShouldBePackagePrivate.java",
+            Matchers.is(false),
+            Matchers.containsString("JUnit5TestShouldBePackagePrivate")
+        ).validate();
+    }
 }

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -616,7 +616,7 @@ public final class PmdValidatorTest {
 
     /**
      * PmdValidator can allow only package private methods,
-     * annotated @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest.
+     * annotated by @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest.
      * @throws Exception If something wrong happens inside.
      */
     @Test

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/AllowAssertFail.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/AllowAssertFail.java
@@ -4,10 +4,10 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class AllowAssertFail {
+class AllowAssertFail {
 
     @Test
-    public void prohibitPlainJunitAssertionsInTests() throws Exception {
+    void prohibitPlainJunitAssertionsInTests() throws Exception {
         Matchers.assertThat("errorMessage", "expected", Matchers.is("actual"));
         Assertions.fail("fail test");
     }

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/JunitStaticPublicMethods.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/JunitStaticPublicMethods.java
@@ -2,12 +2,12 @@ package foo.test;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
 
-public class SomeTest {
+class SomeTest {
 
     @BeforeClass
     public static void beforeClass(){
@@ -15,7 +15,7 @@ public class SomeTest {
     }
 
     @Test
-    public void emptyTest(){
+    void emptyTest(){
         //test something
     }
 

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/TestShouldBePackagePrivate.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/TestShouldBePackagePrivate.java
@@ -1,0 +1,16 @@
+package com.qulice.pmd;
+
+import org.junit.jupiter.api.Test;
+
+public class SomeTest {
+
+    @Test
+    public void testOne() {
+        // empty body
+    }
+
+    @Test
+    public void testTwo() {
+        // empty body
+    }
+}


### PR DESCRIPTION
Closes: #1130
Related to: https://github.com/objectionary/eo/issues/1035
According to:  https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#junit5testshouldbepackageprivate

Reports JUnit 5 test classes and methods that are not package-private. Contrary to JUnit 4 tests, which required public visibility to be run by the engine, JUnit 5 tests can also be run if they’re package-private. Marking them as such is a good practice to limit their visibility.

Test methods are identified as those which use `@Test`, `@RepeatedTest`, `@TestFactory`, `@TestTemplate` or `@ParameterizedTest`.