### PR TITLE
reports on JUnit test classes declared non-final.

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -257,4 +257,30 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       </property>
     </properties>
   </rule>
+  <rule name="JUnitTestClassShouldBeFinal" language="java" class="net.sourceforge.pmd.lang.rule.XPathRule" message="JUnit test class should be final">
+    <description><![CDATA[
+      Reports on JUnit test classes declared non-final.
+    ]]></description>
+    <priority>3</priority>
+    <properties>
+      <property name="version" value="2.0"/>
+      <!--Solve priority confict-->
+      <property name="xpath">
+        <value><![CDATA[
+        //TypeDeclaration
+          //ClassOrInterfaceDeclaration[
+          (: a Junit 3,4 and 5 test class :)
+            @Interface=false() and
+            ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+              [Annotation//Name[
+                pmd-java:typeIs('junit.framework.TestCase')
+                or pmd-java:typeIs('org.junit.Test')
+                or pmd-java:typeIs('org.junit.jupiter.api.Test')
+              ]]
+          ]
+          [@Final = false()]
+        ]]></value>
+      </property>
+    </properties>
+  </rule>
 </ruleset>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -627,4 +627,58 @@ public final class PmdValidatorTest {
             Matchers.containsString("JUnit5TestShouldBePackagePrivate")
         ).validate();
     }
+
+    /**
+     * PmdValidator can allow only final JUnit3 test classes.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void allowJunitThirdTestClassToBeFinal() throws Exception {
+        new PmdAssert(
+            "Junit3TestClassShouldBeFinal.java",
+            Matchers.is(false),
+            Matchers.containsString("JUnitTestClassShouldBeFinal")
+        ).validate();
+    }
+
+    /**
+     * PmdValidator can allow only final JUnit4 test classes.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void allowJunitFourthTestClassToBeFinal() throws Exception {
+        new PmdAssert(
+            "Junit4TestClassShouldBeFinal.java",
+            Matchers.is(false),
+            Matchers.containsString("JUnitTestClassShouldBeFinal")
+        ).validate();
+    }
+
+    /**
+     * PmdValidator can allow only final JUnit5 test classes.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void allowJunitFifthTestClassToBeFinal() throws Exception {
+        new PmdAssert(
+            "Junit5TestClassShouldBeFinal.java",
+            Matchers.is(false),
+            Matchers.containsString("JUnitTestClassShouldBeFinal")
+        ).validate();
+    }
+
+    /**
+     * PmdValidator can allow only final Junit test classes.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void allowJunitTestClassToBeFinal() throws Exception {
+        new PmdAssert(
+            "JunitTestClassIsFinal.java",
+            Matchers.is(true),
+            Matchers.not(
+                Matchers.containsString("JUnitTestClassShouldBeFinal")
+            )
+        ).validate();
+    }
 }

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/AllowAssertFail.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/AllowAssertFail.java
@@ -4,7 +4,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class AllowAssertFail {
+final class AllowAssertFail {
 
     @Test
     void prohibitPlainJunitAssertionsInTests() throws Exception {

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/Junit3TestClassShouldBeFinal.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/Junit3TestClassShouldBeFinal.java
@@ -1,0 +1,12 @@
+package com.qulice.pmd;
+
+import junit.framework.TestCase;
+
+class SomeTest {
+
+    @TestCase
+    void testOne() {
+        // empty body
+    }
+
+}

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/Junit4TestClassShouldBeFinal.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/Junit4TestClassShouldBeFinal.java
@@ -1,0 +1,12 @@
+package com.qulice.pmd;
+
+import org.junit.Test;
+
+class SomeTest {
+
+    @Test
+    void testOne() {
+        // empty body
+    }
+
+}

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/Junit5TestClassShouldBeFinal.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/Junit5TestClassShouldBeFinal.java
@@ -1,0 +1,16 @@
+package com.qulice.pmd;
+
+import org.junit.jupiter.api.Test;
+
+class SomeTest {
+
+    @Test
+    void testOne() {
+        // empty body
+    }
+
+    @Test
+    void testTwo() {
+        // empty body
+    }
+}

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/JunitStaticPublicMethods.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/JunitStaticPublicMethods.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.Collections;
 
-class SomeTest {
+final class SomeTest {
 
     @BeforeClass
     public static void beforeClass(){

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/JunitTestClassIsFinal.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/JunitTestClassIsFinal.java
@@ -1,0 +1,16 @@
+package com.qulice.pmd;
+
+import org.junit.jupiter.api.Test;
+
+final class SomeTest {
+
+    @Test
+    void testOne() {
+        // empty body
+    }
+
+    @Test
+    void testTwo() {
+        // empty body
+    }
+}


### PR DESCRIPTION
Closes: #1158 

What is done:
- added a new rule to the PMD ruleset to report on test classes declared non-final;
- added support for JUnit3, JUnit4 and JUnit5 test classes;
- Wrote some tests.