### PR TITLE
Run qulice-pmd tests in parallel

### DIFF
--- a/qulice-pmd/pom.xml
+++ b/qulice-pmd/pom.xml
@@ -122,9 +122,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <parallel>classes</parallel>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>com.github.github</groupId>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdEmptyTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdEmptyTest.java
@@ -35,9 +35,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link PmdValidator} class.
  * @since 0.15
- * @todo #544:30min Tests below pass only when run sequentially, when they are
- *  run in parallel some of them start to fail. Please fix the tests below and
- *  remove override of maven-surefire-plugin configuration in qulice-pmd pom.xml
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class PmdEmptyTest {


### PR DESCRIPTION
From what I see, TODO from #1116 is no longer relevant: I removed `parallel`, and tests still pass.