### PR TITLE
Improve single-line block comment check

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -53,7 +53,6 @@ import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.Replaced;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.Trimmed;
-import org.cactoos.text.UncheckedText;
 import org.xml.sax.InputSource;
 
 /**

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/SingleLineCommentCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/SingleLineCommentCheck.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2011-2022 Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * C++ style inline comment is not allowed.
+ * Use //-style comment instead.
+ * @since 0.18
+ */
+public final class SingleLineCommentCheck extends AbstractCheck {
+    /**
+     * When inside a block comment, holds begin line number.
+     */
+    private int begin;
+
+    @Override
+    public boolean isCommentNodesRequired() {
+        return true;
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[]{
+            TokenTypes.BLOCK_COMMENT_BEGIN,
+            TokenTypes.BLOCK_COMMENT_END,
+        };
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        if (ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN) {
+            this.begin = ast.getLineNo();
+        } else if (this.begin == ast.getLineNo()) {
+            this.log(ast, "This kind of comment is not allowed.");
+        }
+    }
+}

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -78,14 +78,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     <property name="message" value="Line has trailing spaces."/>
   </module>
   <!--
-    C++ style inline comment is not allowed.
-    -->
-  <module name="RegexpSingleline">
-    <property name="format" value="/\*.*\*/"/>
-    <property name="fileExtensions" value="java"/>
-    <property name="message" value="This kind of comment is not allowed."/>
-  </module>
-  <!--
     Windows line endings are not allowed.
     -->
   <module name="RegexpMultiline">

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -263,6 +263,18 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator accepts string literal which
+     * contains multiline comment.
+     * @throws Exception If test failed.
+     */
+    @Test
+    public void acceptsValidSingleLineComment() throws Exception {
+        this.runValidation(
+            "ValidSingleLineCommentCheck.java", true
+        );
+    }
+
+    /**
      * CheckstyleValidator accepts the valid indentation
      * refused by forceStrictCondition.
      * @throws Exception when error.

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidSingleLineCommentCheck.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidSingleLineCommentCheck.java
@@ -1,0 +1,28 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Correct Javadoc for class {@link AtClauseOrder}.
+ *
+ * @since 1.0
+ */
+public final class ValidSingleLineCommentCheck {
+    /**
+     * A valid literal (Qulice may not report its contents as it is domain-specific string,
+     * not Java code).
+     */
+    public static final String LITERAL_WHICH_LOOKS_LIKE_COMMENT = "/* Hello */";
+
+    /**
+     * Same here.
+     */
+    public static final String ANOTHER_LITERAL = "/**/";
+
+    /**
+     * Empty constructor.
+     */
+    private AtClauseOrder() {
+    }
+}


### PR DESCRIPTION
Previously it was implemented using a regex. However this approach is inherently not accurate, leading to problems like iss. 1079.

This patch converts to it AST-based check pass which should have no false-positives.