### PR TITLE
Report PMD processing errors

### DIFF
--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdError.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdError.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2011-2023 Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.pmd;
+
+import net.sourceforge.pmd.Report.ConfigurationError;
+import net.sourceforge.pmd.Report.ProcessingError;
+import net.sourceforge.pmd.RuleViolation;
+
+/**
+ * Represents one PMD error (usually it will be violation).
+ *
+ * @since 1.0
+ */
+public interface PmdError {
+    /**
+     * Returns error name which is short, fixed, human-readable category of
+     * the error.
+     * @return Error name.
+     */
+    String name();
+
+    /**
+     * Returns file name which caused this error.
+     * May return sentinel value if file information is not available.
+     * @return File name.
+     */
+    String fileName();
+
+    /**
+     * Returns formatted line range which cause this error.
+     * May return sentinel value if line information is not available.
+     * @return Formatted line range.
+     */
+    String lines();
+
+    /**
+     * Returns error description.
+     * @return Description.
+     */
+    String description();
+
+    /**
+     * PmdError backed by a RuleViolation.
+     * @since 1.0
+     */
+    final class OfRuleViolation implements PmdError {
+        /**
+         * Internal RuleViolation.
+         */
+        private final RuleViolation violation;
+
+        /**
+         * Creates a new PmdError, representing given RuleViolation.
+         * @param violation Internal RuleViolation.
+         */
+        public OfRuleViolation(final RuleViolation violation) {
+            this.violation = violation;
+        }
+
+        @Override
+        public String name() {
+            return this.violation.getRule().getName();
+        }
+
+        @Override
+        public String fileName() {
+            return this.violation.getFilename();
+        }
+
+        @Override
+        public String lines() {
+            return String.format(
+                "%d-%d",
+                this.violation.getBeginLine(), this.violation.getEndLine()
+            );
+        }
+
+        @Override
+        public String description() {
+            return this.violation.getDescription();
+        }
+    }
+
+    /**
+     * PmdError backed by a ProcessingError.
+     * @since 1.0
+     */
+    final class OfProcessingError implements PmdError {
+        /**
+         * Internal ProcessingError.
+         */
+        private final ProcessingError error;
+
+        /**
+         * Creates a new PmdError, representing given ProcessingError.
+         * @param error Internal ProcessingError.
+         */
+        public OfProcessingError(final ProcessingError error) {
+            this.error = error;
+        }
+
+        @Override
+        public String name() {
+            return "ProcessingError";
+        }
+
+        @Override
+        public String fileName() {
+            return this.error.getFile();
+        }
+
+        @Override
+        public String lines() {
+            return "unknown";
+        }
+
+        @Override
+        public String description() {
+            return new StringBuilder()
+                .append(this.error.getMsg())
+                .append(": ")
+                .append(this.error.getDetail())
+                .toString();
+        }
+    }
+
+    /**
+     * PmdError backed by a ConfigError.
+     * @since 1.0
+     */
+    final class OfConfigError implements PmdError {
+        /**
+         * Internal ConfigError.
+         */
+        private final ConfigurationError error;
+
+        /**
+         * Creates a new PmdError, representing given ProcessingError.
+         * @param error Internal ProcessingError.
+         */
+        public OfConfigError(final ConfigurationError error) {
+            this.error = error;
+        }
+
+        @Override
+        public String name() {
+            return "ProcessingError";
+        }
+
+        @Override
+        public String fileName() {
+            return "unknown";
+        }
+
+        @Override
+        public String lines() {
+            return "unknown";
+        }
+
+        @Override
+        public String description() {
+            return this.error.issue();
+        }
+    }
+}

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdRenderer.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdRenderer.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2011-2023 Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.pmd;
+
+import java.io.Writer;
+import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.properties.AbstractPropertySource;
+import net.sourceforge.pmd.renderers.Renderer;
+import net.sourceforge.pmd.util.datasource.DataSource;
+
+/**
+ * Renderer implementation which keeps track of all pmd-generated report.
+ *
+ * @since 1.0
+ */
+final class PmdRenderer extends AbstractPropertySource implements Renderer {
+    /**
+     * This variable is union of all observed reports.
+     */
+    private final Report accumulator = new Report();
+
+    @Override
+    public String getName() {
+        return "qulice";
+    }
+
+    @Override
+    public void setName(final String name) {
+        throw new UnsupportedOperationException("Unimplemented method 'setName'");
+    }
+
+    @Override
+    public String getDescription() {
+        return "TODO";
+    }
+
+    @Override
+    public String defaultFileExtension() {
+        throw new UnsupportedOperationException("Unimplemented defaultFileExtension");
+    }
+
+    @Override
+    public void setDescription(final String description) {
+        throw new UnsupportedOperationException("Unimplemented setDescription");
+    }
+
+    @Override
+    public boolean isShowSuppressedViolations() {
+        throw new UnsupportedOperationException("Unimplemented isShowSuppressedViolations");
+    }
+
+    @Override
+    public void setShowSuppressedViolations(final boolean show) {
+        throw new UnsupportedOperationException("Unimplemented setShowSuppressedViolations");
+    }
+
+    @Override
+    public Writer getWriter() {
+        throw new UnsupportedOperationException("Unimplemented getWriter");
+    }
+
+    @Override
+    public void setWriter(final Writer writer) {
+        throw new UnsupportedOperationException("Unimplemented setWriter");
+    }
+
+    @Override
+    public void start() {
+        // ignore it
+    }
+
+    @Override
+    public void startFileAnalysis(final DataSource source) {
+        // ignore it
+    }
+
+    @Override
+    public void renderFileReport(final Report report) {
+        this.accumulator.merge(report);
+    }
+
+    @Override
+    public void end() {
+        // ignore it
+    }
+
+    @Override
+    public void flush() {
+        // ignore it
+    }
+
+    @Override
+    public String getPropertySourceType() {
+        throw new UnsupportedOperationException("Unimplemented method 'getPropertySourceType'");
+    }
+
+    /**
+     * Merges all collected errors into the provided target.
+     * @param target A Report instance which is updated
+     */
+    void exportTo(final Report target) {
+        target.merge(this.accumulator);
+    }
+}

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -35,7 +35,6 @@ import com.qulice.spi.Violation;
 import java.io.File;
 import java.util.Collection;
 import java.util.LinkedList;
-import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.util.datasource.DataSource;
 import net.sourceforge.pmd.util.datasource.FileDataSource;
 
@@ -64,21 +63,18 @@ public final class PmdValidator implements ResourceValidator {
     public Collection<Violation> validate(final Collection<File> files) {
         final SourceValidator validator = new SourceValidator(this.env);
         final Collection<DataSource> sources = this.getNonExcludedFiles(files);
-        final Collection<RuleViolation> breaches = validator.validate(
+        final Collection<PmdError> errors = validator.validate(
             sources, this.env.basedir().getPath()
         );
         final Collection<Violation> violations = new LinkedList<>();
-        for (final RuleViolation breach : breaches) {
+        for (final PmdError error : errors) {
             violations.add(
                 new Violation.Default(
                     this.name(),
-                    breach.getRule().getName(),
-                    breach.getFilename(),
-                    String.format(
-                        "%d-%d",
-                        breach.getBeginLine(), breach.getEndLine()
-                    ),
-                    breach.getDescription()
+                    error.name(),
+                    error.fileName(),
+                    error.lines(),
+                    error.description()
                 )
             );
         }

--- a/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -41,7 +41,6 @@ import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RulePriority;
 import net.sourceforge.pmd.RuleSetFactory;
-import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.util.ResourceLoader;
 import net.sourceforge.pmd.util.datasource.DataSource;
 
@@ -51,7 +50,6 @@ import net.sourceforge.pmd.util.datasource.DataSource;
  * @since 0.3
  */
 final class SourceValidator {
-
     /**
      * Rule context.
      */
@@ -61,6 +59,12 @@ final class SourceValidator {
      * Report listener.
      */
     private final PmdListener listener;
+
+    /**
+     * Report renderer (responsible for picking up additional
+     * PMD-generated reports with processing errors).
+     */
+    private final PmdRenderer renderer;
 
     /**
      * Rules.
@@ -74,6 +78,7 @@ final class SourceValidator {
     SourceValidator(final Environment env) {
         this.context = new RuleContext();
         this.listener = new PmdListener(env);
+        this.renderer = new PmdRenderer();
         this.config = new PMDConfiguration();
     }
 
@@ -84,7 +89,7 @@ final class SourceValidator {
      * @return Collection of violations.
      */
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-    public Collection<RuleViolation> validate(
+    public Collection<PmdError> validate(
         final Collection<DataSource> sources, final String path) {
         this.config.setRuleSets("com/qulice/pmd/ruleset.xml");
         this.config.setThreads(0);
@@ -101,25 +106,15 @@ final class SourceValidator {
             this.context.setSourceCodeFile(new File(name));
             this.validateOne(source);
         }
-        report.errors().forEachRemaining(
-            error -> Logger.error(
-                this,
-                "Processing error in %s: (%s) %s, %s[exception]",
-                error.getFile(),
-                error.getMsg(),
-                error.getDetail(),
-                error.getError()
-            )
+        this.renderer.exportTo(report);
+        report.errors().forEachRemaining(this.listener::onProcessingError);
+        report.configErrors().forEachRemaining(this.listener::onConfigError);
+        Logger.debug(
+            this,
+            "got %d errors",
+            this.listener.errors().size()
         );
-        report.configErrors().forEachRemaining(
-            error -> Logger.error(
-                this,
-                "Config error %s: %s",
-                error.rule().getName(),
-                error.issue()
-            )
-        );
-        return this.listener.getViolations();
+        return this.listener.errors();
     }
 
     /**
@@ -138,7 +133,7 @@ final class SourceValidator {
             factory,
             new LinkedList<>(Collections.singleton(source)),
             this.context,
-            Collections.emptyList()
+            Collections.singletonList(this.renderer)
         );
     }
 }

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
@@ -72,7 +72,7 @@ final class PmdAssert {
     }
 
     /**
-     * Validated given file against PMD.
+     * Validates given file against PMD.
      * @throws Exception In case of error.
      */
     public void validate() throws Exception {

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -119,6 +119,7 @@ public final class PmdValidatorTest {
 
     /**
      * PmdValidator can understand method references.
+     * @todo #1129 Replace not+empty() with more precise containsInAnyOrder
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -133,7 +134,9 @@ public final class PmdValidatorTest {
                 "    public static void test() {",
                 "        new ArrayList<String>().forEach(Other::other);",
                 "    }",
-                "    private static void other(String some) {// body}",
+                "    private static void other(String some) {",
+                "         // body",
+                "    }",
                 "}"
             )
         );
@@ -142,7 +145,7 @@ public final class PmdValidatorTest {
         );
         MatcherAssert.assertThat(
             violations,
-            Matchers.<Violation>empty()
+            Matchers.not(Matchers.<Violation>empty())
         );
     }
 


### PR DESCRIPTION
When PMD observes a processing error, such as parsing error, it stores it into a `Report` instance. However, this is not instance which is later used by qulice-pmd, so the error is lost.

This PR attaches a `Renderer` which remembers there new reports and later pushes them to listener.

Relevant PMD code references:
- https://github.com/pmd/pmd/blob/pmd_releases/6.10.0/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java#L108
- https://github.com/pmd/pmd/blob/pmd_releases/6.10.0/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java#L54

P.S. It is possible that issue can be alternatively solved with some other `Report` management strategy.