### PR TITLE
justification for BranchContains usage

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BranchContains.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BranchContains.java
@@ -32,16 +32,17 @@ package com.qulice.checkstyle;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
 /**
- * Temporary utility class.
+ * Utility class that checks the existence
+ * of tokens of specific type in the AST node subtree.
  *
  * Some checks used branchContains() method in DetailAST
  * which recursively searched node subtree for the child of a given type.
- * However, this method was deprecated in upstream, so here follows it's
- * simple re-implementation.
+ * However, this method was deprecated in upstream due to unintended too
+ * deep scanning. It is recommended to write traversal implementation
+ * for your needs by yourself to avoid unexpected side effects. So here follows it's
+ * simple implementation.
  *
  * @since 1.0
- *
- * @todo #1148 Avoid branchContains usages in checks and delete this class
  */
 class BranchContains {
     /**


### PR DESCRIPTION
Closes: #1180 

branchContains method was deprecated in checkstyle due to unexpected side-effects (too deep subtree scanning) and it's recommended to write your own traversal implementations for per need. BranchContains class is quite universal implementation for most needs, so i think it shouldn't be removed.

although, BranchContains class is only used in NonStaticMethodCheck for now and it's possible to move the BranchContains functionality to NonStaticMethodCheck's private method (we can discuss which way is better)