### PR TITLE
Add simple buildsClassloader test

### DIFF
--- a/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
@@ -45,8 +45,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.types.Path;
 
 /**
  * Environment, passed from ant task to validators.
@@ -57,12 +55,12 @@ public final class AntEnvironment implements Environment {
     /**
      * Ant project.
      */
-    private final Project project;
+    private final AntProject project;
 
     /**
      * Sources dirs.
      */
-    private final Path sources;
+    private final AntPath sources;
 
     /**
      * Classes dir (only one dir is supported).
@@ -73,7 +71,7 @@ public final class AntEnvironment implements Environment {
      * Classpath dirs and files.
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    private final Path classpath;
+    private final AntPath classpath;
 
     /**
      * Public ctor.
@@ -84,10 +82,10 @@ public final class AntEnvironment implements Environment {
      * @checkstyle ParameterNumber (5 lines)
      */
     public AntEnvironment(
-        final Project prjct,
-        final Path srcs,
+        final AntProject prjct,
+        final AntPath srcs,
         final File clss,
-        final Path clsspth) {
+        final AntPath clsspth) {
         this.project = prjct;
         this.sources = srcs;
         this.classes = clss;
@@ -177,7 +175,7 @@ public final class AntEnvironment implements Environment {
     }
 
     /**
-     * Creates URL ClassLoadere in privileged block.
+     * Creates URL ClassLoader in privileged block.
      *
      * @since 0.1
      */

--- a/qulice-ant/src/main/java/com/qulice/ant/AntPath.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/AntPath.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2011-2023 Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.ant;
+
+import org.apache.tools.ant.types.Path;
+
+/**
+ * Represents subset of org.apache.tools.ant.types.Path API which is relevant to Qulice.
+ *
+ * @since 1.0
+ */
+public interface AntPath {
+    /**
+     * Returns all indivudual pathes of this path.
+     * @return List of elements.
+     */
+    String[] list();
+
+    /**
+     * Default implementation which wraps Ant path.
+     * @since 1.0
+     */
+    class Default implements AntPath {
+        /**
+         * Wrapped path.
+         */
+        private final Path path;
+
+        /**
+         * Returns AntPath equivalent to the given path.
+         * @param path A path to wrap.
+         */
+        Default(final Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public String[] list() {
+            return this.path.list();
+        }
+    }
+
+    /**
+     * Simple implementation for tests.
+     * @since 1.0
+     */
+    class Fake implements AntPath {
+        /**
+         * Result for the list() method.
+         */
+        private final String[] listres;
+
+        /**
+         * Creates fake AntPath.
+         * @param listres Array to return from the list(), assumed to be immutable.
+         * @since 1.0
+         */
+        Fake(final String... listres) {
+            this.listres = listres;
+        }
+
+        @Override
+        public String[] list() {
+            return this.listres;
+        }
+    }
+}

--- a/qulice-ant/src/main/java/com/qulice/ant/AntProject.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/AntProject.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2011-2023 Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.ant;
+
+import java.io.File;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.tools.ant.Project;
+
+/**
+ * Represents subset of org.apache.tools.ant.Project API which is relevant to Qulice.
+ *
+ * @since 1.0
+ */
+interface AntProject {
+    /**
+     * Returns Ant project property.
+     *
+     * @param property Name of the property to get.
+     * @return Property value or null.
+     */
+    String getProperty(String property);
+
+    /**
+     * Returns Ant project base directory.
+     *
+     * @return Base directory.
+     */
+    File getBaseDir();
+
+    /**
+     * Default implementation which wraps Ant Project.
+     * @since 1.0
+     */
+    class Default implements AntProject {
+        /**
+         * Wrapped project.
+         */
+        private final Project project;
+
+        /**
+         * Creates a new AntProject equivalent to the given Project.
+         * @param project Project to wrap.
+         */
+        Default(final Project project) {
+            this.project = project;
+        }
+
+        @Override
+        public String getProperty(final String property) {
+            return this.project.getProperty(property);
+        }
+
+        @Override
+        public File getBaseDir() {
+            return this.project.getBaseDir();
+        }
+    }
+
+    /**
+     * Fake implementation of AntProject which allows caller to
+     * customize both methods with lambdas.
+     *
+     * @since 1.0
+     */
+    class Fake implements AntProject {
+        /**
+         * Implementation of the getProperty() method.
+         */
+        private final Function<String, String> prop;
+
+        /**
+         * Implementation of the getBaseDir() method.
+         */
+        private final Supplier<File> basedir;
+
+        /**
+         * Creates a new FakeAntProject which will use provided
+         * functions.
+         *
+         * @param prop Implementation of the getProperty(String).
+         * @param basedir Implementation of the getBaseDir().
+         */
+        Fake(
+            final Function<String, String> prop,
+            final Supplier<File> basedir
+        ) {
+            this.prop = prop;
+            this.basedir = basedir;
+        }
+
+        @Override
+        public String getProperty(final String property) {
+            return this.prop.apply(property);
+        }
+
+        @Override
+        public File getBaseDir() {
+            return this.basedir.get();
+        }
+    }
+}

--- a/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
@@ -129,10 +129,10 @@ public final class QuliceTask extends Task {
             throw new BuildException("classpath not defined for QuliceTask");
         }
         return new AntEnvironment(
-            this.getProject(),
-            this.sources,
+            new AntProject.Default(this.getProject()),
+            new AntPath.Default(this.sources),
             this.classes,
-            this.classpath
+            new AntPath.Default(this.classpath)
         );
     }
 

--- a/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
+++ b/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
@@ -29,6 +29,8 @@
  */
 package com.qulice.ant;
 
+import com.qulice.spi.Environment;
+import java.io.File;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -42,12 +44,28 @@ public class AntEnvironmentTest {
 
     /**
      * AntEnvironment can build Classloader from org.apache.tools.ant.Project.
+     *
+     * It is also checked that this classloader does not depend on ant enviroment information.
      * @throws Exception If something wrong happens inside
      */
     @Test
     @Disabled
     @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
     public void buildsClassloader() throws Exception {
+        final Environment env = new AntEnvironment(
+            new AntProject.Fake(
+                ignored -> {
+                    throw new UnsupportedOperationException();
+                },
+                () -> {
+                    throw new UnsupportedOperationException();
+                }
+            ),
+            new AntPath.Fake(new String[]{"/foo.java", "bar.java"}),
+            new File("/some/build/out"),
+            new AntPath.Fake(new String[]{"/libfoo", "/libbar"})
+        );
+        env.classloader();
     }
 
     /**


### PR DESCRIPTION
This PR adds a simple test for one of AntEnvironment methods.

This class currently directly uses some Ant class which complicates testing. This PR replaces them with interfaces which allow simple fake implementations. 