### PR TITLE
Prohibit access to static members via instance reference.

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -145,7 +145,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       </property>
     </properties>
   </rule>
-  <rule name="StaticAccessToStaticFields" message="Static fields should be accessed in a static way [CLASS_NAME.FIELD_NAME]." language="java" class="net.sourceforge.pmd.lang.rule.XPathRule">
+  <rule name="AvoidDirectAccessToStaticFields" message="Static fields should be accessed in a static way [CLASS_NAME.FIELD_NAME]." language="java" class="net.sourceforge.pmd.lang.rule.XPathRule">
     <description>
       Avoid accessing static fields directly.
     </description>
@@ -154,6 +154,25 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <property name="xpath">
         <value><![CDATA[
           //Name[@Image = //FieldDeclaration[@Static='true']/@VariableName]
+        ]]></value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidAccessToStaticMembersViaThis" message="Static members should be accessed in a static way [CLASS_NAME.FIELD_NAME], not via instance reference." language="java" class="net.sourceforge.pmd.lang.rule.XPathRule">
+    <description>
+      Avoid accessing static fields or methods via instance with 'this' keyword.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value><![CDATA[
+          //PrimaryExpression[
+            (./PrimaryPrefix[@ThisModifier='true']) and
+            (./PrimarySuffix[
+              @Image=//FieldDeclaration[@Static='true']/@VariableName
+              or @Image=//MethodDeclaration[@Static='true']/@MethodName
+            ])
+          ]
         ]]></value>
       </property>
     </properties>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -58,6 +58,13 @@ public final class PmdValidatorTest {
     private static final String STATIC_ACCESS = "%s\\[\\d+-\\d+\\]: Static fields should be accessed in a static way \\[CLASS_NAME.FIELD_NAME\\]\\.";
 
     /**
+     * Error message for forbidding access to static members
+     * via instance reference using 'this' keyword.
+     * @checkstyle LineLength (2 lines)
+     */
+    private static final String STATIC_VIA_THIS = "%s\\[\\d+-\\d+\\]: Static members should be accessed in a static way \\[CLASS_NAME.FIELD_NAME\\], not via instance reference.";
+
+    /**
      * Error message for forbidding instructions inside a constructor
      * other than field initialization or call to other constructors.
      * @checkstyle LineLength (2 lines)
@@ -392,27 +399,68 @@ public final class PmdValidatorTest {
         final String file = "StaticAccessToStaticFields.java";
         new PmdAssert(
             file, Matchers.is(true),
-            Matchers.not(
-                RegexMatchers.containsPattern(
-                    String.format(PmdValidatorTest.STATIC_ACCESS, file)
+            Matchers.allOf(
+                Matchers.not(
+                    RegexMatchers.containsPattern(
+                        String.format(PmdValidatorTest.STATIC_ACCESS, file)
+                    )
+                ),
+                Matchers.not(
+                    RegexMatchers.containsPattern(
+                        String.format(PmdValidatorTest.STATIC_VIA_THIS, file)
+                    )
                 )
             )
         ).validate();
     }
 
     /**
-     * PmdValidator forbids calls to static fields
+     * PmdValidator forbids calls to static fields directly
      * in a non static way.
      * @throws Exception If something wrong happens inside.
      */
     @Test
-    public void forbidsCallToStaticFieldsInNonStaticWay()
+    public void forbidsCallToStaticFieldsDirectly()
         throws Exception {
-        final String file = "NonStaticAccessToStaticFields.java";
+        final String file = "DirectAccessToStaticFields.java";
         new PmdAssert(
             file, Matchers.is(false),
             RegexMatchers.containsPattern(
                 String.format(PmdValidatorTest.STATIC_ACCESS, file)
+            )
+        ).validate();
+    }
+
+    /**
+     * PmdValidator forbids calls to static fields
+     * in a non static way via instance reference.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void forbidsCallToStaticFieldsViaThis()
+        throws Exception {
+        final String file = "AccessToStaticFieldsViaThis.java";
+        new PmdAssert(
+            file, Matchers.is(false),
+            RegexMatchers.containsPattern(
+                String.format(PmdValidatorTest.STATIC_VIA_THIS, file)
+            )
+        ).validate();
+    }
+
+    /**
+     * PmdValidator forbids calls to static methods
+     * in a non static way via instance reference.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void forbidsCallToStaticMethodsViaThis()
+        throws Exception {
+        final String file = "AccessToStaticMethodsViaThis.java";
+        new PmdAssert(
+            file, Matchers.is(false),
+            RegexMatchers.containsPattern(
+                String.format(PmdValidatorTest.STATIC_VIA_THIS, file)
             )
         ).validate();
     }

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/AccessToStaticFieldsViaThis.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/AccessToStaticFieldsViaThis.java
@@ -1,0 +1,9 @@
+package foo;
+
+public final class AccessToStaticFieldsViaThis {
+    private static final int num = 1;
+
+    public int number() {
+        return this.num;
+    }
+}

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/AccessToStaticMethodsViaThis.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/AccessToStaticMethodsViaThis.java
@@ -1,0 +1,11 @@
+package foo;
+
+public final class AccessToStaticMethodsViaThis {
+    private static int number() {
+        return 1;
+    }
+
+    public int another() {
+        return 1 + this.number();
+    }
+}

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/DirectAccessToStaticFields.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/DirectAccessToStaticFields.java
@@ -1,6 +1,6 @@
 package foo;
 
-public final class NonStaticAccessToStaticFields {
+public final class DirectAccessToStaticFields {
     private static int num = 1;
 
     public static int number() {


### PR DESCRIPTION
Add pmd-xpath rule that prohibits access to static fields/methods via instance reference (particularly 'this' keyword).
Closes: #984