### PR TITLE
Refactor PmdValidatorTest#understandsMethodReferences test

### DIFF
--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -36,7 +36,6 @@ import com.qulice.pmd.rules.ProhibitPlainJunitAssertionsRule;
 import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
-import java.util.Collection;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -127,34 +126,18 @@ public final class PmdValidatorTest {
 
     /**
      * PmdValidator can understand method references.
-     * @todo #1129 Replace not+empty() with more precise containsInAnyOrder
      * @throws Exception If something wrong happens inside.
      */
     @Test
-    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public void understandsMethodReferences() throws Exception {
-        final String file = "src/main/java/Other.java";
-        final Environment env = new Environment.Mock().withFile(
+        final String file = "UnderstandsMethodReferences.java";
+        new PmdAssert(
             file,
-            Joiner.on('\n').join(
-                "import java.util.ArrayList;",
-                "class Other {",
-                "    public static void test() {",
-                "        new ArrayList<String>().forEach(Other::other);",
-                "    }",
-                "    private static void other(String some) {",
-                "         // body",
-                "    }",
-                "}"
+            Matchers.is(true),
+            Matchers.not(
+                Matchers.containsString("(UnusedPrivateMethod)")
             )
-        );
-        final Collection<Violation> violations = new PmdValidator(env).validate(
-            Collections.singletonList(new File(env.basedir(), file))
-        );
-        MatcherAssert.assertThat(
-            violations,
-            Matchers.not(Matchers.<Violation>empty())
-        );
+        ).validate();
     }
 
     /**

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/UnderstandsMethodReferences.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/UnderstandsMethodReferences.java
@@ -1,0 +1,14 @@
+package foo;
+
+import java.util.ArrayList;
+
+public final class UnderstandsMethodReferences {
+    public void test() {
+        new ArrayList<String>().forEach(
+            UnderstandsMethodReferences::other
+        );
+    }
+    private static void other() {
+        // body
+    }
+}


### PR DESCRIPTION
Closes: #1193

Related to that issue puzzle states `todo #1129 Replace not+empty() with more precise containsInAnyOrder`. 
Although, the initial purpose of the test (checking that there's no `UnusedPrivateMethod` violation) was lost due to a typo in code sample (https://github.com/yegor256/qulice/commit/81fd2573431eaab4994496efb1726196048aee14).

So I refactored the test a little bit:
 - implemented the check `not+containsString("(UnusedPrivateMethod)")` instead of `containsInAnyOrder`, it seems clearer to me
 - put the sample code to a separate file and used PmdAssert class for validation