### PR TITLE
Move check for pmd analyse ".java" files only

### DIFF
--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
@@ -85,13 +85,9 @@ final class PmdListener implements ThreadSafeReportListener {
     /**
      * Registers a new ProcessingError.
      * @param error A processing error that needs to be reported.
-     * @todo #1129 If was added to avoid failing build, but there should be
-     *  better place for this check.
      */
     public void onProcessingError(final ProcessingError error) {
-        if (error.getFile().endsWith(".java")) {
-            this.errors.add(new PmdError.OfProcessingError(error));
-        }
+        this.errors.add(new PmdError.OfProcessingError(error));
     }
 
     /**

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -98,7 +98,7 @@ public final class PmdValidator implements ResourceValidator {
             final String name = file.getPath().substring(
                 this.env.basedir().toString().length()
             );
-            if (!this.env.exclude("pmd", name)) {
+            if (name.endsWith(".java") && !this.env.exclude("pmd", name)) {
                 sources.add(new FileDataSource(file));
             }
         }


### PR DESCRIPTION
Closes: #1192

Moved check to `PmdValidator#getNonExcludedFiles` method, this place seems more appropriate to filter files for pmd analysis (of course, as long as only java files should be processed by pmd, otherwise this solution is wrong)