### PR TITLE
[#1197] fix AvoidAccessToStaticMembersViaThis rule

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -182,8 +182,8 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
           //PrimaryExpression[
             (./PrimaryPrefix[@ThisModifier=true()]) and
             (./PrimarySuffix[
-              @Image=//FieldDeclaration[@Static=true()]/VariableDeclarator/VariableDeclaratorId/@Name
-              or @Image=//MethodDeclaration[@Static=true()]/@MethodName
+              @Image=./ancestor::ClassOrInterfaceBody[1]/ClassOrInterfaceBodyDeclaration/FieldDeclaration[@Static=true()]/VariableDeclarator/VariableDeclaratorId/@Name
+              or @Image=./ancestor::ClassOrInterfaceBody[1]/ClassOrInterfaceBodyDeclaration/MethodDeclaration[@Static=true()]/@MethodName
             ])
           ]
         ]]></value>

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -153,9 +153,10 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     </description>
     <priority>3</priority>
     <properties>
+      <property name="version" value="2.0"/>
       <property name="xpath">
         <value><![CDATA[
-          //Name[@Image = //FieldDeclaration[@Static='true']/@VariableName]
+          //Name[@Image = //FieldDeclaration[@Static=true()]/VariableDeclarator/VariableDeclaratorId/@Name]
         ]]></value>
       </property>
     </properties>
@@ -175,13 +176,14 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     </description>
     <priority>3</priority>
     <properties>
+      <property name="version" value="2.0"/>
       <property name="xpath">
         <value><![CDATA[
           //PrimaryExpression[
-            (./PrimaryPrefix[@ThisModifier='true']) and
+            (./PrimaryPrefix[@ThisModifier=true()]) and
             (./PrimarySuffix[
-              @Image=//FieldDeclaration[@Static='true']/@VariableName
-              or @Image=//MethodDeclaration[@Static='true']/@MethodName
+              @Image=//FieldDeclaration[@Static=true()]/VariableDeclarator/VariableDeclaratorId/@Name
+              or @Image=//MethodDeclaration[@Static=true()]/@MethodName
             ])
           ]
         ]]></value>

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -183,7 +183,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
             (./PrimaryPrefix[@ThisModifier=true()]) and
             (./PrimarySuffix[
               @Image=./ancestor::ClassOrInterfaceBody[1]/ClassOrInterfaceBodyDeclaration/FieldDeclaration[@Static=true()]/VariableDeclarator/VariableDeclaratorId/@Name
-              or @Image=./ancestor::ClassOrInterfaceBody[1]/ClassOrInterfaceBodyDeclaration/MethodDeclaration[@Static=true()]/@MethodName
+              or @Image=./ancestor::ClassOrInterfaceBody[1]/ClassOrInterfaceBodyDeclaration/MethodDeclaration[@Static=true()]/@Name
             ])
           ]
         ]]></value>

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/StaticAccessToStaticFields.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/StaticAccessToStaticFields.java
@@ -12,6 +12,21 @@ public final class StaticAccessToStaticFields {
     }
 
     public int addToNum(final int another) {
-        return another + StaticAccessToStaticFields.number();
+        return another + StaticAccessToStaticFields.number() + this.another();
+    }
+
+    class InternalClass {
+        final int num;
+
+        InternalClass(final int par) {
+            this.num = par;
+        }
+        static int another() {
+            return 1;
+        }
+
+        public int add(final int a) {
+            return a + this.num;
+        }
     }
 }


### PR DESCRIPTION
- rule AvoidAccessToStaticMembersViaThis fixed to get only current class methods and fields
- remove deprecation warnings

Fix #1197 