### PR TITLE
issue permissions to reports-check.yml

### DIFF
--- a/.github/workflows/reports-check.yml
+++ b/.github/workflows/reports-check.yml
@@ -3,6 +3,9 @@ name: reports-check
 on:
   issues:
     types: [opened]
+permissions:
+  issues: write
+  contents: read
 jobs:
   check:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
@pnatashap take a look, please

In [prev](https://github.com/yegor256/qulice/pull/1232) Pr I forgot add permissions needed to run the check. Without them workflow will be failed with a message:
```
"Error: Resource not accessible by integration"
```
Here I added them:
* `issues` write
* `contents` read