### PR TITLE
Fix deprecated addViolation usage

### DIFF
--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/ProhibitPlainJunitAssertionsRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/ProhibitPlainJunitAssertionsRule.java
@@ -57,8 +57,8 @@ public final class ProhibitPlainJunitAssertionsRule
     @Override
     public Object visit(final ASTMethodDeclaration method, final Object data) {
         if (this.isJUnitMethod(method, data)
-            && this.containsPlainJunitAssert(method.getBlock())) {
-            this.addViolation(data, method);
+            && this.containsPlainJunitAssert(method.getBody())) {
+            this.asCtx(data).addViolation(method);
         }
         return data;
     }
@@ -68,7 +68,7 @@ public final class ProhibitPlainJunitAssertionsRule
         for (final String element : ProhibitPlainJunitAssertionsRule
             .PROHIBITED) {
             if (imp.getImportedName().contains(element)) {
-                this.addViolation(data, imp);
+                this.asCtx(data).addViolation(imp);
                 break;
             }
         }

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -46,7 +46,6 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
  *
  * @since 0.4
  */
-@SuppressWarnings("deprecation")
 public final class UnnecessaryLocalRule extends AbstractJavaRule {
     @Override
     public Object visit(final ASTMethodDeclaration meth, final Object data) {
@@ -83,12 +82,10 @@ public final class UnnecessaryLocalRule extends AbstractJavaRule {
      * @param data Context.
      * @param name Variable name.
      */
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     private void usages(final JavaNode node, final Object data,
         final ASTVariableDeclarator name) {
         final Map<NameDeclaration, List<NameOccurrence>> vars = name
             .getScope().getDeclarations();
-        // @checkstyle LineLength (1 line)
         for (final Map.Entry<NameDeclaration, List<NameOccurrence>> entry
             : vars.entrySet()) {
             final List<NameOccurrence> usages = entry.getValue();
@@ -97,8 +94,8 @@ public final class UnnecessaryLocalRule extends AbstractJavaRule {
             }
             for (final NameOccurrence occ: usages) {
                 if (occ.getLocation().equals(name)) {
-                    this.addViolation(
-                        data, node, new Object[]{name.getImage()}
+                    this.asCtx(data).addViolation(
+                        node, name.getImage()
                     );
                 }
             }


### PR DESCRIPTION
Part of migrating to PMD7

From migration guide:
"When reporting a violation, you might see a deprecation of the addViolation methods. These methods have been moved to RuleContext. E.g. instead of addViolation(data, node, ...) use asCtx(data).addViolation(node, ...)."