### PR TITLE
Remove excessive excludes for duplicate finder

### DIFF
--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -153,7 +153,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
                 <exclude>dependencies:org.antlr</exclude>
                 <exclude>xml:/src/main/resources/com/qulice/checkstyle/checks.xml</exclude>
                 <exclude>xml:/src/test/resources/com/qulice/checkstyle/ChecksTest/.*</exclude>
-                <exclude>duplicatefinder:</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -154,11 +154,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <!-- version from parent -->
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <!-- version from parent -->
-    </dependency>
-    <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-log</artifactId>
       <!-- version from parent -->
@@ -415,6 +410,9 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
                 <exclude>pmd:.*/src/it/.*</exclude>
                 <exclude>pmd:.*/src/test/resources/com/qulice/maven/ValidationExclusion/.*</exclude>
                 <exclude>xml:/src/it/.*</exclude>
+                <exclude>duplicatefinder:about.html</exclude>
+                <exclude>dependencies:org.apache.maven.resolver:maven-resolver-api</exclude>
+                <exclude>dependencies:org.apache.maven.resolver:maven-resolver-util</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -71,6 +71,26 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-exec</artifactId>
       <version>1.6.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.aether</groupId>
+          <artifactId>aether-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.aether</groupId>
+          <artifactId>aether-util</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>1.9.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>1.9.8</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
@@ -395,7 +415,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
                 <exclude>pmd:.*/src/it/.*</exclude>
                 <exclude>pmd:.*/src/test/resources/com/qulice/maven/ValidationExclusion/.*</exclude>
                 <exclude>xml:/src/it/.*</exclude>
-                <exclude>duplicatefinder:.*</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
@@ -31,12 +31,10 @@
 package com.qulice.maven;
 
 import com.qulice.spi.ValidationException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Properties;
 import java.util.stream.Collectors;
-import org.apache.commons.collections.CollectionUtils;
 
 /**
  * Validate with maven-duplicate-finder-plugin.
@@ -58,12 +56,9 @@ public final class DuplicateFinderValidator implements MavenValidator {
             props.put("useResultFile", "false");
             props.put(
                 "ignoredResourcePatterns",
-                CollectionUtils.union(
-                    env.excludes(prefix).stream()
-                        .filter(s -> !s.contains(":"))
-                        .collect(Collectors.toList()),
-                    Arrays.asList("META-INF/.*", "module-info.class")
-                )
+                env.excludes(prefix).stream()
+                    .filter(s -> !s.contains(":"))
+                    .collect(Collectors.toList())
             );
             final Collection<Properties> deps = new LinkedList<>();
             for (final String sdep : env.excludes(prefix)) {


### PR DESCRIPTION
Changes in this PR:
- Do not add module-info.class and related items to skiplist, because they are already [skiplisted](https://basepom.github.io/duplicate-finder-maven-plugin/release-2.0.0/ignoring_dependencies_and_resources.html#usedefaultresourceignorelist-flag)
- Remove `duplicatefinder:` wildcard suppression from qulice-checkstyle and qulice-maven-plugin modules (which completely disables check)
- Explicitly replace some aether-* packages with maven-resolver-* ones (according to https://maven.apache.org/aether.html, former are legacy anyway) (manual testing did not show other violations)

Unfortunately this PR can be neither tested or merged until next qulice-maven-plugin release (with updated `duplicate-finder-maven-plugin`)