### PR TITLE
Use Java 21 in CI

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022, ubuntu-22.04, macos-12]
-        java: [11, 20]
+        java: [11, 21]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
Java 21 has long-term vendor support, unlike Java 20