### PR TITLE
Do not suppress warnings in Violation

### DIFF
--- a/qulice-spi/src/main/java/com/qulice/spi/Violation.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Violation.java
@@ -38,7 +38,6 @@ import lombok.ToString;
  *
  * @since 0.17
  */
-@SuppressWarnings("PMD.TooManyMethods")
 public interface Violation extends Comparable<Violation> {
 
     /**


### PR DESCRIPTION
Default threshold is [10 methods](https://docs.pmd-code.org/latest/pmd_rules_java_design.html#toomanymethods), and `Violation` interface has only 5, so there is no need to suppress anything