### PR TITLE
1. Fixed a bug when adding extra spaces after the parameter name. 2. Fixed a bug when using comment-like text in string literals.

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -36,9 +36,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -69,7 +67,7 @@ public final class JavadocTagsCheck extends AbstractCheck {
     /**
      * Map of tag and its pattern.
      */
-    private final Map<String, Pattern> tags = new HashMap<>();
+    private final List<RequiredJavaDocTag> required = new ArrayList<>(1);
 
     /**
      * List of prohibited javadoc tags.
@@ -97,10 +95,13 @@ public final class JavadocTagsCheck extends AbstractCheck {
 
     @Override
     public void init() {
-        this.tags.put(
-            "since",
-            Pattern.compile(
+        this.required.add(
+            new RequiredJavaDocTag(
+                "since",
+                Pattern.compile(
                 "^\\d+(\\.\\d+){1,2}(\\.[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+                ),
+                this::log
             )
         );
     }
@@ -115,23 +116,12 @@ public final class JavadocTagsCheck extends AbstractCheck {
             for (final String tag : this.prohibited) {
                 this.findProhibited(lines, start, cstart, cend, tag);
             }
-            for (final String tag : this.tags.keySet()) {
-                this.matchTagFormat(lines, cstart, cend, tag);
+            for (final RequiredJavaDocTag tag : this.required) {
+                tag.matchTagFormat(lines, cstart, cend);
             }
         } else {
             this.log(0, "Problem finding class/interface comment");
         }
-    }
-
-    /**
-     * Get the text of the given tag.
-     * @param line Line with the tag.
-     * @return The text of the tag.
-     */
-    private static String getTagText(final String line) {
-        return line.substring(
-            line.indexOf(' ', line.indexOf('@')) + 1
-        );
     }
 
     /**
@@ -192,38 +182,6 @@ public final class JavadocTagsCheck extends AbstractCheck {
                 "Prohibited ''@{0}'' tag in class/interface comment",
                 tag
             );
-        }
-    }
-
-    /**
-     * Check if the tag text matches the format from pattern.
-     * @param lines List of all lines.
-     * @param start Line number where comment starts.
-     * @param end Line number where comment ends.
-     * @param tag Name of the tag.
-     * @checkstyle ParameterNumber (3 lines)
-     */
-    private void matchTagFormat(final String[] lines, final int start,
-        final int end, final String tag) {
-        final List<Integer> found = this.findTagLineNum(lines, start, end, tag);
-        if (found.isEmpty()) {
-            this.log(
-                start + 1,
-                "Missing ''@{0}'' tag in class/interface comment",
-                tag
-            );
-            return;
-        }
-        for (final Integer item : found) {
-            final String text = JavadocTagsCheck.getTagText(lines[item]);
-            if (!this.tags.get(tag).matcher(text).matches()) {
-                this.log(
-                    item + 1,
-                    "Tag text ''{0}'' does not match the pattern ''{1}''",
-                    text,
-                    this.tags.get(tag).toString()
-                );
-            }
         }
     }
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultiLineCommentCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultiLineCommentCheck.java
@@ -37,12 +37,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * C++ style inline comment is not allowed.
- * Use //-style comment instead.
- * @since 0.18
+ * Multi line comment checker.
+ * @since 0.23.1
  */
-public final class SingleLineCommentCheck extends AbstractCheck {
-
+public final class MultiLineCommentCheck extends AbstractCheck {
     /**
      * Pattern for check.
      */
@@ -58,11 +56,6 @@ public final class SingleLineCommentCheck extends AbstractCheck {
      */
     @SuppressWarnings("PMD.AvoidStringBufferField")
     private StringBuilder line;
-
-    /**
-     * When inside a block comment, holds begin line number.
-     */
-    private int begin;
 
     @Override
     public boolean isCommentNodesRequired() {
@@ -92,13 +85,12 @@ public final class SingleLineCommentCheck extends AbstractCheck {
     public void visitToken(final DetailAST ast) {
         if (ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN) {
             this.line = new StringBuilder(ast.getText());
-            this.begin = ast.getLineNo();
         } else if (ast.getType() == TokenTypes.COMMENT_CONTENT) {
             this.line.append(ast.getText());
         } else {
             this.line.append(ast.getText());
             final Matcher matcher = this.format.matcher(this.line.toString());
-            if (matcher.matches() && this.singleLineCStyleComment(ast)) {
+            if (matcher.matches()) {
                 this.log(ast, this.message);
             }
         }
@@ -110,15 +102,5 @@ public final class SingleLineCommentCheck extends AbstractCheck {
 
     public void setMessage(final String msg) {
         this.message = msg;
-    }
-
-    /**
-     * Checks for the end of a comment line.
-     * @param ast Checkstyle's AST nodes.
-     * @return True if this is the end of the comment
-     *  and the starting line number is equal to the ending line number.
-     */
-    private boolean singleLineCStyleComment(final DetailAST ast) {
-        return ast.getType() == TokenTypes.BLOCK_COMMENT_END && this.begin == ast.getLineNo();
     }
 }

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2011-2024 Qulice.com
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Check the required JavaDoc tag in the lines.
+ * <p>Correct format is the following (of a class javadoc):
+ *
+ * <pre>
+ * &#47;**
+ *  * This is my new class.
+ *  *
+ *  * &#64;since 0.3
+ *  *&#47;
+ * public final class Foo {
+ *     &#47;**
+ *      * This is my other class.
+ *      *
+ *      *    &#64;since    0.3
+ *      *&#47;
+ *     public final class Boo {
+ *     // ...
+ * </pre>
+ *
+ * <p>"&#36;Id&#36;" will be replaced by a full text automatically
+ * by Subversion as explained in their documentation (see link below).
+ *
+ * @see <a href="http://svnbook.red-bean.com/en/1.4/svn.advanced.props.special.keywords.html">Keywords substitution in Subversion</a>
+
+ * @since 0.23.1
+ */
+final class RequiredJavaDocTag {
+    /**
+     * Tag name.
+     */
+    private final String name;
+
+    /**
+     * Pattern for searching a tag in a string.
+     */
+    private final Pattern tag;
+
+    /**
+     * Pattern for checking the contents of a tag in a string.
+     */
+    private final Pattern content;
+
+    /**
+     * Reference to a method for writing a message to the log.
+     */
+    private final LogWriter writer;
+
+    /**
+     * Ctor.
+     * @param name Tag name.
+     * @param patt Pattern for checking the contents of a tag in a string.
+     * @param lwriter Reference to a method for writing a message to the log.
+     */
+    RequiredJavaDocTag(final String name, final Pattern patt,
+        final LogWriter lwriter) {
+        this(
+            name,
+            Pattern.compile(
+                String.format(
+                    "(?<name>^ +\\* +@%s)( +)(?<cont>.*)",
+                    name
+                )
+            ),
+            patt,
+            lwriter
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param cname Tag name.
+     * @param ptag Pattern for searching a tag in a string.
+     * @param patt Pattern for checking the contents of a tag in a string.
+     * @param lwriter Reference to a method for writing a message to the log.
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    RequiredJavaDocTag(final String cname, final Pattern ptag,
+        final Pattern patt, final LogWriter lwriter) {
+        this.name = cname;
+        this.tag = ptag;
+        this.content = patt;
+        this.writer = lwriter;
+    }
+
+    /**
+     * Check if the tag text matches the format from pattern.
+     * @param lines List of all lines.
+     * @param start Line number where comment starts.
+     * @param end Line number where comment ends.
+     */
+    public void matchTagFormat(final String[] lines, final int start,
+        final int end) {
+        final Map<Integer, String> found = new HashMap<>(1);
+        for (int pos = start; pos <= end; pos += 1) {
+            final String line = lines[pos];
+            final Matcher matcher = this.tag.matcher(line);
+            if (matcher.matches()
+                && !RequiredJavaDocTag.empty(matcher.group("name"))
+                && !RequiredJavaDocTag.empty(matcher.group("cont"))
+            ) {
+                found.put(pos, matcher.group("cont"));
+                break;
+            }
+        }
+        if (found.isEmpty()) {
+            this.writer.log(
+                start + 1,
+                "Missing ''@{0}'' tag in class/interface comment",
+                this.name
+            );
+        } else {
+            for (final Map.Entry<Integer, String> item : found.entrySet()) {
+                if (!this.content.matcher(item.getValue()).matches()) {
+                    this.writer.log(
+                        item.getKey() + 1,
+                        "Tag text ''{0}'' does not match the pattern ''{1}''",
+                        item.getValue(),
+                        this.content.toString()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks for an empty string.
+     * @param str Line to check.
+     * @return True if str is empty.
+     */
+    private static boolean empty(final String str) {
+        return str == null || str.isBlank();
+    }
+
+    /**
+     * Logger.
+     * @see com.puppycrawl.tools.checkstyle.api.AbstractCheck.log
+     * @since 0.23.1
+     */
+    interface LogWriter {
+        /**
+         * Log a message that has no column information.
+         *
+         * @param line The line number where the audit event was found.
+         * @param msg The message that describes the audit event.
+         * @param args The details of the message.
+         * @see java.text.MessageFormat
+         */
+        void log(int line, String msg, Object... args);
+    }
+}

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -104,25 +104,25 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
   JavaDoc regexp checks
   -->
   <module name="RegexpSingleline">
-    <property name="format" value="\* +@return +[^A-Z]"/>
+    <property name="format" value="\* +@return +[^A-Z ]"/>
     <property name="fileExtensions" value="java"/>
     <property name="id" value="ReturnShouldStartWithCapitalLetter"/>
     <property name="message" value="@return tag description should start with capital letter"/>
   </module>
   <module name="RegexpSingleline">
-    <property name="format" value="\* +@param +\w+ +[^A-Z]"/>
+    <property name="format" value="\* +@param +\w+ +[^A-Z ]"/>
     <property name="fileExtensions" value="java"/>
     <property name="id" value="ParamShouldStartWithCapitalLetter"/>
     <property name="message" value="@param tag description should start with capital letter"/>
   </module>
   <module name="RegexpSingleline">
-    <property name="format" value="/\*\* +[^A-Z\{]"/>
+    <property name="format" value="/\*\* +[^A-Z\{ ]"/>
     <property name="fileExtensions" value="java"/>
     <property name="id" value="FirstLetterInCommentShouldBeCapital"/>
     <property name="message" value="First sentence in a comment should start with a capital letter"/>
   </module>
   <module name="RegexpMultiline">
-    <property name="format" value="/\*\*\W+\* +[^A-Z\{]"/>
+    <property name="format" value="/\*\*\W+\* +[^A-Z\{ ]"/>
     <property name="fileExtensions" value="java"/>
     <property name="id" value="FirstLetterInCommentShouldBeCapital2"/>
     <property name="message" value="First sentence in a comment should start with a capital letter"/>

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -116,18 +116,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     <property name="message" value="@param tag description should start with capital letter"/>
   </module>
   <module name="RegexpSingleline">
-    <property name="format" value="/\*\* +[^A-Z\{ ]"/>
-    <property name="fileExtensions" value="java"/>
-    <property name="id" value="FirstLetterInCommentShouldBeCapital"/>
-    <property name="message" value="First sentence in a comment should start with a capital letter"/>
-  </module>
-  <module name="RegexpMultiline">
-    <property name="format" value="/\*\*\W+\* +[^A-Z\{ ]"/>
-    <property name="fileExtensions" value="java"/>
-    <property name="id" value="FirstLetterInCommentShouldBeCapital2"/>
-    <property name="message" value="First sentence in a comment should start with a capital letter"/>
-  </module>
-  <module name="RegexpSingleline">
     <property name="format" value="synchronized +\(this\) +\{"/>
     <property name="fileExtensions" value="java"/>
     <property name="id" value="UsingThisAsLock"/>
@@ -380,6 +368,26 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     <module name="com.qulice.checkstyle.DiamondOperatorCheck"/>
     <module name="com.qulice.checkstyle.JavadocParameterOrderCheck"/>
     <module name="com.qulice.checkstyle.JavadocTagsCheck"/>
+    <module name="com.qulice.checkstyle.SingleLineCommentCheck">
+      <property name="format" value=" */\*[^*].*\*/ *"/>
+      <property name="message" value="This kind of comment is not allowed."/>
+      <property name="id" value="CStyleCommentNotAllowed"/>
+    </module>
+    <module name="com.qulice.checkstyle.SingleLineCommentCheck">
+      <property name="format" value=" */\*\* +[^A-Z\{ ][\W\s\S]*"/>
+      <property name="message" value="First sentence in a comment should start with a capital letter."/>
+      <property name="id" value="FirstLetterInCommentShouldBeCapital"/>
+    </module>
+    <module name="com.qulice.checkstyle.MultiLineCommentCheck">
+      <property name="format" value=" */\*\*\W+\* +[^A-Z\{ ][\W\s\S]*"/>
+      <property name="message" value="First sentence in a comment should start with a capital letter."/>
+      <property name="id" value="FirstLetterInCommentShouldBeCapital2"/>
+    </module>
+    <module name="com.qulice.checkstyle.MultiLineCommentCheck">
+      <property name="format" value=" */\*\* +[^A-Z\{ ][\W\s\S]*"/>
+      <property name="message" value="First sentence in a comment should start with a capital letter."/>
+      <property name="id" value="FirstLetterInCommentShouldBeCapital3"/>
+    </module>
   </module>
   <!--
   Our custom checkers.

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -195,7 +195,8 @@ final class ChecksTest {
             "JavadocEmptyLineCheck",
             "JavadocTagsCheck",
             "ProhibitNonFinalClassesCheck",
-            "QualifyInnerClassCheck"
+            "QualifyInnerClassCheck",
+            "CommentCheck"
         ).map(s -> String.format("ChecksTest/%s", s));
     }
 

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -48,7 +48,6 @@ import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -776,7 +775,6 @@ final class CheckstyleValidatorTest {
      *
      * @throws Exception In case of error
      */
-    @Disabled
     @Test
     void checkLambdaAndGenericsAtEndOfLine() throws Exception {
         this.runValidation("ValidLambdaAndGenericsAtEndOfLine.java", true);

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/RequiredJavaDocTagTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/RequiredJavaDocTagTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2011-2024 Qulice.com
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle;
+
+import java.text.MessageFormat;
+import java.util.regex.Pattern;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link RequiredJavaDocTag} class.
+ * @since 0.23.1
+ */
+final class RequiredJavaDocTagTest {
+
+    /**
+     * Logger.
+     */
+    private final WriterStub writer = new WriterStub();
+
+    /**
+     * Object under test.
+     */
+    private final RequiredJavaDocTag tag = new RequiredJavaDocTag(
+        "since",
+        Pattern.compile(
+            "^\\d+(\\.\\d+){1,2}(\\.[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+        ),
+        this.writer
+    );
+
+    @Test
+    void success() {
+        final String[] lines = {" *", " * @since 0.3", " *"};
+        this.tag.matchTagFormat(lines, 0, 2);
+        MatcherAssert.assertThat(
+            "Empty string expected",
+            this.writer.formattedMessage(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void successWithSpaces() {
+        final String[] lines = {" *", "    *    @since    0.3", " *"};
+        this.tag.matchTagFormat(lines, 0, 2);
+        MatcherAssert.assertThat(
+            "Empty string expected",
+            this.writer.formattedMessage(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void tagNotFound() {
+        final String[] lines = {" *", " * @sinc 0.3", " *"};
+        this.tag.matchTagFormat(lines, 0, 2);
+        MatcherAssert.assertThat(
+            "Expected tag not found",
+            this.writer.formattedMessage(),
+            Matchers.equalTo("Missing '@since' tag in class/interface comment")
+        );
+    }
+
+    @Test
+    void tagNotMatched() {
+        final String[] lines = {" *", " * @since 0.3.4.4.", " *"};
+        this.tag.matchTagFormat(lines, 0, 2);
+        MatcherAssert.assertThat(
+            "Regular expression non-match expected",
+            this.writer.formattedMessage(),
+            Matchers.equalTo(
+                String.format(
+                    "Tag text '0.3.4.4.' does not match the pattern '%s'",
+                    "^\\d+(\\.\\d+){1,2}(\\.[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+                )
+            )
+        );
+    }
+
+    /**
+     * Stub for {@link RequiredJavaDocTag.LogWriter} class.
+     * @since 0.23.1
+     */
+    private static class WriterStub implements RequiredJavaDocTag.LogWriter {
+
+        /**
+         * Message.
+         */
+        private String message;
+
+        /**
+         * Ctor.
+         */
+        WriterStub() {
+            this.message = "";
+        }
+
+        @Override
+        public void log(final int line, final String msg, final Object... args) {
+            this.message = MessageFormat.format(msg, args);
+        }
+
+        String formattedMessage() {
+            return this.message;
+        }
+    }
+}

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/RequiredJavaDocTagTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/RequiredJavaDocTagTest.java
@@ -108,10 +108,10 @@ final class RequiredJavaDocTagTest {
     }
 
     /**
-     * Stub for {@link RequiredJavaDocTag.LogWriter} class.
+     * Stub for {@link RequiredJavaDocTag.Reporter} class.
      * @since 0.23.1
      */
-    private static class WriterStub implements RequiredJavaDocTag.LogWriter {
+    private static class WriterStub implements RequiredJavaDocTag.Reporter {
 
         /**
          * Message.

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CommentCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CommentCheck/Invalid.java
@@ -1,0 +1,22 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+
+/* C-style comment */
+public final class ProhibitedCStyleComment {
+
+    /** first sentence in a comment should start with a capital letter */
+    public void main() {
+    }
+
+    /**
+     * first sentence in a comment should start with a capital letter
+     */
+    private static String TEXT = "some text";
+
+    /** first sentence in a comment should start with a capital letter
+     */
+    private static String OTHER_TEXT = "some text";
+}
+

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CommentCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CommentCheck/Valid.java
@@ -1,0 +1,25 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+
+/**
+ * Class comment.
+ * @since 0.23.1
+ */
+public final class Valid {
+
+    /**
+     * Valid multiline comment
+     */
+    private static String VALID_CSTYLE_LITERAL = "/* C-style comment */";
+
+    /** Valid single-line comment. */
+    private static String SINGLE_LINE_LITERAL =
+        "/** first sentence in a comment should start with a capital letter */";
+
+    /** Valid multiline comment
+     */
+    public void main() {
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CommentCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CommentCheck/config.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2011-2024 Qulice.com
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met: 1) Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer. 2) Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution. 3) Neither the name of the Qulice.com nor
+the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.SingleLineCommentCheck">
+      <property name="format" value=" */\*[^*].*\*/ *"/>
+      <property name="message" value="This kind of comment is not allowed."/>
+      <property name="id" value="CStyleCommentNotAllowed"/>
+    </module>
+    <module name="com.qulice.checkstyle.SingleLineCommentCheck">
+      <property name="format" value=" */\*\* +[^A-Z\{ ][\W\s\S]*"/>
+      <property name="message" value="First sentence in a comment should start with a capital letter."/>
+      <property name="id" value="FirstLetterInCommentShouldBeCapital"/>
+    </module>
+    <module name="com.qulice.checkstyle.MultiLineCommentCheck">
+      <property name="format" value=" */\*\*\W+\* +[^A-Z\{ ][\W\s\S]*"/>
+      <property name="message" value="First sentence in a comment should start with a capital letter."/>
+      <property name="id" value="FirstLetterInCommentShouldBeCapital2"/>
+    </module>
+    <module name="com.qulice.checkstyle.MultiLineCommentCheck">
+      <property name="format" value=" */\*\* +[^A-Z\{ ][\W\s\S]*"/>
+      <property name="message" value="First sentence in a comment should start with a capital letter."/>
+      <property name="id" value="FirstLetterInCommentShouldBeCapital3"/>
+    </module>
+  </module>
+</module>

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CommentCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/CommentCheck/violations.txt
@@ -1,0 +1,5 @@
+6:This kind of comment is not allowed.
+9:First sentence in a comment should start with a capital letter.
+9:First sentence in a comment should start with a capital letter.
+15:First sentence in a comment should start with a capital letter.
+19:First sentence in a comment should start with a capital letter.

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidLiteralComparisonCheck.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidLiteralComparisonCheck.java
@@ -4,26 +4,26 @@
 package foo;
 
 /**
- * Simple.
- * @since 1.0
+ *  Simple.
+ *  @since 1.0
  */
 public final class ValidLiteralComparisonCheck {
     /**
-     * Some text.
+     *  Some text.
      */
     private final String text;
 
     /**
-     * Constructor.
-     * @param txt Some text.
+     *  Constructor.
+     *  @param  txt  Some text.
      */
     public ValidLiteralCheck(final String txt) {
         this.text = txt;
     }
 
     /**
-     * Method using input.equals("contents")
-     * instead of "contents".equals(input).
+     *   Method using input.equals("contents")
+     *    instead of "contents".equals(input).
      */
     public void validStringComparison() {
         System.out.println(this.text.equals("contents"));

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidSingleLineCommentCheck.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidSingleLineCommentCheck.java
@@ -20,6 +20,20 @@ public final class ValidSingleLineCommentCheck {
      */
     public static final String ANOTHER_LITERAL = "/**/";
 
+    /** Valide sinle line literal. */
+    public static final String SINGLE_LINE_LITERAL = "/**   this is not comment  **/";
+
+    /**
+     * Valid multi line literal.
+     * @checkstyle ArrayTrailingCommaCheck (6 lines)
+     */
+    public static final String[] MULTILINE_LITERAL = {
+        " /**", " * @since 0.3.4.4.", " **/",
+        " /**",
+        " * @since 0.3.4.4.",
+        " **/"
+    };
+
     /**
      * Empty constructor.
      */


### PR DESCRIPTION
@pnatashap @yegor256 
Please review, this should resolve the issue [1079](https://github.com/yegor256/qulice/issues/1079).

