### PR TITLE
Added flag 'threadSafe = true' to CheckMojo class

### DIFF
--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
@@ -58,7 +58,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * @since 0.3
  */
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY,
-    requiresDependencyResolution = ResolutionScope.TEST)
+    requiresDependencyResolution = ResolutionScope.TEST,
+    threadSafe = true)
 public final class CheckMojo extends AbstractQuliceMojo {
 
     /**


### PR DESCRIPTION
@pnatashap @yegor256 
Please review.
The flag 'threadSafe = true' has been added to the CheckMojo class. This should fix [1024](https://github.com/yegor256/qulice/issues/1024)