### PR TITLE
Fix MultilineJavadocTagsCheck failing on block comments

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
@@ -113,7 +113,9 @@ public final class MultilineJavadocTagsCheck extends AbstractCheck {
      * @return Line number with found starting comment or -1 otherwise.
      */
     private static int findCommentStart(final String[] lines, final int start) {
-        return MultilineJavadocTagsCheck.findTrimmedTextUp(lines, start, "/**");
+        final int doc = MultilineJavadocTagsCheck.findTrimmedTextUp(lines, start, "/**");
+        final int comment = MultilineJavadocTagsCheck.findTrimmedTextUp(lines, start, "/*");
+        return Math.max(doc, comment);
     }
 
     /**

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -724,6 +724,17 @@ final class CheckstyleValidatorTest {
     }
 
     /**
+     * {@link MultilineJavadocTagsCheck} mustn't throw an internal exception,
+     * if it meets a block comment instead of javadoc.
+     * @throws Exception If an internal exception occurs
+     */
+    @Test
+    void rejectsInvalidMethodDocWithoutInternalException()
+        throws Exception {
+        this.runValidation("InvalidMethodDoc.java", false);
+    }
+
+    /**
      * Convert file name to URL.
      * @param file The file
      * @return The URL

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/InvalidMethodDoc.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/InvalidMethodDoc.java
@@ -1,0 +1,17 @@
+/*
+ * Hello
+ */
+package foo;
+
+/**
+ * The {@code InvalidMethodDoc#method} comment isn't javadoc, but it's not a reason
+ * to fail {@code MultilineJavadocTagsCheck} validation with an unhandled exception.
+ * @foo bar
+ */
+class InvalidMethodDoc {
+    /*
+     * Run method.
+     */
+    void method() {
+    }
+}


### PR DESCRIPTION
This change fixes the issue #1318. Now MultilineJavadocTagsCheck doesn't throw an unhandled exception if it meets a block comment instead of a javadoc comment.