### PR TITLE
Fix a bug with missed check a closing bracket in nested expressions

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
@@ -102,7 +102,10 @@ public final class BracketsStructureCheck extends AbstractCheck {
      */
     private void checkExpressionList(final DetailAST elist, final int end) {
         if (elist.getChildCount() > 0) {
-            final DetailAST last = elist.getLastChild();
+            DetailAST last = elist.getLastChild();
+            while (last.getChildCount() > 0) {
+                last = last.getLastChild();
+            }
             final int lline = last.getLineNo();
             if (lline == end) {
                 this.log(lline, "Closing bracket should be on a new line");

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/BracketsStructureCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/BracketsStructureCheck/Invalid.java
@@ -41,4 +41,31 @@ public final class Invalid {
       Invalid d1 = new Invalid(
         x, y);
     }
+    // Check nested method call
+    public String nest(String... lines) {
+        nest(
+          nest(
+            "Good"
+          )
+        );
+        nest(
+          nest(
+            "Bad"
+          ));
+        nest(
+          nest(
+            "Good"
+          ),
+          nest(
+             "Bad"
+          ));
+        nest(
+          nest(
+            "Good"
+          ),
+          nest(
+            "Good"
+          )
+        );
+    }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/BracketsStructureCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/BracketsStructureCheck/violations.txt
@@ -14,3 +14,5 @@
 37:Closing bracket should be on a new line
 40:Closing bracket should be on a new line
 42:Closing bracket should be on a new line
+54:Closing bracket should be on a new line
+61:Closing bracket should be on a new line


### PR DESCRIPTION
This commits fix a bug from #1321, when BracketsStructureCheck misses a improper closing bracket, if it closes an expression that has brackets itself in different lines. 