### PR TITLE
Update ResourceValidator.java

### DIFF
--- a/qulice-spi/src/main/java/com/qulice/spi/ResourceValidator.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/ResourceValidator.java
@@ -17,7 +17,7 @@ public interface ResourceValidator {
     /**
      * Validate and throws exception if there are any problems.
      * @param files Files to validate
-     * @return Validation results
+     * @return Non-null collection of validation results. Returns an empty collection if no violations are found.
      */
     Collection<Violation> validate(Collection<File> files);
 


### PR DESCRIPTION
Problem: The validate method returns a Collection<Violation>, but does not specify whether it can return a null or an empty collection.

Improvement: Add a Javadoc comment clarifying that the method always returns a non-null collection (possibly empty if there are no violations).