### PR TITLE
Update Validator.java

### DIFF
--- a/qulice-spi/src/main/java/com/qulice/spi/Validator.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Validator.java
@@ -13,8 +13,9 @@ public interface Validator {
 
     /**
      * Validate and throws exception if there are any problems.
-     * @param env The environment to work with
+     * @param env The environment to work with (must not be null)
      * @throws ValidationException In case of any violations found
+     * @throws IllegalArgumentException If env is null
      */
     void validate(Environment env) throws ValidationException;
 


### PR DESCRIPTION
@yegor256 

Problem: The validate method does not specify whether env can be null.

Improvement: Add a Javadoc comment clarifying that env should not be null.