### PR TITLE
#1373: Add ubuntu-22.04, macos-14 and windows-2025 to CI build

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-24.04, macos-15]
+        os: [windows-2022, windows-2025, ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         java: [17, 21]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
@yegor256 Add ubuntu-22.04, macos-14 and windows-2025 to CI build. Can you check it out?