### PR TITLE
test(#1457): add test for excluding paths from validation checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local-repo/
 node_modules/
 target/
 .aidy/
+.factorypath

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -216,25 +216,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.pmd</groupId>
-      <artifactId>pmd-core</artifactId>
-      <version>6.55.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.sourceforge.saxon</groupId>
-          <artifactId>saxon</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <!-- version from parent -->

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidationExclusionTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidationExclusionTest.java
@@ -10,17 +10,18 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import net.sourceforge.pmd.util.datasource.DataSource;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link DefaultMavenEnvironment} class methods that
@@ -28,11 +29,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.19
  */
 final class ValidationExclusionTest {
-    /**
-     * Temporary directory for the project source folder.
-     */
-    private static final String TEMP_DIR = "src";
-
     /**
      * Temporary directory for the project subfolder to be excluded.
      */
@@ -45,79 +41,142 @@ final class ValidationExclusionTest {
 
     /**
      * DefaultMavenEnvironment can exclude a path from PMD validation.
+     * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      */
     @Test
-    void excludePathFromPmdValidation() throws Exception {
-        final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
-        final Path dir = Files.createTempDirectory(ValidationExclusionTest.TEMP_DIR);
-        final Path subdir = Files.createTempDirectory(dir, ValidationExclusionTest.TEMP_SUB);
-        final File file = File.createTempFile(
-            "PmdExample", ValidationExclusionTest.JAVA_EXT,
-            subdir.toFile()
-        );
-        final MavenProject project = new MavenProject();
+    void excludePathFromPmdValidation(@TempDir final Path dir) throws Exception {
+        final var env = new DefaultMavenEnvironment();
+        final var subdir = Files.createTempDirectory(dir, ValidationExclusionTest.TEMP_SUB);
+        final var project = new MavenProject();
         project.setFile(subdir.toFile());
         env.setProject(project);
-        Assertions.assertNotNull(project.getBasedir());
-        final String source = new TextOf(
-            new ResourceOf("com/qulice/maven/ValidationExclusion/PmdExample.txt")
-        ).asString();
-        FileUtils.forceDeleteOnExit(file);
-        FileUtils.writeStringToFile(
-            file,
-            source,
-            StandardCharsets.UTF_8
+        Assertions.assertNotNull(
+            project.getBasedir(),
+            "We expect basedir to be set"
+        );
+        final var file = ValidationExclusionTest.java(
+            subdir, "com/qulice/maven/ValidationExclusion/PmdExample.txt"
         );
         env.setExcludes(
             Collections.singletonList(
                 String.format("pmd:/%s/.*", subdir.getFileName())
             )
         );
-        final PmdValidator validator = new PmdValidator(env);
-        final Collection<DataSource> files = validator.getNonExcludedFiles(
-            Collections.singletonList(file)
+        Assertions.assertTrue(
+            new PmdValidator(env).getNonExcludedFiles(
+                Collections.singletonList(file)
+            ).isEmpty(),
+            "We expect no files to be returned for PMD validation"
         );
-        Assertions.assertTrue(files.isEmpty());
     }
 
     /**
      * DefaultMavenEnvironment can exclude a path from Checkstyle validation.
+     * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      */
     @Test
-    void excludePathFromCheckstyleValidation() throws Exception {
-        final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
-        final Path dir = Files.createTempDirectory(ValidationExclusionTest.TEMP_DIR);
-        final Path subdir = Files.createTempDirectory(dir, ValidationExclusionTest.TEMP_SUB);
-        final File file = File.createTempFile(
-            "CheckstyleExample", ValidationExclusionTest.JAVA_EXT,
-            subdir.toFile()
-        );
-        final Build build = new Build();
+    void excludePathFromCheckstyleValidation(@TempDir final Path dir) throws Exception {
+        final var env = new DefaultMavenEnvironment();
+        final var subdir = Files.createTempDirectory(dir, ValidationExclusionTest.TEMP_SUB);
+        final var build = new Build();
         build.setOutputDirectory(dir.toString());
-        final MavenProject project = new MavenProject();
+        final var project = new MavenProject();
         project.setFile(subdir.toFile());
         project.setBuild(build);
         env.setProject(project);
-        Assertions.assertNotNull(project.getBasedir());
-        Assertions.assertNotNull(env.tempdir());
-        final String source = new TextOf(
-            new ResourceOf("com/qulice/maven/ValidationExclusion/CheckstyleExample.txt")
-        ).asString();
-        FileUtils.forceDeleteOnExit(file);
-        FileUtils.writeStringToFile(
-            file,
-            source,
-            StandardCharsets.UTF_8
+        Assertions.assertNotNull(
+            project.getBasedir(),
+            "We expect basedir to be set"
+        );
+        Assertions.assertNotNull(
+            env.tempdir(),
+            "We expect tempdir to be set"
+        );
+        final var file = ValidationExclusionTest.java(
+            subdir, "com/qulice/maven/ValidationExclusion/CheckstyleExample.txt"
         );
         env.setExcludes(
             Collections.singletonList(
                 String.format("checkstyle:/%s/.*", subdir.getFileName())
             )
         );
-        final CheckstyleValidator validator = new CheckstyleValidator(env);
-        final List<File> files = validator.getNonExcludedFiles(Collections.singletonList(file));
-        Assertions.assertTrue(files.isEmpty());
+        final var validator = new CheckstyleValidator(env);
+        final var files = validator.getNonExcludedFiles(Collections.singletonList(file));
+        Assertions.assertTrue(
+            files.isEmpty(),
+            "We expect no files to be returned for Checkstyle validation"
+        );
+    }
+
+    /**
+     * DefaultMavenEnvironment can exclude a path from entire validation.
+     * @param dir Temporary directory
+     * @throws Exception If something wrong happens inside
+     * @todo #1457:90min Add global exclusion support to qulice.
+     *  Currently, DefaultMavenEnvironment and validators support only
+     *  tool-specific exclusions. Once global exclusion support is added,
+     *  the {@link #excludePathFromEntireValidation}
+     *  should be enabled and verified to work as expected.
+     *  The original task comes from:
+     *  <a href="https://github.com/yegor256/qulice/issues/1457">#1457"</a>
+     */
+    @Test
+    @Disabled
+    void excludePathFromEntireValidation(@TempDir final Path dir) throws Exception {
+        final var env = new DefaultMavenEnvironment();
+        final var subdir = Files.createTempDirectory(dir, ValidationExclusionTest.TEMP_SUB);
+        final var build = new Build();
+        build.setOutputDirectory(dir.toString());
+        final var project = new MavenProject();
+        project.setFile(subdir.toFile());
+        project.setBuild(build);
+        env.setProject(project);
+        env.setExcludes(
+            Collections.singletonList(
+                String.format("*:/%s/.*", subdir.getFileName())
+            )
+        );
+        final List<File> included = Arrays.asList(
+            ValidationExclusionTest.java(
+                subdir, "com/qulice/maven/ValidationExclusion/CheckstyleExample.txt"
+            ),
+            ValidationExclusionTest.java(
+                subdir, "com/qulice/maven/ValidationExclusion/PmdExample.txt"
+            )
+        );
+        final var pmd = new PmdValidator(env).getNonExcludedFiles(included).size();
+        final var checkstyle = new CheckstyleValidator(env).getNonExcludedFiles(included).size();
+        final var total = pmd + checkstyle;
+        Assertions.assertEquals(
+            0,
+            total,
+            String.format(
+                "We expect no files to be returned for entire validation, but found %d files",
+                total
+            )
+        );
+    }
+
+    /**
+     * Create a temporary Java file from resource.
+     * @param dir Directory to create the file in
+     * @param resource Resource to read the content from
+     * @return Created file with content from resource
+     * @throws Exception If something goes wrong
+     */
+    private static File java(final Path dir, final String resource) throws Exception {
+        final var file = File.createTempFile(
+            "Test", ValidationExclusionTest.JAVA_EXT, dir.toFile()
+        );
+        FileUtils.writeStringToFile(
+            file,
+            new TextOf(
+                new ResourceOf(resource)
+            ).asString(),
+            StandardCharsets.UTF_8
+        );
+        return file;
     }
 }


### PR DESCRIPTION
Add test for `<exclude>*:**/*.java</exclude>`. The implementation will be added in the next PR.

Related to #1457