### PR TITLE
docs(#1457): add documentation for excluding all Java classes from checks

### DIFF
--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -349,6 +349,11 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
     private static class CheckerExcludes implements Function<String, String> {
 
         /**
+         * All checkers.
+         */
+        private static final String ALL = "*";
+
+        /**
          * Name of checker.
          */
         private final String checker;
@@ -367,11 +372,15 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
             String result = null;
             if (input != null) {
                 final String[] exclude = input.split(":", 2);
-                if (this.checker.equals(exclude[0]) && exclude.length > 1) {
+                final String check = exclude[0];
+                final boolean appropriate = check.equals(CheckerExcludes.ALL)
+                    || this.checker.equals(check);
+                if (appropriate && exclude.length > 1) {
                     result = exclude[1];
                 }
             }
             return result;
         }
+
     }
 }

--- a/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
@@ -63,7 +63,8 @@ Exclude
   Every <<<exclude>>> item is a regular expression. The following
   exclusion prefixes are supported now (the list may actually be longer):
   <<<checkstyle:>>>, <<<pmd:>>>,
-  <<<dependencies:>>>, <<<duplicatefinder:>>>.
+  <<<dependencies:>>>, <<<duplicatefinder:>>>,
+  <<<*>>>.
 
   Dependencies exclude uses syntax of groupId:artifactId, so to exclude e.g.
   guava library you should add <<<dependencies:com.google.guava:guava>>> as an
@@ -72,3 +73,24 @@ Exclude
   be used.
 
   To disable duplicatefinder check you should write empty value <<<duplicatefinder:>>>.
+
+  You can also exclude files from all checkers using the `*:` prefix.
+
++--
+<build>
+  <plugins>
+    <plugin>
+      <groupId>com.qulice</groupId>
+      <artifactId>qulice-maven-plugin</artifactId>
+      <version>${project.version}</version>
+      <configuration>
+        <excludes>
+          <exclude>*:/src/it/.*.java</exclude>
+        </excludes>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
++--
+
+  This configuration will exclude all Java files in the `src/it` folder from all checks.

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidationExclusionTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidationExclusionTest.java
@@ -19,7 +19,6 @@ import org.apache.maven.project.MavenProject;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -123,7 +122,6 @@ final class ValidationExclusionTest {
      *  <a href="https://github.com/yegor256/qulice/issues/1457">#1457"</a>
      */
     @Test
-    @Disabled
     void excludePathFromEntireValidation(@TempDir final Path dir) throws Exception {
         final var env = new DefaultMavenEnvironment();
         final var subdir = Files.createTempDirectory(dir, ValidationExclusionTest.TEMP_SUB);


### PR DESCRIPTION
This PR enhances the documentation for exclusion patterns in the `qulice-maven-plugin`, including support for excluding files from all checkers using the `*:` prefix.

Fixes #1457