### PR TITLE
feat(#1452): add logging for file processing duration in Checkstyle and PMD validators

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -4,6 +4,7 @@
  */
 package com.qulice.checkstyle;
 
+import com.jcabi.log.Logger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
@@ -68,7 +69,15 @@ public final class CheckstyleValidator implements ResourceValidator {
     public Collection<Violation> validate(final Collection<File> files) {
         final List<File> sources = this.getNonExcludedFiles(files);
         try {
+            Logger.debug(this, "Checkstyle processing %d files", sources.size());
+            final long start = System.currentTimeMillis();
             this.checker.process(sources);
+            Logger.debug(
+                this,
+                "Checkstyle processed %d files in %[ms]s",
+                sources.size(),
+                System.currentTimeMillis() - start
+            );
         } catch (final CheckstyleException ex) {
             throw new IllegalStateException("Failed to process files", ex);
         }

--- a/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -82,9 +82,16 @@ final class SourceValidator {
         this.context.setReport(report);
         for (final DataSource source : sources) {
             final String name = source.getNiceFileName(false, path);
-            Logger.debug(this, "Processing file: %s", name);
+            final long start = System.currentTimeMillis();
+            Logger.debug(this, "PMD processing file: %s", name);
             this.context.setSourceCodeFile(new File(name));
             this.validateOne(source);
+            Logger.debug(
+                this,
+                "PMD processed file: %[file]s in %[ms]s",
+                name,
+                System.currentTimeMillis() - start
+            );
         }
         this.renderer.exportTo(report);
         report.errors().forEachRemaining(this.listener::onProcessingError);


### PR DESCRIPTION
This PR enhances logging in `CheckstyleValidator` and `SourceValidator` to improve debugging and performance tracking, addressing the `TimeoutException` in `CheckMojo`.

Related to #1452