### PR TITLE
#1471: Change back switch expressions and pattern matching

### DIFF
--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
@@ -24,16 +24,15 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(final ASTInfixExpression expr, final Object data) {
-        if (isComparison(expr)
-            && (
-                matchesLengthCheck(
-                    expr.getLeftOperand(),
-                    expr.getRightOperand()
-                )
+        if (isComparison(expr) && (
+            matchesLengthCheck(
+                expr.getLeftOperand(),
+                expr.getRightOperand()
+            )
                 || matchesLengthCheck(
-                    expr.getRightOperand(),
-                    expr.getLeftOperand()
-                )
+                expr.getRightOperand(),
+                expr.getLeftOperand()
+            )
             )
         ) {
             asCtx(data).addViolation(expr);
@@ -42,14 +41,26 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
     }
 
     private static boolean isComparison(final ASTInfixExpression expr) {
-        return switch (expr.getOperator()) {
-            case EQ, NE, GT, LT, GE, LE -> true;
-            default -> false;
-        };
+        final boolean result;
+        switch (expr.getOperator()) {
+            case EQ:
+            case NE:
+            case GT:
+            case LT:
+            case GE:
+            case LE:
+                result = true;
+                break;
+            default:
+                result = false;
+                break;
+        }
+        return result;
     }
 
     /**
      * Checks if length is length() or literal is 0 or 1.
+     *
      * @param length The method
      * @param literal The number
      * @return True if matches, false otherwise
@@ -59,14 +70,16 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
         final ASTExpression length,
         final ASTExpression literal
     ) {
-        return length != null
-            && literal != null
-            && isZeroOrOneLiteral(literal)
-            && length instanceof ASTMethodCall call
-            && "length".equals(call.getMethodName())
-            && call.getArguments().isEmpty()
-            && call.getQualifier() != null
-            && isStringExpression(call.getQualifier());
+        boolean result = false;
+        if (length != null && literal != null && isZeroOrOneLiteral(literal)
+            && length instanceof ASTMethodCall) {
+            final ASTMethodCall call = (ASTMethodCall) length;
+            result = "length".equals(call.getMethodName())
+                && call.getArguments().isEmpty()
+                && call.getQualifier() != null
+                && isStringExpression(call.getQualifier());
+        }
+        return result;
     }
 
     private static boolean isZeroOrOneLiteral(final ASTExpression expr) {


### PR DESCRIPTION
Fix (I hope) these errors in rultor:

```
  (use -source 14 or higher to enable switch expressions)
/home/r/repo/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java:46: error: multiple case labels are not supported in -source 8
            case EQ, NE, GT, LT, GE, LE -> true;
                   ^
  (use -source 14 or higher to enable multiple case labels)
/home/r/repo/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java:46: error: switch rules are not supported in -source 8
            case EQ, NE, GT, LT, GE, LE -> true;
                                        ^
  (use -source 14 or higher to enable switch rules)
/home/r/repo/qulice-pmd/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java:65: error: pattern matching in instanceof is not supported in -source 8
            && length instanceof ASTMethodCall call
                                               ^
  (use -source 16 or higher to enable pattern matching in instanceof)
4 errors
Command line was: /usr/lib/jvm/java-17-openjdk-amd64/bin/javadoc -J-Duser.language= -J-Duser.country= @options @packages

Refer to the generated Javadoc files in '/home/r/repo/qulice-pmd/target/reports/apidocs' dir.

    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.doExecuteJavadocCommandLine (AbstractJavadocMojo.java:5116)
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.executeJavadocCommandLine (AbstractJavadocMojo.java:4989)
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.executeReport (AbstractJavadocMojo.java:2058)
    at org.apache.maven.plugins.javadoc.JavadocJarMojo.doExecute (JavadocJarMojo.java:196)
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.execute (AbstractJavadocMojo.java:1850)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:569)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :qulice-pmd
\u001b[0m\u001b[0mcontainer 1a635b3dd7d565cbef3e828b0c2ddd7f5a2e3076073f83a45b697a41c2bf07a0 is dead
Thu Jan  1 16:21:00 UTC 2026
```