### PR TITLE
Fix Javadoc typos and incorrect documentation

### DIFF
--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
@@ -183,7 +183,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
     }
 
     /**
-     * Teimeout value for timeout.
+     * Timeout value for timeout.
      * @return Timeout value
      */
     private long timeoutValue() {

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
@@ -68,7 +68,7 @@ public final class MojoExecutor {
     }
 
     /**
-     * Find and configure a mojor.
+     * Find and configure a mojo.
      * @param coords Maven coordinates,
      *  e.g. "com.qulice:maven-qulice-plugin:1.0"
      * @param goal Maven plugin goal to execute
@@ -155,7 +155,7 @@ public final class MojoExecutor {
     }
 
     /**
-     * Recuresively convert Properties to Xpp3Dom.
+     * Recursively convert Properties to Xpp3Dom.
      * @param config The config to convert
      * @param name High-level name of it
      * @return The Xpp3Dom document

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdError.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdError.java
@@ -140,8 +140,8 @@ public interface PmdError {
         private final Report.ConfigurationError error;
 
         /**
-         * Creates a new PmdError, representing given ProcessingError.
-         * @param error Internal ProcessingError.
+         * Creates a new PmdError, representing given ConfigurationError.
+         * @param error Internal ConfigurationError.
          */
         public OfConfigError(final Report.ConfigurationError error) {
             this.error = error;


### PR DESCRIPTION
@yegor256 
- Fix 'mojor' -> 'mojo' in MojoExecutor.java
- Fix 'Recuresively' -> 'Recursively' in MojoExecutor.java
- Fix 'Teimeout' -> 'Timeout' in CheckMojo.java
- Fix wrong Javadoc for OfConfigError constructor in PmdError.java
