### PR TITLE
Fix bug in PmdError.OfConfigError.name() and code quality improvements

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
@@ -111,7 +111,7 @@ public final class QualifyInnerClassCheck extends AbstractCheck {
         for (
             DetailAST child = content.getFirstChild();
             child != null;
-            child  = child.getNextSibling()
+            child = child.getNextSibling()
         ) {
             if (child.getType() == TokenTypes.CLASS_DEF
                 || child.getType() == TokenTypes.ENUM_DEF

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
@@ -67,7 +67,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
         } catch (final ValidationException ex) {
             Logger.info(
                 this,
-                "Read our quality policy: http://www.qulice.com/quality.html"
+                "Read our quality policy: https://www.qulice.com/quality.html"
             );
             throw new MojoFailureException("Failure", ex);
         }

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
@@ -7,7 +7,7 @@ package com.qulice.maven;
 import com.jcabi.log.Logger;
 import com.qulice.spi.ValidationException;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.maven.execution.MavenSession;
@@ -88,8 +88,8 @@ public final class MojoExecutor {
                 descriptor.getPluginDescriptor(),
                 this.session,
                 Thread.currentThread().getContextClassLoader(),
-                new LinkedList<String>(),
-                new LinkedList<String>()
+                List.of(),
+                List.of()
             );
         } catch (final PluginResolutionException ex) {
             throw new IllegalStateException("Plugin resolution problem", ex);

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdError.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdError.java
@@ -149,7 +149,7 @@ public interface PmdError {
 
         @Override
         public String name() {
-            return "ProcessingError";
+            return "ConfigurationError";
         }
 
         @Override


### PR DESCRIPTION
- Fix OfConfigError.name() returning 'ProcessingError' instead of 'ConfigurationError'
- Fix extra whitespace in QualifyInnerClassCheck for-loop
- Use HTTPS instead of HTTP for qulice.com URL in CheckMojo
- Replace new LinkedList<String>() with List.of() in MojoExecutor