### PR TITLE
Disable PMD UnnecessaryLocalRule due to false positives

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -29,6 +29,7 @@
     <exclude name="ExcessiveImports"/>
     <exclude name="CyclomaticComplexity"/>
     <exclude name="FinalFieldCouldBeStatic"/>
+    <exclude name="TooManyMethods"/>
   </rule>
   <rule ref="category/java/documentation.xml">
     <exclude name="CommentRequired"/>
@@ -54,6 +55,13 @@
       </property>
       <property name="skipAnnotations">
         <value>true</value>
+      </property>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/TooManyMethods">
+    <properties>
+      <property name="maxmethods">
+        <value>30</value>
       </property>
     </properties>
   </rule>


### PR DESCRIPTION
Fixes #1508.

Test classes can be intentionally large; the default TooManyMethods threshold
is too strict and causes noisy failures. This PR relaxes the threshold to reduce
false positives while keeping the rule enabled.

- Config-only change
- No functional code changes