### PR TITLE
Fix #1517: UnnecessaryLocalRule for variable in a try-catch-with-resources statement

### DIFF
--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -8,6 +8,7 @@ import java.util.List;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTResource;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
@@ -27,6 +28,10 @@ public final class UnnecessaryLocalRule extends AbstractJavaRulechainRule {
         final ASTVariableDeclarator variable,
         final Object data
     ) {
+        // Skip variables that are declared as resources in a try-with-resources block
+        if (variable.ancestors(ASTResource.class).toStream().findAny().isPresent()) {
+            return data;
+        }
         if (variable.getInitializer() != null) {
             final String name = variableName(variable);
             if (!name.isEmpty()) {

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/ValidTryWithResources.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/ValidTryWithResources.java
@@ -1,0 +1,21 @@
+package com.qulice.pmd;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public final class ValidTryWithResources {
+    private static long folderSizeInMb(final Path path) throws IOException {
+        try (Stream<Path> paths = Files.walk(path)) {
+            return paths.filter(Files::isRegularFile).mapToLong(
+                p -> {
+                    try {
+                        return Files.size(p);
+                    } catch (final IOException exception) {
+                        throw new IllegalStateException("Failed", exception);
+                    }
+                }
+            ).sum() / 1024L / 1024L;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1517

**The Problem:**
`UnnecessaryLocalRule` was incorrectly flagging variables declared in a `try-with-resources` block as unnecessary if they were only referenced once inside the block. These variables cannot be inlined because they are required by Java syntax to ensure the resource is auto-closed.

**The Solution:**
Modified `UnnecessaryLocalRule.java` to check if the evaluated `ASTVariableDeclarator` is a descendant of an `ASTResource` node. If it is, the visitor returns early and ignores the variable. 

## Checklist
- [x] Updated `UnnecessaryLocalRule.java` to ignore `ASTResource` variables.
- [x] Added a valid test case representing the `try-with-resources` scenario.
- [x] Ran `mvn clean install` locally and all static analysis checks and tests pass successfully.