### PR TITLE
#1360: allow suppressing LineLengthCheck via nearby comment

### DIFF
--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -50,6 +50,17 @@
     <property name="checkFormat" value="$1"/>
   </module>
   <!--
+  Allows suppression of Checker-level checks (e.g. LineLength) via nearby
+  comments using the same `@checkstyle CheckName (N lines)` syntax that
+  SuppressWithNearbyCommentFilter supports inside TreeWalker.
+  See https://github.com/yegor256/qulice/issues/1360
+  -->
+  <module name="SuppressWithNearbyTextFilter">
+    <property name="nearbyTextPattern" value="@checkstyle (\w+) \((\d+) lines?\)"/>
+    <property name="checkPattern" value="$1"/>
+    <property name="lineRange" value="$2"/>
+  </module>
+  <!--
   TAB chars are not allowed anywhere.
   -->
   <module name="FileTabCharacter">

--- a/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -151,6 +151,18 @@ final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator does not report a LineLength violation when
+     * the long line is preceded by a {@code @checkstyle LineLengthCheck (N lines)}
+     * comment.
+     * See https://github.com/yegor256/qulice/issues/1360.
+     * @throws Exception when error.
+     */
+    @Test
+    void suppressesLineLengthInCommentsViaNearbyComment() throws Exception {
+        this.runValidation("SuppressLineLengthInComment.java", true);
+    }
+
+    /**
      * CheckstyleValidator can report Apache Commons {@code CharEncoding} class
      * usages.
      * @throws Exception when error.

--- a/src/test/resources/com/qulice/checkstyle/SuppressLineLengthInComment.java
+++ b/src/test/resources/com/qulice/checkstyle/SuppressLineLengthInComment.java
@@ -1,0 +1,16 @@
+/*
+ * Hello.
+ */
+// @checkstyle LineLengthCheck (4 lines)
+// This algorithm has been found in a very long article with many details.
+// Here is another line of comment that is intentionally very, very, very long to trigger LineLengthCheck.
+// End of comment.
+package foo;
+
+/**
+ * Sample class for testing LineLength suppression in comments.
+ *
+ * @since 1.0
+ */
+public interface SuppressLineLengthInComment {
+}


### PR DESCRIPTION
Fixes #1360.

The `@checkstyle LineLengthCheck (N lines)` comment did not suppress
`LineLengthCheck` because Checkstyle's `SuppressWithNearbyCommentFilter`
only filters events produced by checks inside `TreeWalker`, and
`LineLength` is a `Checker`-level module.

This PR adds `SuppressWithNearbyTextFilter` at the `Checker` level with
the same `@checkstyle (\w+) \((\d+) lines?\)` nearby-text pattern, so
the long-standing suppression syntax now also covers non-TreeWalker
checks such as `LineLength`.

A new test `suppressesLineLengthInCommentsViaNearbyComment` reproduces
the issue reported by @fabriciofx and verifies the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_013E5KRY68h6wgzUa4nWeCzf)_