### PR TITLE
#1360 Fix LineLengthCheck suppression in comments

### DIFF
--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -50,6 +50,16 @@
     <property name="checkFormat" value="$1"/>
   </module>
   <!--
+  Enables "@checkstyle XxxCheck (N lines)" suppressions for Checker-level
+  checks like LineLength, which are not children of TreeWalker and hence
+  cannot be suppressed by SuppressWithNearbyCommentFilter (see #1360).
+  -->
+  <module name="SuppressWithNearbyTextFilter">
+    <property name="nearbyTextPattern" value="@checkstyle (\w+) \((\d+) lines?\)"/>
+    <property name="checkPattern" value="$1"/>
+    <property name="lineRange" value="$2"/>
+  </module>
+  <!--
   TAB chars are not allowed anywhere.
   -->
   <module name="FileTabCharacter">

--- a/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -127,6 +127,16 @@ final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator can suppress LineLengthCheck in comments
+     * with {@code @checkstyle LineLengthCheck (N lines)} marker.
+     * @throws Exception when error.
+     */
+    @Test
+    void suppressesLineLengthCheckInComments() throws Exception {
+        this.runValidation("SuppressLineLengthInComments.java", true);
+    }
+
+    /**
      * CheckstyleValidator reports an error when comment or Javadoc has too
      * long line.
      * @throws Exception when error.

--- a/src/test/resources/com/qulice/checkstyle/SuppressLineLengthInComments.java
+++ b/src/test/resources/com/qulice/checkstyle/SuppressLineLengthInComments.java
@@ -1,0 +1,15 @@
+/*
+ * Hello.
+ */
+package foo;
+
+// @checkstyle LineLengthCheck (3 lines)
+// This algorithm has been found here:
+// https://stackoverflow.com/questions/11377117/rock-paper-scissors-determine-win-loss-tie-using-math
+
+/**
+ * Suppression of LineLengthCheck in single-line comments.
+ * @since 1.0
+ */
+public interface SuppressLineLengthInComments {
+}


### PR DESCRIPTION
@yegor256 this PR fixes #1360.

## What was wrong

Writing this in your code:

```java
// @checkstyle LineLengthCheck (4 lines)
// This algorithm has been found here:
// https://stackoverflow.com/questions/11377117/rock-paper-scissors-determine-win-loss-tie-using-math
```

did not suppress the `LineLengthCheck` warning, even though the marker is exactly the one documented via `SuppressWithNearbyCommentFilter`.

## Why it was wrong

In `src/main/resources/com/qulice/checkstyle/checks.xml`, `LineLength` is declared as a direct child of the top-level `Checker` module (it was moved out of `TreeWalker` in Checkstyle 8.x). The existing `SuppressWithNearbyCommentFilter`, however, lives inside `TreeWalker`. TreeWalker filters only apply to audit events produced by modules that are themselves children of `TreeWalker`, so the comment suppression never reaches file-level `LineLength` events. The same would be true for any other Checker-level check.

## How I fixed it

Added a sibling filter at the `Checker` level, using Checkstyle's `SuppressWithNearbyTextFilter` (available since Checkstyle 10.20; we are on 12.3.1). It operates on raw file text rather than on Javadoc/AST tokens, so it can suppress events from any module — including `LineLength`. The pattern is kept byte-identical to the existing `SuppressWithNearbyCommentFilter` (`@checkstyle (\w+) \((\d+) lines?\)`), so there is no new syntax for users to learn; the marker they were already writing now just starts working.

## Changes

- `src/main/resources/com/qulice/checkstyle/checks.xml` — add `SuppressWithNearbyTextFilter` at the `Checker` level.
- `src/test/resources/com/qulice/checkstyle/SuppressLineLengthInComments.java` — test fixture with exactly the scenario from #1360.
- `src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java` — new test `suppressesLineLengthCheckInComments` (fails without the fix, passes with it).

## Verification

- [x] New unit test fails on `master` and passes on this branch.
- [x] Full unit test suite (237 tests) passes locally.
- [x] `mvn verify -Pqulice` (qulice dogfood) passes locally.
- [x] All 25 CI check runs on this PR are green (Ubuntu/macOS/Windows × JDK 17/21, plus linters).

Ready for your review.
