### PR TITLE
#1337: match .java extension case-insensitively in PmdValidator

### DIFF
--- a/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -12,6 +12,7 @@ import com.qulice.spi.Violation;
 import java.io.File;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Locale;
 
 /**
  * Validates source code with PMD.
@@ -79,7 +80,7 @@ public final class PmdValidator implements ResourceValidator {
             if (this.env.exclude("pmd", name)) {
                 continue;
             }
-            if (!name.matches("^.*\\.java$")) {
+            if (!name.toLowerCase(Locale.ROOT).endsWith(".java")) {
                 continue;
             }
             sources.add(file);

--- a/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -7,6 +7,7 @@ package com.qulice.pmd;
 import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
+import java.util.Collection;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -31,6 +32,51 @@ final class PmdValidatorTest {
                 Collections.singletonList(new File(env.basedir(), file))
             ),
             Matchers.not(Matchers.<Violation>empty())
+        );
+    }
+
+    @Test
+    void acceptsJavaFilesWithUppercaseExtension() throws Exception {
+        final String file = "src/main/java/Main.JAVA";
+        final Environment env = new Environment.Mock()
+            .withFile(file, "class Main { int x = 0; }");
+        final Collection<File> kept = new PmdValidator(env).getNonExcludedFiles(
+            Collections.singletonList(new File(env.basedir(), file))
+        );
+        MatcherAssert.assertThat(
+            "Java files with uppercase .JAVA extension should not be skipped",
+            kept,
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void acceptsJavaFilesWithMixedCaseExtension() throws Exception {
+        final String file = "src/main/java/Main.Java";
+        final Environment env = new Environment.Mock()
+            .withFile(file, "class Main { int x = 0; }");
+        final Collection<File> kept = new PmdValidator(env).getNonExcludedFiles(
+            Collections.singletonList(new File(env.basedir(), file))
+        );
+        MatcherAssert.assertThat(
+            "Java files with mixed-case .Java extension should not be skipped",
+            kept,
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void skipsFilesThatAreNotJava() throws Exception {
+        final String file = "src/main/java/notes.txt";
+        final Environment env = new Environment.Mock()
+            .withFile(file, "hello");
+        final Collection<File> kept = new PmdValidator(env).getNonExcludedFiles(
+            Collections.singletonList(new File(env.basedir(), file))
+        );
+        MatcherAssert.assertThat(
+            "Non-Java files should be skipped",
+            kept,
+            Matchers.empty()
         );
     }
 }


### PR DESCRIPTION
Fixes #1337.

## Summary
- `PmdValidator#getNonExcludedFiles` skipped files whose `.java` extension was not all lowercase, because it filtered with the case-sensitive regex `^.*\.java$`. On case-insensitive file systems (Windows / default macOS) `javac` happily compiles `Foo.JAVA`, but qulice never asked PMD to look at it.
- Replaced the regex with `name.toLowerCase(Locale.ROOT).endsWith(".java")`, which is both case-insensitive and simpler than the regex it replaces.

## Test plan
- [x] Added `acceptsJavaFilesWithUppercaseExtension` and `acceptsJavaFilesWithMixedCaseExtension` in `PmdValidatorTest` that fail on the old regex and pass with the fix.
- [x] Added `skipsFilesThatAreNotJava` to guard against the obvious regression (non-Java files must still be skipped).
- [x] Verified the failing tests reproduce the bug before the fix (2 failures), and that the full module test suite (`mvn -B test`) passes after the fix (318 tests, 0 failures).
