### PR TITLE
Bump checkstyle to 13.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
     <dependency>
       <groupId>com.puppycrawl.tools</groupId>
       <artifactId>checkstyle</artifactId>
-      <version>13.4.0</version>
+      <version>13.4.1</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.pmd</groupId>


### PR DESCRIPTION
@yegor256 — this PR bumps the bundled `com.puppycrawl.tools:checkstyle` dependency from `13.4.0` to `13.4.1`.

The upgrade was the only stable update available across the project's direct dependencies and plugins (the parent `com.jcabi:parent` is at `0.73.1`, lombok at `1.18.46`, PMD at `7.24.0`, error-prone at `2.49.0`, ASM at `9.9.1`, hibernate-validator at `9.1.0.Final`, etc., are all already the latest stable releases).

## What 13.4.1 brings

It is a backward-compatible bug-fix release that improves checks Qulice already exposes:

- `ImportOrder`: correct handling of empty lines between regular and static imports
- `AnnotationLocation`: closes a false negative where parameterless annotations on class declarations were silently accepted
- `VariableDeclarationUsageDistance`: now flags variable usage inside `try` blocks
- `AtclauseOrder`: support for `RECORD_DEF` and `COMPACT_CTOR_DEF` in `google_checks.xml`

Release notes: https://github.com/checkstyle/checkstyle/releases/tag/checkstyle-13.4.1

## Verification

- `mvn clean install -Pqulice` passes locally (320 unit tests + 16 invoker integration tests, including the existing `checkstyle-violations`, `checkstyle-newlines` and `checkstyle-locale` IT modules that exercise the bundled checkstyle directly)
- All 11 CI checks are green (`mvn` on ubuntu-24.04/macos-15/windows-2025, plus `actionlint`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`)
- No code or configuration changes outside the version bump in `pom.xml` were necessary; the patch release is API-compatible

Ready for merge.