### PR TITLE
Fix #1341: fail fast when checkstyle cache directory is not writable

### DIFF
--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -156,6 +156,14 @@ public final class CheckstyleValidator implements ResourceValidator {
                 )
             );
         }
+        if (!parent.canWrite()) {
+            throw new IllegalStateException(
+                String.format(
+                    "Cannot write to %s, check filesystem permissions",
+                    parent.getAbsolutePath()
+                )
+            );
+        }
         final Properties props = new Properties();
         props.setProperty("cache.file", cache.getPath());
         final Configuration config;

--- a/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -17,6 +17,7 @@ import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -78,6 +79,43 @@ final class CheckstyleValidatorTest {
         Assertions.assertDoesNotThrow(
             () -> this.runValidation("ValidLiteralComparisonCheck.java", true)
         );
+    }
+
+    @Test
+    void failsClearlyWhenCacheParentIsNotWritable() throws Exception {
+        final Environment.Mock mock = new Environment.Mock();
+        final File parent = new File(mock.tempdir(), "checkstyle");
+        Assumptions.assumeTrue(
+            parent.mkdirs() || parent.isDirectory(),
+            "Parent directory must exist for the regression scenario"
+        );
+        try {
+            Assumptions.assumeTrue(
+                parent.setReadOnly(),
+                "Filesystem does not support marking a directory read-only"
+            );
+            Assumptions.assumeFalse(
+                parent.canWrite(),
+                "Skipped: current user can write despite read-only attribute"
+            );
+            final Environment env = mock.withFile(
+                "src/main/java/foo/Foo.java",
+                "package foo; class Foo {}"
+            );
+            MatcherAssert.assertThat(
+                "Validation must fail fast with a clear writability error",
+                Assertions.assertThrows(
+                    IllegalStateException.class,
+                    () -> new CheckstyleValidator(env).validate(env.files("Foo.java"))
+                ).getMessage(),
+                Matchers.allOf(
+                    Matchers.containsString("write"),
+                    Matchers.containsString(parent.getAbsolutePath())
+                )
+            );
+        } finally {
+            parent.setWritable(true, false);
+        }
     }
 
     @Test


### PR DESCRIPTION
@yegor256 — this PR closes #1341.

PR #1342 has been waiting for the missing regression test you asked for, so this PR adds that test alongside the same writability check. The history is intentionally split so each piece can be reviewed independently:

1. **`Add failing test reproducing #1341`** introduces `failsClearlyWhenCacheParentIsNotWritable` in `CheckstyleValidatorTest`. The test creates the cache parent directory, marks it read-only with `setReadOnly()`, and asserts that `CheckstyleValidator.validate(...)` throws an `IllegalStateException` whose message names the directory and mentions writability. It uses `Assumptions` (rather than skipping silently) when the platform/user can still write despite the read-only attribute (e.g., root on Linux), so it actually runs on the GitHub Actions matrix where the runner is unprivileged. Without the fix, this test fails with `Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.`, reproducing the bug from the ticket.

2. **`Fix #1341: fail fast when checkstyle cache directory is not writable`** adds a `parent.canWrite()` check right after the existing `mkdirs()` block in `CheckstyleValidator.configuration()`. When the directory exists but is not writable, the validator now throws an `IllegalStateException` that names the directory and points the user at filesystem permissions, instead of letting Checkstyle fail later with an opaque IO error during cache writes.

## Verification
- `mvn install` — green locally on Linux (root + non-root user) and on the CI matrix (Ubuntu / macOS / Windows, JDK 21).
- `mvn verify -Pqulice -DskipTests -DskipITs -Dinvoker.skip` — green; the new test passes the qulice quality rules (`UnitTestContainsTooManyAsserts`, `LocalFinalVariableNameCheck`, etc.).
- Reverting only the fix on top of the test commit reproduces the original failure mode, confirming the test guards the regression.

## Test plan
- [x] `mvn install` on Linux (root, non-root)
- [x] `mvn verify -Pqulice` quality gate
- [x] CI matrix (Ubuntu / macOS / Windows, JDK 21) all green