### PR TITLE
Fix #1337: match .java extension case-insensitively in PmdValidator

### DIFF
--- a/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -12,6 +12,7 @@ import com.qulice.spi.Violation;
 import java.io.File;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Locale;
 
 /**
  * Validates source code with PMD.
@@ -79,7 +80,7 @@ public final class PmdValidator implements ResourceValidator {
             if (this.env.exclude("pmd", name)) {
                 continue;
             }
-            if (!name.matches("^.*\\.java$")) {
+            if (!name.toLowerCase(Locale.ROOT).endsWith(".java")) {
                 continue;
             }
             sources.add(file);

--- a/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -33,4 +33,18 @@ final class PmdValidatorTest {
             Matchers.not(Matchers.<Violation>empty())
         );
     }
+
+    @Test
+    void acceptsJavaFilesWithUppercaseExtension() throws Exception {
+        final String file = "src/main/java/Main.JAVA";
+        final Environment env = new Environment.Mock()
+            .withFile(file, "class Main { int x = 0; }");
+        MatcherAssert.assertThat(
+            "File with uppercase .JAVA extension should not be filtered out",
+            new PmdValidator(env).getNonExcludedFiles(
+                Collections.singletonList(new File(env.basedir(), file))
+            ),
+            Matchers.not(Matchers.empty())
+        );
+    }
 }


### PR DESCRIPTION
@yegor256 this PR closes #1337.

**Root cause:** `PmdValidator.getNonExcludedFiles` filters files with the regex `^.*\.java$`, which is case-sensitive. `CheckstyleValidator.getNonExcludedFiles` already lowercases the extension before comparison (`name.substring(dot + 1).toLowerCase(Locale.ROOT)`), so for the same input file set the two validators disagree: a file named `Foo.JAVA` is silently dropped by PMD but picked up by Checkstyle.

**Fix:** Lowercase the path before checking the suffix (`name.toLowerCase(Locale.ROOT).endsWith(".java")`), which also drops the unnecessary regex compilation per call. Behavior now matches Checkstyle's case-insensitive treatment.

**Commits:**

1. `Add failing test reproducing #1337` — adds `PmdValidatorTest.acceptsJavaFilesWithUppercaseExtension`, which calls `getNonExcludedFiles` with a single `Main.JAVA` and asserts the list is non-empty. Fails on master with `Expected: not an empty collection but: was <[]>`.
2. `Fix #1337: match .java extension case-insensitively in PmdValidator` — applies the fix described above.

**Verification:**

- All 79 tests in `com.qulice.pmd` pass locally (`mvn test -Dtest='Pmd*Test'`).
- `mvn verify -Pqulice -DskipTests -DskipITs` passes locally.
- All 11 CI jobs are green: actionlint, copyrights, markdown-lint, mvn (macos-15/21, ubuntu-24.04/21, windows-2025/21), pdd, reuse, typos, xcop, yamllint.

Ready for merge.