### PR TITLE
Fix #1584: allow defensive Arrays.copyOf in ConstructorsCodeFreeCheck

### DIFF
--- a/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
@@ -25,6 +25,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * at construction time: only the lambda object or the anonymous class
  * instance is created. Such subtrees are skipped.
  *
+ * <p>Defensive array copy idioms — {@code Arrays.copyOf(...)} and
+ * {@code <expr>.clone()} — are also tolerated, since there is no
+ * method-call-free way to defensively copy an array field at
+ * construction time (Effective Java item 50).
+ *
  * @since 0.24
  */
 public final class ConstructorsCodeFreeCheck extends AbstractCheck {
@@ -54,7 +59,8 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
 
     /**
      * Reports every method call found anywhere in the given subtree,
-     * except those nested inside lambda bodies or anonymous class bodies.
+     * except those nested inside lambda bodies or anonymous class bodies,
+     * and except sanctioned defensive-copy idioms.
      * @param node Root of the subtree to scan
      */
     private void reportCalls(final DetailAST node) {
@@ -64,7 +70,8 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
             if (type == TokenTypes.LAMBDA || type == TokenTypes.OBJBLOCK) {
                 continue;
             }
-            if (type == TokenTypes.METHOD_CALL) {
+            if (type == TokenTypes.METHOD_CALL
+                && !ConstructorsCodeFreeCheck.isDefensiveCopy(child)) {
                 this.log(
                     child.getLineNo(),
                     "Constructor must not contain method calls"
@@ -72,5 +79,88 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
             }
             this.reportCalls(child);
         }
+    }
+
+    /**
+     * Is this method call a defensive array-copy idiom?
+     *
+     * <p>Recognizes {@code Arrays.copyOf(...)} (static, any qualifier
+     * ending in {@code Arrays.copyOf}) and any zero-argument
+     * {@code <expr>.clone()} call.
+     *
+     * @param call A {@code METHOD_CALL} AST node
+     * @return True if the call is a sanctioned defensive copy
+     */
+    private static boolean isDefensiveCopy(final DetailAST call) {
+        final DetailAST dot = call.getFirstChild();
+        final boolean defensive;
+        if (dot == null || dot.getType() != TokenTypes.DOT) {
+            defensive = false;
+        } else {
+            final DetailAST method = dot.getLastChild();
+            defensive = method != null
+                && method.getType() == TokenTypes.IDENT
+                && (
+                    ConstructorsCodeFreeCheck.isArraysCopyOf(dot, method)
+                        || ConstructorsCodeFreeCheck.isArrayClone(call, method)
+                );
+        }
+        return defensive;
+    }
+
+    /**
+     * Is this an {@code Arrays.copyOf(...)} call?
+     * @param dot The {@code DOT} node that is first child of {@code METHOD_CALL}
+     * @param method The {@code IDENT} that is the called method's name
+     * @return True if it matches the {@code Arrays.copyOf} idiom
+     */
+    private static boolean isArraysCopyOf(
+        final DetailAST dot, final DetailAST method
+    ) {
+        final DetailAST qualifier = dot.getFirstChild();
+        return "copyOf".equals(method.getText())
+            && qualifier != null
+            && ConstructorsCodeFreeCheck.endsWith(qualifier, "Arrays");
+    }
+
+    /**
+     * Is this a no-argument {@code <expr>.clone()} call?
+     * @param call The {@code METHOD_CALL} AST node
+     * @param method The {@code IDENT} that is the called method's name
+     * @return True if it matches the array-clone idiom
+     */
+    private static boolean isArrayClone(
+        final DetailAST call, final DetailAST method
+    ) {
+        final DetailAST elist = call.findFirstToken(TokenTypes.ELIST);
+        return "clone".equals(method.getText())
+            && elist != null
+            && elist.getFirstChild() == null;
+    }
+
+    /**
+     * Does the qualifier expression end in the given identifier?
+     *
+     * <p>Handles a bare {@code IDENT} (e.g. {@code Arrays}) and a
+     * dotted chain (e.g. {@code java.util.Arrays}), where the final
+     * segment of the chain is the identifier we look for.
+     *
+     * @param node The qualifier AST node
+     * @param name The expected last identifier
+     * @return True if the qualifier's last segment matches
+     */
+    private static boolean endsWith(final DetailAST node, final String name) {
+        final boolean match;
+        if (node.getType() == TokenTypes.IDENT) {
+            match = name.equals(node.getText());
+        } else if (node.getType() == TokenTypes.DOT) {
+            final DetailAST last = node.getLastChild();
+            match = last != null
+                && last.getType() == TokenTypes.IDENT
+                && name.equals(last.getText());
+        } else {
+            match = false;
+        }
+        return match;
     }
 }

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ConstructorsCodeFreeCheck/Valid-defensive-copy.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ConstructorsCodeFreeCheck/Valid-defensive-copy.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle.ChecksTest.ConstructorsCodeFreeCheck;
+
+import java.util.Arrays;
+
+/**
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public final class ValidDefensiveCopy {
+    private final byte[] data;
+    private final int[] codes;
+    private final long[] points;
+    private final char[] letters;
+
+    public ValidDefensiveCopy(final byte[] bytes) {
+        this.data = Arrays.copyOf(bytes, bytes.length);
+        this.codes = null;
+        this.points = null;
+        this.letters = null;
+    }
+
+    public ValidDefensiveCopy(final int[] ints) {
+        this.data = null;
+        this.codes = Arrays.copyOf(ints, ints.length);
+        this.points = null;
+        this.letters = null;
+    }
+
+    public ValidDefensiveCopy(final long[] longs) {
+        this.data = null;
+        this.codes = null;
+        this.points = longs.clone();
+        this.letters = null;
+    }
+
+    public ValidDefensiveCopy(final char[] chars) {
+        this.data = null;
+        this.codes = null;
+        this.points = null;
+        this.letters = chars.clone();
+    }
+
+    static final class Nested {
+        private final byte[] payload;
+        Nested(final byte[] bytes) {
+            this(Arrays.copyOf(bytes, bytes.length));
+        }
+        Nested(final byte[] bytes, final int unused) {
+            this.payload = Arrays.copyOf(bytes, bytes.length);
+        }
+    }
+}


### PR DESCRIPTION
@yegor256 ready for review.

Closes #1584.

## What changed
`ConstructorsCodeFreeCheck` was flagging the canonical Effective Java item 50 idiom for storing an array field immutably:

```java
this.data = Arrays.copyOf(arr, arr.length);   // flagged
this.data = arr.clone();                      // flagged
```

There is no method-call-free way to express a defensive copy of an array, so the rule effectively forbade correct, safe code and forced contributors to sprinkle `@checkstyle ConstructorsCodeFreeCheck (5 lines)` suppressions in every constructor that holds an array field.

The check now whitelists two narrow shapes:

1. **`Arrays.copyOf(...)`** — qualifier ending in the simple name `Arrays`, so both `Arrays.copyOf(...)` and `java.util.Arrays.copyOf(...)` are accepted.
2. **Zero-argument `<expr>.clone()`** — covers `arr.clone()`, `this.field.clone()`, etc.

Everything else in constructors is still flagged, including:
- Non-`Arrays` static `copyOf` (e.g. `List.copyOf(...)` continues to be a violation, since it is not constructor-free).
- `clone(arg)` with arguments (impossible for `Object#clone`, but stays defensive against custom overloads).
- `Pattern.compile`, `Integer.parseInt`, `System.out.println`, etc. (existing `Invalid.java` fixture still produces the same 5 violations).

## Tests
- New `Valid-defensive-copy.java` fixture in `ChecksTest/ConstructorsCodeFreeCheck/` covering all four primitive arrays, both idioms, and a nested case where `Arrays.copyOf(...)` is the argument to a delegating `this(...)` constructor call. It fails on master and passes on this branch.
- `mvn test -Dtest=ChecksTest` — 80 passing.
- `mvn verify -Pqulice -DskipTests -Dinvoker.skip=true` — qulice self-check passes.
- All 11 CI jobs green (linters + Maven on macos / ubuntu / windows).