### PR TITLE
Add Architecture section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,83 @@ works fine. To use it just add `-Dhttp.proxyHost=HOST -Dhttp.proxyPort=PORT`
 to your `MAVEN_OPTS` environment variable or to Maven command, e.g.
 `mvn clean verify -Dhttp.proxyHost=HOST -Dhttp.proxyPort=PORT`.
 
+## Architecture
+
+Qulice aggregates [Checkstyle](https://checkstyle.sourceforge.io/),
+  [PMD](https://pmd.github.io/), and
+  [ErrorProne](https://errorprone.info/) behind a single
+  [Maven](https://maven.apache.org/) `verify`-phase goal, `check`.
+Unlike running each tool as a separate Maven plugin with its own
+  configuration file, Qulice requires no per-tool setup in `pom.xml`.
+The bundled rule sets are locked: all adopting projects share the same
+  [Checkstyle](https://checkstyle.sourceforge.io/) and
+  [PMD](https://pmd.github.io/) configuration.
+This differs from [Spotless](https://github.com/diffplug/spotless)
+  or the [Checkstyle Maven Plugin][csmp] used standalone, both of
+  which allow per-project rule customization.
+
+The [Checkstyle](https://checkstyle.sourceforge.io/) configuration
+  (`checks.xml`) and [PMD](https://pmd.github.io/) ruleset
+  (`ruleset.xml`) ship as classpath resources inside the Qulice JAR
+  and cannot be overridden by the adopting project.
+Projects may suppress specific checks only via the `<excludes>`
+  parameter; they cannot add or redefine rules.
+This trades flexibility for consistency: code review style expectations
+  are identical across every repository that uses Qulice.
+
+The `com.qulice.spi` package defines the extension boundary between
+  Maven and the linting logic.
+`Environment` exposes project structure (base directory, classpath,
+  source files, exclude patterns) without leaking Maven internals,
+  enabling validators to be unit-tested without a Maven runtime.
+`ResourceValidator` accepts a `Collection<File>` and returns
+  `Collection<Violation>`; `Validator` consumes the full `Environment`
+  for checks that require broader project context.
+
+[Checkstyle](https://checkstyle.sourceforge.io/),
+  [PMD](https://pmd.github.io/), and
+  [ErrorProne](https://errorprone.info/) run concurrently inside a
+  five-thread `ExecutorService` in `CheckMojo`.
+Each validator is submitted as a `Callable<Collection<Violation>>`
+  and results are collected via `Future`.
+A configurable timeout (default ten minutes, overridable via
+  `qulice.check-timeout`) prevents a hung validator from blocking
+  the build indefinitely.
+
+[ErrorProne](https://errorprone.info/) requires `--add-exports` and
+  `--add-opens` JVM flags to access internal `jdk.compiler` APIs.
+Rather than injecting those flags into Maven's own JVM (which
+  would require a `.mvn/jvm.config` in every adopting project),
+  Qulice forks a separate `javac` process via
+  [Jaxec](https://github.com/yegor256/jaxec).
+The flags apply only to the forked process; Maven's JVM is unchanged.
+
+After parallel linting, five Maven-specific validators run
+  sequentially: `PomXpathValidator` checks `pom.xml` against
+  user-supplied [XPath](https://www.w3.org/TR/xpath/) expressions;
+  `EnforcerValidator` delegates to [maven-enforcer-plugin][mep] to
+  verify JDK and Maven versions; `DependenciesValidator` uses
+  [maven-dependency-analyzer][mda] to find unused or undeclared
+  compile-scope dependencies; `DuplicateFinderValidator` detects
+  duplicate classes across classpath JARs; and `SnapshotsValidator`
+  rejects SNAPSHOT dependencies in production builds.
+
+Both [Checkstyle](https://checkstyle.sourceforge.io/) and
+  [PMD](https://pmd.github.io/) are extended with custom rules.
+The `com.qulice.checkstyle` package contains roughly forty custom
+  `AbstractCheck` implementations (e.g., `ConstructorsOrderCheck`,
+  `IfThenThrowElseCheck`) covering constraints absent from the
+  standard [Checkstyle](https://checkstyle.sourceforge.io/) catalog.
+The `com.qulice.pmd.rules` package adds custom `AbstractJavaRule`
+  implementations (e.g., `UnitTestContainsTooManyAssertsRule`,
+  `ProhibitPlainJunitAssertionsRule`) that replace upstream
+  [PMD](https://pmd.github.io/) rules with known false-positive
+  defects filed in the upstream tracker.
+
+[csmp]: https://maven.apache.org/plugins/maven-checkstyle-plugin/
+[mep]: https://maven.apache.org/plugins/maven-enforcer-plugin/
+[mda]: https://maven.apache.org/shared/maven-dependency-analyzer/
+
 ## How to contribute
 
 Fork repository, make changes, send us a pull request. We will review


### PR DESCRIPTION
@yegor256, I added an "Architecture" section to README.md, placed right before "How to Contribute".

The section explains seven key architectural decisions that distinguish Qulice from running Checkstyle, PMD, and ErrorProne as separate Maven plugins:

1. **Single aggregated goal, zero per-tool config** — Qulice replaces three independent plugin configurations with one `check` goal. Contrasted with Spotless and the standalone Checkstyle Maven Plugin, which both expose per-project rule customization.

2. **Bundled, non-overridable rule sets** — `checks.xml` (Checkstyle) and `ruleset.xml` (PMD) ship inside the JAR. Projects can suppress checks via `<excludes>` but cannot add or redefine rules. The trade-off (flexibility vs. cross-repo consistency) is stated explicitly.

3. **`com.qulice.spi` extension boundary** — `Environment`, `ResourceValidator`, and `Validator` interfaces decouple linting logic from Maven internals, making validators independently unit-testable.

4. **Parallel linting via `ExecutorService`** — Checkstyle, PMD, and ErrorProne run concurrently in a five-thread pool with a configurable timeout.

5. **ErrorProne in a forked `javac` process** — Avoids injecting `--add-exports`/`--add-opens` into Maven's own JVM, so adopting projects need no `.mvn/jvm.config` changes. Implemented via [Jaxec](https://github.com/yegor256/jaxec).

6. **Sequential Maven-specific validators** — Five Maven-aware validators (PomXpathValidator, EnforcerValidator, DependenciesValidator, DuplicateFinderValidator, SnapshotsValidator) run after the parallel linting phase.

7. **Custom Checkstyle and PMD rules** — ~40 custom `AbstractCheck` implementations and several custom `AbstractJavaRule` implementations replace upstream rules that have known false-positive defects.

All lines are within 80 characters; continuation lines use two-space indentation. `markdownlint` reports no warnings.
