### PR TITLE
#1606 Match only known assert methods in UnitTestContainsTooManyAssertsRule

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/UnitTestContainsTooManyAssertsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UnitTestContainsTooManyAssertsRule.java
@@ -4,6 +4,7 @@
  */
 package com.qulice.pmd.rules;
 
+import java.util.Set;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -13,15 +14,45 @@ import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 /**
  * Rule to check that JUnit/TestNG test methods do not contain more than
  * one assertion. Unlike the PMD built-in
- * {@code UnitTestContainsTooManyAsserts} rule, this implementation does
- * not count calls to {@code assertThrows} as assertions, because a
- * common idiom wraps {@code assertThrows(...).getMessage()} inside an
+ * {@code UnitTestContainsTooManyAsserts} rule, this implementation only
+ * counts calls whose simple name is one of the known JUnit/Hamcrest
+ * assertion methods, instead of counting any identifier with an
+ * {@code assert}, {@code check} or {@code verify} prefix. The PMD
+ * default produces false positives for unrelated APIs such as
+ * {@code pull.checks()} (jcabi-github) or {@code Mockito.verify(...)},
+ * and the {@code assertThrows} method is also excluded because a common
+ * idiom wraps {@code assertThrows(...).getMessage()} inside an
  * {@code assertThat} to verify the thrown exception's message in a
  * single logical check.
  * @since 0.26.0
  */
 public final class UnitTestContainsTooManyAssertsRule
     extends AbstractJavaRulechainRule {
+
+    /**
+     * Method names recognised as JUnit / Hamcrest assertions. The list
+     * intentionally excludes {@code assertThrows}, which is treated as
+     * an exception-capturing helper, not an assertion.
+     */
+    private static final Set<String> ASSERTIONS = Set.of(
+        "assertThat",
+        "assertEquals",
+        "assertNotEquals",
+        "assertTrue",
+        "assertFalse",
+        "assertNull",
+        "assertNotNull",
+        "assertSame",
+        "assertNotSame",
+        "assertArrayEquals",
+        "assertIterableEquals",
+        "assertLinesMatch",
+        "assertDoesNotThrow",
+        "assertTimeout",
+        "assertTimeoutPreemptively",
+        "assertAll",
+        "fail"
+    );
 
     public UnitTestContainsTooManyAssertsRule() {
         super(ASTMethodDeclaration.class);
@@ -41,7 +72,8 @@ public final class UnitTestContainsTooManyAssertsRule
     }
 
     private static boolean isCountedAssert(final ASTMethodCall call) {
-        return TestFrameworksUtil.isProbableAssertCall(call)
-            && !"assertThrows".equals(call.getMethodName());
+        return UnitTestContainsTooManyAssertsRule.ASSERTIONS.contains(
+            call.getMethodName()
+        );
     }
 }

--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -38,13 +38,16 @@
     -->
     <exclude name="UnitTestShouldIncludeAssert"/>
     <!--
-      UnitTestContainsTooManyAsserts is excluded because it counts
-      Assertions.assertThrows as an assertion, producing false positives
-      when a test wraps assertThrows(...).getMessage() inside assertThat
-      to verify the thrown exception's message in a single logical check.
-      Until PMD supports excluding method names, we use our own
-      UnitTestContainsTooManyAssertsRule that ignores assertThrows.
+      UnitTestContainsTooManyAsserts is excluded because it counts any
+      method invocation whose simple name starts with 'assert', 'check'
+      or 'verify', producing false positives for unrelated APIs such as
+      pull.checks() (jcabi-github) or Mockito.verify(...). It also
+      counts Assertions.assertThrows, which breaks the common idiom of
+      wrapping assertThrows(...).getMessage() inside assertThat. We use
+      our own UnitTestContainsTooManyAssertsRule that only counts the
+      known JUnit/Hamcrest assertion methods and ignores assertThrows.
       Downstream: https://github.com/yegor256/qulice/issues/1519
+      Downstream: https://github.com/yegor256/qulice/issues/1606
     -->
     <exclude name="UnitTestContainsTooManyAsserts"/>
     <exclude name="UnusedPrivateField"/>
@@ -238,9 +241,14 @@
   </rule>
   <rule name="UnitTestContainsTooManyAsserts" message="Unit tests should not contain more than 1 assert(s)." language="java" class="com.qulice.pmd.rules.UnitTestContainsTooManyAssertsRule">
     <description>
-      Unit tests should not contain more than one assertion. This
-      variant of PMD's UnitTestContainsTooManyAsserts rule does not
-      count calls to assertThrows as assertions, so a test that wraps
+      Unit tests should not contain more than one assertion. Unlike
+      PMD's UnitTestContainsTooManyAsserts rule, this variant only
+      counts calls whose simple name is one of the known JUnit /
+      Hamcrest assertion methods (assertThat, assertEquals, assertTrue,
+      fail, ...) instead of counting any identifier with an 'assert',
+      'check' or 'verify' prefix. Calls such as Mockito.verify(...) or
+      pull.checks() are therefore not flagged. Calls to assertThrows
+      are also not counted, so a test that wraps
       assertThrows(...).getMessage() inside an assertThat to verify the
       thrown exception's message is not flagged.
     </description>

--- a/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
@@ -114,6 +114,26 @@ final class PmdAssertionsTest {
     }
 
     /**
+     * PmdValidator does not report UnitTestContainsTooManyAsserts when a test
+     * has a single assertion combined with calls such as
+     * {@code Mockito.verify(...)} or {@code pull.checks()} whose simple name
+     * starts with 'verify' or 'check' but which are not JUnit/Hamcrest
+     * assertions.
+     * Regression test for https://github.com/yegor256/qulice/issues/1606
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    void allowsMockitoVerifyAndChecksCalls() throws Exception {
+        new PmdAssert(
+            "AssertThatWithMockitoVerifyAndChecks.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("UnitTestContainsTooManyAsserts")
+            )
+        ).assertOk();
+    }
+
+    /**
      * PmdValidator can allow only package private methods, marked with: Test,
      * RepeatedTest, TestFactory, TestTemplate or ParameterizedTest annotations.
      * @throws Exception If something wrong happens inside.

--- a/src/test/resources/com/qulice/pmd/AssertThatWithMockitoVerifyAndChecks.java
+++ b/src/test/resources/com/qulice/pmd/AssertThatWithMockitoVerifyAndChecks.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+final class AssertThatWithMockitoVerifyAndChecksTest {
+
+    @Test
+    void detectsSuccess() {
+        final Pull pull = new Pull();
+        final Observer observer = Mockito.mock(Observer.class);
+        MatcherAssert.assertThat("ok", true, Matchers.is(true));
+        final MkChecks checks = (MkChecks) pull.checks();
+        Mockito.verify(observer).onSuccess();
+    }
+
+    private static final class Pull {
+        Object checks() {
+            return null;
+        }
+    }
+
+    private static final class MkChecks {
+    }
+
+    private interface Observer {
+        void onSuccess();
+    }
+}


### PR DESCRIPTION
Closes #1606.

## Summary

`UnitTestContainsTooManyAssertsRule` previously delegated to PMD's
`TestFrameworksUtil.isProbableAssertCall`, which counts any invocation
whose simple name starts with `assert`, `check` or `verify` as an
assertion. That produced false positives for unrelated APIs:

- `pull.checks()` — jcabi-github API for listing PR checks
- `commit.checks()`, `repo.checks()`, and similar jcabi accessors
- `Mockito.verify(mock).foo()` — the standard Mockito verification idiom

So a test with a single `MatcherAssert.assertThat(...)` plus a
`Mockito.verify(...)` and a `pull.checks()` call was reported as
containing three assertions.

## Fix

Replace the prefix-based check with an explicit allowlist of the
JUnit / Hamcrest assertion method names (`assertThat`, `assertEquals`,
`assertTrue`, `assertFalse`, `assertNull`, `assertNotNull`,
`assertSame`, `assertNotSame`, `assertArrayEquals`,
`assertIterableEquals`, `assertLinesMatch`, `assertDoesNotThrow`,
`assertTimeout`, `assertTimeoutPreemptively`, `assertAll`, `fail`,
plus `assertNotEquals`). `assertThrows` continues to be excluded, as
before.

## Test plan

- [x] Added `AssertThatWithMockitoVerifyAndChecks.java` fixture
  reproducing the issue's example.
- [x] Added `allowsMockitoVerifyAndChecksCalls` test in
  `PmdAssertionsTest`. Verified it fails against the previous rule
  implementation and passes after the fix.
- [x] All 15 `PmdAssertionsTest` tests pass (and all 98 PMD tests in
  the module).


---
_Generated by [Claude Code](https://claude.ai/code/session_016iJTKCGb2sgbnQucPvwEvK)_