### PR TITLE
Exclude PMD ExceptionAsFlowControl rule

### DIFF
--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -165,6 +165,16 @@
     <exclude name="CyclomaticComplexity"/>
     <exclude name="FinalFieldCouldBeStatic"/>
     <exclude name="TooManyMethods"/>
+    <!--
+      ExceptionAsFlowControl is excluded because it flags legitimate
+      validate-and-recover patterns where several guard clauses inside a
+      single try block share one fallback path in the catch. The only
+      "fix" the rule allows is to duplicate the catch body across N
+      methods or wrap each throw in its own try, both of which are
+      strictly worse than the original code.
+      Downstream: https://github.com/yegor256/qulice/issues/1609
+    -->
+    <exclude name="ExceptionAsFlowControl"/>
   </rule>
   <rule ref="category/java/design.xml/TooManyMethods">
     <properties>

--- a/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
@@ -45,6 +45,7 @@ final class PmdDisabledRulesTest {
                 {"UnnecessaryVarargsArrayCreation"},
                 {"ShortMethodName"},
                 {"AvoidFieldNameMatchingMethodName"},
+                {"ExceptionAsFlowControl"},
             }
         );
     }

--- a/src/test/resources/com/qulice/pmd/ExceptionAsFlowControl.java
+++ b/src/test/resources/com/qulice/pmd/ExceptionAsFlowControl.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class ExceptionAsFlowControl {
+
+    public void register(final String host, final String login,
+        final String key) {
+        try {
+            if (host.isEmpty()) {
+                throw new IllegalArgumentException("SSH host is empty");
+            }
+            if (login.isEmpty()) {
+                throw new IllegalArgumentException("SSH login is empty");
+            }
+            if (key.isEmpty()) {
+                throw new IllegalArgumentException("SSH key is empty");
+            }
+        } catch (final IllegalArgumentException ex) {
+            System.out.println(
+                String.format("Failed to read profile: %s", ex.getMessage())
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1609.

PMD's `ExceptionAsFlowControl` rule fires when multiple `throw` statements inside a single `try` block are caught by a shared `catch` clause. That pattern is the natural way to express "validate several preconditions, share one fallback path", and the rule's only "fix" is to either duplicate the catch body across N methods or wrap each `throw` in its own `try`, both of which are strictly worse than the original code.

The rule is implemented in Java (not XPath), and the false positive is structural rather than syntactic — there is no clean way to distinguish "validate-and-recover" from "exception as goto" via a `violationSuppressXPath`, since both can have substantive catch bodies. So this excludes the rule from the design.xml import with a comment pointing back to the issue, consistent with how other noisy PMD rules (`LawOfDemeter`, `SignatureDeclareThrowsException`, `LoosePackageCoupling`, ...) are handled in the same ruleset.

## Changes

- `src/main/resources/com/qulice/pmd/ruleset.xml` — add `ExceptionAsFlowControl` to the design.xml excludes with an explanatory comment.
- `src/test/resources/com/qulice/pmd/ExceptionAsFlowControl.java` — new fixture mirroring the validate-and-recover snippet from the issue.
- `src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java` — add `ExceptionAsFlowControl` to the parameterized list so the regression is locked in.

## Test plan

- [x] `mvn test -Dtest=PmdDisabledRulesTest` — 12/12 pass.
- [x] `mvn test -Dtest='Pmd*Test'` — 80/80 pass.
- [x] Confirmed the new fixture trips three `ExceptionAsFlowControl` violations when the exclusion is reverted, then passes with it in place.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AVwPXk9WvqysqMZv1VDvPP)_