### PR TITLE
Exempt delegate-only constructors from ConstructorsCodeFreeCheck

### DIFF
--- a/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
@@ -77,8 +77,8 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
         final DetailAST first = body.getFirstChild();
         final boolean delegate;
         if (first == null
-            || (first.getType() != TokenTypes.CTOR_CALL
-                && first.getType() != TokenTypes.SUPER_CTOR_CALL)) {
+            || first.getType() != TokenTypes.CTOR_CALL
+            && first.getType() != TokenTypes.SUPER_CTOR_CALL) {
             delegate = false;
         } else {
             final DetailAST next = first.getNextSibling();

--- a/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
@@ -16,9 +16,14 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * via {@code this(...)} or {@code super(...)}. Calling any method
  * (static or instance) from inside a constructor is forbidden,
  * including as the right-hand side of a field assignment
- * (e.g. {@code this.bar = Foo.createBar()}), as an argument to a
- * delegating constructor call, or as a nested argument to a {@code new}
- * expression.
+ * (e.g. {@code this.bar = Foo.createBar()}) or as a nested argument
+ * to a {@code new} expression.
+ *
+ * <p>A constructor whose only statement is a delegating
+ * {@code this(...)} or {@code super(...)} call is exempt: such a
+ * constructor performs no work of its own, and the method-call
+ * arguments to the delegate (e.g. {@code this(System.currentTimeMillis())})
+ * are accepted as a sanctioned factory-style entry point.
  *
  * <p>Method calls nested inside lambda bodies or anonymous class bodies
  * are not considered constructor code, because they are not executed
@@ -52,9 +57,34 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
     @Override
     public void visitToken(final DetailAST ast) {
         final DetailAST body = ast.findFirstToken(TokenTypes.SLIST);
-        if (body != null) {
+        if (body != null && !ConstructorsCodeFreeCheck.isOnlyDelegate(body)) {
             this.reportCalls(body);
         }
+    }
+
+    /**
+     * Is the constructor body a single delegating
+     * {@code this(...)} or {@code super(...)} call?
+     *
+     * <p>The body's {@code SLIST} consists of the delegate call node
+     * (a {@code CTOR_CALL} or {@code SUPER_CTOR_CALL}) followed by
+     * the closing {@code RCURLY}, with nothing else in between.
+     *
+     * @param body The {@code SLIST} of the constructor body
+     * @return True if the body delegates and does nothing else
+     */
+    private static boolean isOnlyDelegate(final DetailAST body) {
+        final DetailAST first = body.getFirstChild();
+        final boolean delegate;
+        if (first == null
+            || (first.getType() != TokenTypes.CTOR_CALL
+                && first.getType() != TokenTypes.SUPER_CTOR_CALL)) {
+            delegate = false;
+        } else {
+            final DetailAST next = first.getNextSibling();
+            delegate = next == null || next.getType() == TokenTypes.RCURLY;
+        }
+        return delegate;
     }
 
     /**

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ConstructorsCodeFreeCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ConstructorsCodeFreeCheck/Valid.java
@@ -43,6 +43,28 @@ public final class Valid {
         }
     }
 
+    static final class DelegateWithCall {
+        private final long when;
+        DelegateWithCall() {
+            this(System.currentTimeMillis());
+        }
+        DelegateWithCall(final long value) {
+            this.when = value;
+        }
+    }
+
+    static class Parent {
+        Parent(final String text) {
+            // empty on purpose
+        }
+    }
+
+    static final class SuperWithCall extends Parent {
+        SuperWithCall(final Object obj) {
+            super(String.valueOf(obj));
+        }
+    }
+
     enum Color {
         RED(1), GREEN(2), BLUE(3);
         private final int code;


### PR DESCRIPTION
## Summary

Fixes #1603 per the maintainer's recommendation: do not raise `ConstructorsCodeFreeCheck` if the only command in the constructor is `this(...);` or `super(...);`.

A constructor whose body consists solely of a delegating `this(...)` or `super(...)` invocation performs no work of its own at construction time — the listed exception in the rule's Javadoc ("may delegate to another constructor") now extends to the delegate's argument list too. This unblocks idioms like `this(System.currentTimeMillis())` for no-arg public constructors that previously had no clean alternative once PMD's `ProhibitPublicStaticMethodsRule` also forbade the static-factory workaround.

## Changes

- `ConstructorsCodeFreeCheck#visitToken` now skips reporting when the constructor body's `SLIST` contains only a `CTOR_CALL` or `SUPER_CTOR_CALL` (followed by the closing `RCURLY`).
- Updated the Javadoc to document the exemption.
- Added `DelegateWithCall` and `SuperWithCall` cases to `Valid.java` so the integration test covers the new allowed patterns.

## Test plan

- [x] `mvn -Dtest=ChecksTest test` — 80 tests pass, including the new valid-case classes and the unchanged invalid cases.



---
_Generated by [Claude Code](https://claude.ai/code/session_0154bC9sh7GVnfAGqgxLUP5F)_