### PR TITLE
Fix #1605: skip TooManyMethods on test classes

### DIFF
--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -166,9 +166,32 @@
     <exclude name="FinalFieldCouldBeStatic"/>
     <exclude name="TooManyMethods"/>
   </rule>
+  <!--
+    TooManyMethods is excluded from the bulk import above and re-enabled
+    here with a violationSuppressXPath that skips unit-test classes
+    (those whose simple name ends with 'Test', 'IT', 'TestCase' or
+    'ITCase'). Splitting asserts into one-assert-per-test methods (as
+    required by UnitTestContainsTooManyAsserts) inflates the method
+    count and would otherwise push test classes past the threshold.
+    The rule fires on the ClassBody node, so the XPath must reach the
+    enclosing ClassDeclaration via parent::ClassDeclaration to read
+    @SimpleName.
+    Downstream: https://github.com/yegor256/qulice/issues/1605
+  -->
   <rule ref="category/java/design.xml/TooManyMethods">
     <properties>
-      <property name="violationSuppressXPath" value=".[ends-with(@SimpleName,'Test')]"/>
+      <property name="violationSuppressXPath">
+        <value><![CDATA[
+          .[
+            parent::ClassDeclaration[
+              ends-with(@SimpleName,'Test')
+              or ends-with(@SimpleName,'IT')
+              or ends-with(@SimpleName,'TestCase')
+              or ends-with(@SimpleName,'ITCase')
+            ]
+          ]
+        ]]></value>
+      </property>
     </properties>
   </rule>
   <rule ref="category/java/documentation.xml">

--- a/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.io.TempDir;
  * Test case for {@link DefaultMavenEnvironment} class.
  * @since 0.8
  */
-@SuppressWarnings("PMD.TooManyMethods")
 final class DefaultMavenEnvironmentTest {
 
     /**

--- a/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.io.TempDir;
  * Test case for {@link DependenciesValidator} class.
  * @since 0.3
  */
-@SuppressWarnings("PMD.TooManyMethods")
 final class DependenciesValidatorTest {
 
     /**

--- a/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
  * related test-class conventions.
  * @since 0.25.0
  */
-@SuppressWarnings("PMD.TooManyMethods")
 final class PmdAssertionsTest {
 
     /**

--- a/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link PmdValidator}'s handling of the
+ * {@code TooManyMethods} rule, which is disabled for unit test
+ * classes so that splitting asserts into separate {@code @Test}
+ * methods (required by {@code UnitTestContainsTooManyAsserts})
+ * does not push the class past the threshold.
+ * Regression test for https://github.com/yegor256/qulice/issues/1605
+ * @since 1.0
+ */
+final class PmdTooManyMethodsTest {
+
+    @Test
+    void allowsManyMethodsInTestClass() throws Exception {
+        new PmdAssert(
+            "ManyMethodsTest.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("TooManyMethods")
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void allowsManyMethodsInIntegrationTestClass() throws Exception {
+        new PmdAssert(
+            "ManyMethodsIT.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("TooManyMethods")
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void reportsTooManyMethodsInNonTestClass() throws Exception {
+        new PmdAssert(
+            "ManyMethods.java",
+            Matchers.is(false),
+            Matchers.containsString("TooManyMethods")
+        ).assertOk();
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ManyMethods.java
+++ b/src/test/resources/com/qulice/pmd/ManyMethods.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class ManyMethods {
+
+    public void firstMethod() {
+    }
+
+    public void secondMethod() {
+    }
+
+    public void thirdMethod() {
+    }
+
+    public void fourthMethod() {
+    }
+
+    public void fifthMethod() {
+    }
+
+    public void sixthMethod() {
+    }
+
+    public void seventhMethod() {
+    }
+
+    public void eighthMethod() {
+    }
+
+    public void ninthMethod() {
+    }
+
+    public void tenthMethod() {
+    }
+
+    public void eleventhMethod() {
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ManyMethodsIT.java
+++ b/src/test/resources/com/qulice/pmd/ManyMethodsIT.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+final class ManyMethodsIT {
+
+    @Test
+    void firstCheck() {
+        MatcherAssert.assertThat("a", "a", Matchers.equalTo("a"));
+    }
+
+    @Test
+    void secondCheck() {
+        MatcherAssert.assertThat("b", "b", Matchers.equalTo("b"));
+    }
+
+    @Test
+    void thirdCheck() {
+        MatcherAssert.assertThat("c", "c", Matchers.equalTo("c"));
+    }
+
+    @Test
+    void fourthCheck() {
+        MatcherAssert.assertThat("d", "d", Matchers.equalTo("d"));
+    }
+
+    @Test
+    void fifthCheck() {
+        MatcherAssert.assertThat("e", "e", Matchers.equalTo("e"));
+    }
+
+    @Test
+    void sixthCheck() {
+        MatcherAssert.assertThat("f", "f", Matchers.equalTo("f"));
+    }
+
+    @Test
+    void seventhCheck() {
+        MatcherAssert.assertThat("g", "g", Matchers.equalTo("g"));
+    }
+
+    @Test
+    void eighthCheck() {
+        MatcherAssert.assertThat("h", "h", Matchers.equalTo("h"));
+    }
+
+    @Test
+    void ninthCheck() {
+        MatcherAssert.assertThat("i", "i", Matchers.equalTo("i"));
+    }
+
+    @Test
+    void tenthCheck() {
+        MatcherAssert.assertThat("j", "j", Matchers.equalTo("j"));
+    }
+
+    @Test
+    void eleventhCheck() {
+        MatcherAssert.assertThat("k", "k", Matchers.equalTo("k"));
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ManyMethodsTest.java
+++ b/src/test/resources/com/qulice/pmd/ManyMethodsTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+final class ManyMethodsTest {
+
+    @Test
+    void firstCheck() {
+        MatcherAssert.assertThat("a", "a", Matchers.equalTo("a"));
+    }
+
+    @Test
+    void secondCheck() {
+        MatcherAssert.assertThat("b", "b", Matchers.equalTo("b"));
+    }
+
+    @Test
+    void thirdCheck() {
+        MatcherAssert.assertThat("c", "c", Matchers.equalTo("c"));
+    }
+
+    @Test
+    void fourthCheck() {
+        MatcherAssert.assertThat("d", "d", Matchers.equalTo("d"));
+    }
+
+    @Test
+    void fifthCheck() {
+        MatcherAssert.assertThat("e", "e", Matchers.equalTo("e"));
+    }
+
+    @Test
+    void sixthCheck() {
+        MatcherAssert.assertThat("f", "f", Matchers.equalTo("f"));
+    }
+
+    @Test
+    void seventhCheck() {
+        MatcherAssert.assertThat("g", "g", Matchers.equalTo("g"));
+    }
+
+    @Test
+    void eighthCheck() {
+        MatcherAssert.assertThat("h", "h", Matchers.equalTo("h"));
+    }
+
+    @Test
+    void ninthCheck() {
+        MatcherAssert.assertThat("i", "i", Matchers.equalTo("i"));
+    }
+
+    @Test
+    void tenthCheck() {
+        MatcherAssert.assertThat("j", "j", Matchers.equalTo("j"));
+    }
+
+    @Test
+    void eleventhCheck() {
+        MatcherAssert.assertThat("k", "k", Matchers.equalTo("k"));
+    }
+}


### PR DESCRIPTION
Closes #1605.

## Problem

`UnitTestContainsTooManyAsserts` forces one assertion per `@Test` method, which inflates the method count of a test class. The existing suppression on `TooManyMethods` was meant to skip test classes, but the XPath `.[ends-with(@SimpleName,'Test')]` never matched because PMD's `TooManyMethods` rule fires on the `ClassBody` node — which has no `@SimpleName` attribute — not on `ClassDeclaration`. The rule was therefore running on every test class.

## Fix

Reach the enclosing `ClassDeclaration` via `parent::ClassDeclaration` and extend the suffix list to `Test`, `IT`, `TestCase` and `ITCase`, matching the convention already used by the `AvoidUsingHardCodedIP` rule in the same ruleset.

Dropped now-unnecessary `@SuppressWarnings("PMD.TooManyMethods")` annotations from `DefaultMavenEnvironmentTest`, `DependenciesValidatorTest` and `PmdAssertionsTest`. `MavenEnvironmentMocker` keeps its suppression because its name does not match a test-class suffix.

## Test plan

- [x] New `PmdTooManyMethodsTest` covers a `*Test` class, an `*IT` class, and a non-test class with many methods.
- [x] `mvn test` — all 327 unit tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HgTDMnziJGn35oQe8Gfytk)_