### PR TITLE
Fix UnnecessaryLocalRule false positives (#1607)

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -29,9 +29,9 @@ public final class UnnecessaryLocalRule extends AbstractJavaRulechainRule {
         final Object data
     ) {
         if (variable.getInitializer() != null) {
-            final String name = variableName(variable);
+            final String name = UnnecessaryLocalRule.variableName(variable);
             if (!name.isEmpty()) {
-                asCtx(data).addViolation(variable, name);
+                this.asCtx(data).addViolation(variable, name);
             }
         }
         return data;
@@ -60,14 +60,17 @@ public final class UnnecessaryLocalRule extends AbstractJavaRulechainRule {
     private static String variableName(final ASTVariableDeclarator variable) {
         String result = "";
         final ASTBlock block = variable.ancestors(ASTBlock.class).first();
-        if (block != null) {
+        if (block != null
+            && !UnnecessaryLocalSkips.freshState(variable.getInitializer())) {
             final String name = variable.getName();
-            if (hasReturnOrArguments(
-                block.descendants(ASTVariableAccess.class)
-                    .crossFindBoundaries()
-                    .filter(ref -> name.equals(ref.getName()))
-                    .toList()
-            )) {
+            final List<ASTVariableAccess> uses = block
+                .descendants(ASTVariableAccess.class)
+                .crossFindBoundaries()
+                .filter(ref -> name.equals(ref.getName()))
+                .toList();
+            if (UnnecessaryLocalRule.hasReturnOrArguments(uses)
+                && !UnnecessaryLocalSkips.acrossBoundary(block, name, uses.size())
+                && !UnnecessaryLocalSkips.interveningCall(variable, uses.get(0))) {
                 result = name;
             }
         }

--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd.rules;
+
+import java.util.Map;
+import java.util.Set;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAmbiguousName;
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTClassType;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+
+/**
+ * Heuristics that veto an {@link UnnecessaryLocalRule} report when the local
+ * is semantically required (closure capture, clock snapshot, or capture
+ * before a destructive call). See issue #1607.
+ * @since 0.27.7
+ */
+final class UnnecessaryLocalSkips {
+
+    /**
+     * Simple class names from {@code java.time} whose {@code now()} factory
+     * returns a fresh snapshot of the system clock.
+     */
+    private static final Set<String> TIME_TYPES = Set.of(
+        "Instant", "LocalDate", "LocalDateTime", "LocalTime",
+        "ZonedDateTime", "OffsetDateTime", "OffsetTime",
+        "Year", "YearMonth", "MonthDay", "Clock"
+    );
+
+    /**
+     * Other (non-{@code now()}) calls that return fresh state on each
+     * invocation, keyed by the qualifier's simple name.
+     */
+    private static final Map<String, Set<String>> FRESH_STATE_CALLS = Map.of(
+        "System", Set.of("currentTimeMillis", "nanoTime"),
+        "UUID", Set.of("randomUUID"),
+        "Math", Set.of("random")
+    );
+
+    private UnnecessaryLocalSkips() {
+    }
+
+    /**
+     * The single use of the local is reachable only by crossing a lambda or
+     * anonymous-class boundary, so the local exists to carry the value into
+     * a different exception scope.
+     * @param block The block enclosing the declaration
+     * @param name The variable name
+     * @param crossings Number of usages found when crossing find boundaries
+     * @return True when at least one usage sits behind a find boundary
+     */
+    static boolean acrossBoundary(
+        final ASTBlock block,
+        final String name,
+        final int crossings
+    ) {
+        return crossings != block
+            .descendants(ASTVariableAccess.class)
+            .filter(ref -> name.equals(ref.getName()))
+            .count();
+    }
+
+    /**
+     * The initialiser snapshots mutable global state - a clock, a randomness
+     * source, or {@code new Date()} - so inlining would change <em>when</em>
+     * the value is taken.
+     * @param init The initialiser expression
+     * @return True if the initialiser captures fresh state
+     */
+    static boolean freshState(final ASTExpression init) {
+        final boolean result;
+        if (init instanceof ASTMethodCall) {
+            result = UnnecessaryLocalSkips.freshStateCall((ASTMethodCall) init);
+        } else if (init instanceof ASTConstructorCall) {
+            final ASTClassType type =
+                ((ASTConstructorCall) init).getTypeNode();
+            result = type != null && "Date".equals(type.getSimpleName());
+        } else {
+            result = false;
+        }
+        return result;
+    }
+
+    /**
+     * The initialiser is a method call on some target, and a later statement
+     * (before the local is read) calls a method on that same target. Inlining
+     * would read the post-mutation value.
+     * @param variable The variable declarator
+     * @param use The single use of the variable
+     * @return True if an intervening statement calls the initialiser's target
+     */
+    static boolean interveningCall(
+        final ASTVariableDeclarator variable,
+        final ASTVariableAccess use
+    ) {
+        boolean found = false;
+        final ASTExpression init = variable.getInitializer();
+        if (init instanceof ASTMethodCall) {
+            final String target = UnnecessaryLocalSkips.qualifierImage(
+                ((ASTMethodCall) init).getQualifier()
+            );
+            if (target != null && !target.isEmpty()) {
+                final Node decl = UnnecessaryLocalSkips.blockLevel(variable);
+                final Node consumer = UnnecessaryLocalSkips.blockLevel(use);
+                found = UnnecessaryLocalSkips.sameBlock(decl, consumer)
+                    && UnnecessaryLocalSkips.scanBetween(decl, consumer, target);
+            }
+        }
+        return found;
+    }
+
+    private static boolean sameBlock(final Node first, final Node second) {
+        return first != null && second != null
+            && first.getParent() instanceof ASTBlock
+            && first.getParent().equals(second.getParent());
+    }
+
+    private static boolean freshStateCall(final ASTMethodCall call) {
+        final String name = call.getMethodName();
+        final String qualifier = UnnecessaryLocalSkips.qualifierImage(
+            call.getQualifier()
+        );
+        return qualifier != null
+            && (
+                UnnecessaryLocalSkips.FRESH_STATE_CALLS
+                    .getOrDefault(qualifier, Set.of()).contains(name)
+                || "now".equals(name)
+                && UnnecessaryLocalSkips.TIME_TYPES.contains(qualifier)
+            );
+    }
+
+    private static boolean scanBetween(
+        final Node decl,
+        final Node consumer,
+        final String target
+    ) {
+        final Node block = decl.getParent();
+        final int last = consumer.getIndexInParent();
+        boolean found = false;
+        for (int idx = decl.getIndexInParent() + 1; idx < last && !found;
+            idx += 1) {
+            found = block.getChild(idx).descendants(ASTMethodCall.class)
+                .crossFindBoundaries()
+                .toStream()
+                .anyMatch(call -> UnnecessaryLocalSkips.callsTarget(call, target));
+        }
+        return found;
+    }
+
+    private static boolean callsTarget(
+        final ASTMethodCall call,
+        final String target
+    ) {
+        return target.equals(
+            UnnecessaryLocalSkips.qualifierImage(call.getQualifier())
+        );
+    }
+
+    private static Node blockLevel(final Node node) {
+        Node current = node;
+        while (current != null && !(current.getParent() instanceof ASTBlock)) {
+            current = current.getParent();
+        }
+        return current;
+    }
+
+    private static String qualifierImage(final ASTExpression expr) {
+        final String result;
+        if (expr instanceof ASTAmbiguousName) {
+            result = ((ASTAmbiguousName) expr).getName();
+        } else if (expr instanceof ASTVariableAccess) {
+            result = ((ASTVariableAccess) expr).getName();
+        } else if (expr instanceof ASTTypeExpression
+            && ((ASTTypeExpression) expr).getTypeNode() instanceof ASTClassType) {
+            result = ((ASTClassType) ((ASTTypeExpression) expr).getTypeNode())
+                .getSimpleName();
+        } else {
+            result = null;
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
@@ -8,6 +8,7 @@ import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
@@ -20,63 +21,78 @@ import org.junit.jupiter.api.Test;
  */
 final class UnnecessaryLocalRuleTest {
 
+    /**
+     * The name of the rule under test.
+     */
+    private static final String RULE = "UnnecessaryLocalRule";
+
+    /**
+     * Path template for the fixture file in the mock environment.
+     */
+    private static final String PATH = "src/main/java/foo/%s";
+
     @Test
     void detectsUnnecessaryLocalVariableOnReturn() throws Exception {
-        final String file = "UnnecessaryLocal.java";
-        final Environment.Mock mock = new Environment.Mock();
-        final String name = String.format("src/main/java/foo/%s", file);
-        final Environment env = mock.withFile(
-            name,
-            new TextOf(
-                this.getClass().getResourceAsStream(file)
-            ).asString()
-        );
         MatcherAssert.assertThat(
             "UnnecessaryLocalRule should fire on a local variable used only in return",
-            new PmdValidator(env).validate(
-                Collections.singletonList(new File(env.basedir(), name))
-            ).stream().map(Violation::name).collect(Collectors.toList()),
-            Matchers.hasItem("UnnecessaryLocalRule")
+            this.violations("UnnecessaryLocal.java"),
+            Matchers.hasItem(UnnecessaryLocalRuleTest.RULE)
         );
     }
 
     @Test
     void doesNotFireWhenVariableIsUsedInLoop() throws Exception {
-        final String file = "UnnecessaryLocalInLoop.java";
-        final Environment.Mock mock = new Environment.Mock();
-        final String name = String.format("src/main/java/foo/%s", file);
-        final Environment env = mock.withFile(
-            name,
-            new TextOf(
-                this.getClass().getResourceAsStream(file)
-            ).asString()
-        );
         MatcherAssert.assertThat(
             "UnnecessaryLocalRule should not fire when variable is used in a loop",
-            new PmdValidator(env).validate(
-                Collections.singletonList(new File(env.basedir(), name))
-            ).stream().map(Violation::name).collect(Collectors.toList()),
-            Matchers.not(Matchers.hasItem("UnnecessaryLocalRule"))
+            this.violations("UnnecessaryLocalInLoop.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
         );
     }
 
     @Test
     void doesNotFireWhenVariableIsUsedMoreThanOnce() throws Exception {
-        final String file = "UnnecessaryLocalUsedTwice.java";
-        final Environment.Mock mock = new Environment.Mock();
-        final String name = String.format("src/main/java/foo/%s", file);
-        final Environment env = mock.withFile(
-            name,
-            new TextOf(
-                this.getClass().getResourceAsStream(file)
-            ).asString()
-        );
         MatcherAssert.assertThat(
             "UnnecessaryLocalRule should not fire when variable is used more than once",
-            new PmdValidator(env).validate(
-                Collections.singletonList(new File(env.basedir(), name))
-            ).stream().map(Violation::name).collect(Collectors.toList()),
-            Matchers.not(Matchers.hasItem("UnnecessaryLocalRule"))
+            this.violations("UnnecessaryLocalUsedTwice.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
         );
+    }
+
+    @Test
+    void doesNotFireWhenUseIsAcrossAnonymousClassOrLambda() throws Exception {
+        MatcherAssert.assertThat(
+            "UnnecessaryLocalRule should not fire when the only use is inside an anonymous class or lambda body",
+            this.violations("UnnecessaryLocalAcrossAnonymousClass.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
+        );
+    }
+
+    @Test
+    void doesNotFireWhenInitialiserCapturesFreshState() throws Exception {
+        MatcherAssert.assertThat(
+            "UnnecessaryLocalRule should not fire when the initialiser captures a clock or randomness source",
+            this.violations("UnnecessaryLocalCapturedTimestamp.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
+        );
+    }
+
+    @Test
+    void doesNotFireWhenInterveningCallMutatesSameTarget() throws Exception {
+        MatcherAssert.assertThat(
+            "UnnecessaryLocalRule should not fire when a later statement calls the same target",
+            this.violations("UnnecessaryLocalDestructiveCleanup.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
+        );
+    }
+
+    private List<String> violations(final String file) throws Exception {
+        final String name = String.format(UnnecessaryLocalRuleTest.PATH, file);
+        final Environment env = new Environment.Mock().withFile(
+            name,
+            new TextOf(this.getClass().getResourceAsStream(file)).asString()
+        );
+        return new PmdValidator(env).validate(
+            Collections.singletonList(new File(env.basedir(), name))
+        ).stream().map(Violation::name).collect(Collectors.toList());
     }
 }

--- a/src/test/resources/com/qulice/pmd/UnnecessaryLocalAcrossAnonymousClass.java
+++ b/src/test/resources/com/qulice/pmd/UnnecessaryLocalAcrossAnonymousClass.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+public final class UnnecessaryLocalAcrossAnonymousClass {
+
+    public Callable<String> capture(final Source src) throws IOException {
+        final String author = src.author();
+        return new Callable<String>() {
+            @Override
+            public String call() {
+                return author;
+            }
+        };
+    }
+
+    public Runnable captureInLambda(final Source src) throws IOException {
+        final String author = src.author();
+        return () -> System.out.println(author);
+    }
+
+    public interface Source {
+        String author() throws IOException;
+    }
+}

--- a/src/test/resources/com/qulice/pmd/UnnecessaryLocalCapturedTimestamp.java
+++ b/src/test/resources/com/qulice/pmd/UnnecessaryLocalCapturedTimestamp.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+public final class UnnecessaryLocalCapturedTimestamp {
+
+    public long timedWork() {
+        final long begin = System.currentTimeMillis();
+        doWork();
+        return System.currentTimeMillis() - begin;
+    }
+
+    public long nanoTimer() {
+        final long begin = System.nanoTime();
+        doWork();
+        return System.nanoTime() - begin;
+    }
+
+    public Instant capturedInstant() {
+        final Instant moment = Instant.now();
+        doWork();
+        return moment;
+    }
+
+    public Date capturedDate() {
+        final Date when = new Date();
+        doWork();
+        return when;
+    }
+
+    public String capturedUuid() {
+        final UUID id = UUID.randomUUID();
+        doWork();
+        return id.toString();
+    }
+
+    public double capturedRandom() {
+        final double rnd = Math.random();
+        doWork();
+        return rnd;
+    }
+
+    private void doWork() {
+        // no-op
+    }
+}

--- a/src/test/resources/com/qulice/pmd/UnnecessaryLocalDestructiveCleanup.java
+++ b/src/test/resources/com/qulice/pmd/UnnecessaryLocalDestructiveCleanup.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class UnnecessaryLocalDestructiveCleanup {
+
+    public String readThenWipe(final Shell shell) {
+        final String stdout = shell.exec("cat file");
+        shell.exec("rm -rf dir");
+        return stdout;
+    }
+
+    public interface Shell {
+        String exec(String cmd);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1607 by skipping `UnnecessaryLocalRule` in three patterns where the local is semantically required and inlining would change behaviour:

- **Closure capture across a method boundary** — the single use is reached only by crossing a lambda or anonymous-class boundary, so the local carries the value into a different exception scope (handles the `String author = comment.author()` example where `dirs()` doesn't declare `throws`).
- **Fresh-state initialiser** — the initialiser snapshots a clock or randomness source (`System.currentTimeMillis`, `System.nanoTime`, `Instant.now` and other `java.time` `now()` factories, `new Date()`, `UUID.randomUUID()`, `Math.random()`), so inlining would change *when* the value is captured.
- **Capture before a destructive call on the same target** — an intervening statement between the declaration and the read calls a method on the same target as the initialiser (e.g. `final String stdout = shell.exec("cat file"); shell.exec("rm -rf dir"); return stdout;`).

## Implementation

The veto heuristics are extracted to a package-private `UnnecessaryLocalSkips` helper class so `UnnecessaryLocalRule` stays focused. Cross-boundary detection compares descendant counts with and without `crossFindBoundaries()`.

## Test plan

- [x] `mvn test -Dtest=UnnecessaryLocalRuleTest` — 6 tests pass (3 new + 3 existing)
- [x] Full test suite (`mvn test`) — 327 tests pass
- [x] Qulice self-check (`mvn -Pqulice verify`) — no violations


---
_Generated by [Claude Code](https://claude.ai/code/session_01XynKe8gjLfXZcXz5WnVEsB)_