### PR TITLE
Add PMD rule for inline closeable resources

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/CloseInlineResourceRule.java
+++ b/src/main/java/com/qulice/pmd/rules/CloseInlineResourceRule.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd.rules;
+
+import java.util.Set;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
+import net.sourceforge.pmd.lang.java.ast.ASTResource;
+import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+
+/**
+ * Rule to flag {@code AutoCloseable} expressions that are created inline and
+ * then consumed by another expression instead of a resource boundary.
+ * @since 0.27.7
+ */
+public final class CloseInlineResourceRule extends AbstractJavaRulechainRule {
+
+    /**
+     * Exact resource types allowed by PMD's CloseResource rule.
+     */
+    private static final Set<String> ALLOWED = Set.of(
+        "java.io.ByteArrayOutputStream",
+        "java.io.ByteArrayInputStream",
+        "java.io.StringWriter",
+        "java.io.CharArrayWriter",
+        "java.util.stream.Stream",
+        "java.util.stream.IntStream",
+        "java.util.stream.LongStream",
+        "java.util.stream.DoubleStream"
+    );
+
+    public CloseInlineResourceRule() {
+        super(ASTConstructorCall.class, ASTMethodCall.class);
+    }
+
+    @Override
+    public Object visit(final ASTConstructorCall call, final Object data) {
+        if (CloseInlineResourceRule.leaksInline(call)) {
+            this.asCtx(data).addViolation(call);
+        }
+        return data;
+    }
+
+    @Override
+    public Object visit(final ASTMethodCall call, final Object data) {
+        if (CloseInlineResourceRule.leaksInline(call)
+            && CloseInlineResourceRule.hasCloseableArgument(call)) {
+            this.asCtx(data).addViolation(call);
+        }
+        return data;
+    }
+
+    private static boolean leaksInline(final ASTExpression expr) {
+        boolean result = false;
+        if (CloseInlineResourceRule.closeable(expr)
+            && !CloseInlineResourceRule.allowed(expr)) {
+            result = CloseInlineResourceRule.unmanagedInline(expr);
+        }
+        return result;
+    }
+
+    private static boolean closeable(final ASTExpression expr) {
+        return TypeTestUtil.isA(AutoCloseable.class, expr);
+    }
+
+    private static boolean allowed(final ASTExpression expr) {
+        return CloseInlineResourceRule.ALLOWED.stream()
+            .anyMatch(type -> TypeTestUtil.isExactlyA(type, expr));
+    }
+
+    private static boolean unmanagedInline(final ASTExpression expr) {
+        return CloseInlineResourceRule.inline(expr)
+            && !CloseInlineResourceRule.closedDirectly(expr)
+            && !CloseInlineResourceRule.returnedDirectly(expr);
+    }
+
+    private static boolean hasCloseableArgument(final ASTMethodCall call) {
+        return call.getArguments().descendants(ASTExpression.class)
+            .any(CloseInlineResourceRule::closeable);
+    }
+
+    private static boolean inline(final ASTExpression expr) {
+        return expr.ancestors(ASTResource.class).isEmpty()
+            && expr.ancestors(ASTVariableDeclarator.class).isEmpty();
+    }
+
+    private static boolean closedDirectly(final ASTExpression expr) {
+        boolean found = false;
+        final Node parent = expr.getParent();
+        if (parent instanceof ASTMethodCall) {
+            final ASTMethodCall call = (ASTMethodCall) parent;
+            found = "close".equals(call.getMethodName())
+                && expr.equals(call.getQualifier());
+        }
+        return found;
+    }
+
+    private static boolean returnedDirectly(final ASTExpression expr) {
+        return expr.getParent() instanceof ASTReturnStatement;
+    }
+}

--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -319,6 +319,15 @@
     </description>
     <priority>3</priority>
   </rule>
+  <rule name="CloseInlineResourceRule" message="Inline AutoCloseable expressions must be closed with try-with-resources" language="java" class="com.qulice.pmd.rules.CloseInlineResourceRule">
+    <description>
+      AutoCloseable values created as inline sub-expressions are invisible to
+      PMD CloseResource's local-variable tracking. Bind them to a
+      try-with-resources resource instead of consuming them directly in method
+      arguments or call chains.
+    </description>
+    <priority>3</priority>
+  </rule>
   <rule name="UnnecessaryLocalRule" message="Avoid creating unnecessary local variables like ''{0}''" language="java" class="com.qulice.pmd.rules.UnnecessaryLocalRule">
   </rule>
   <rule name="ConstructorShouldDoInitialization" message="Avoid doing field initialization outside constructor." language="java" class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">

--- a/src/test/java/com/qulice/pmd/CloseInlineResourceRuleTest.java
+++ b/src/test/java/com/qulice/pmd/CloseInlineResourceRuleTest.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link com.qulice.pmd.rules.CloseInlineResourceRule}.
+ * @since 0.27.7
+ */
+final class CloseInlineResourceRuleTest {
+
+    /**
+     * The name of the rule under test.
+     */
+    private static final String RULE = "CloseInlineResourceRule";
+
+    /**
+     * Path template for the fixture file in the mock environment.
+     */
+    private static final String PATH = "src/main/java/foo/%s";
+
+    @Test
+    void detectsCloseableInsideMethodChain() throws Exception {
+        MatcherAssert.assertThat(
+            "CloseInlineResourceRule should fire on inline closeable expressions",
+            this.violations("InlineCloseableMethodChain.java"),
+            Matchers.hasItem(CloseInlineResourceRuleTest.RULE)
+        );
+    }
+
+    @Test
+    void detectsArgumentAndChainReceiver() throws Exception {
+        MatcherAssert.assertThat(
+            "CloseInlineResourceRule should catch the argument and chain receiver",
+            Collections.frequency(
+                this.violations("InlineCloseableMethodChain.java"),
+                CloseInlineResourceRuleTest.RULE
+            ),
+            Matchers.greaterThanOrEqualTo(2)
+        );
+    }
+
+    @Test
+    void allowsTryWithResources() throws Exception {
+        MatcherAssert.assertThat(
+            "CloseInlineResourceRule should allow try-with-resources",
+            this.violations("InlineCloseableTryWithResources.java"),
+            Matchers.not(Matchers.hasItem(CloseInlineResourceRuleTest.RULE))
+        );
+    }
+
+    private List<String> violations(final String file) throws Exception {
+        final String name = String.format(CloseInlineResourceRuleTest.PATH, file);
+        final Environment env = new Environment.Mock().withFile(
+            name,
+            new TextOf(this.getClass().getResourceAsStream(file)).asString()
+        );
+        return new PmdValidator(env).validate(
+            Collections.singletonList(new File(env.basedir(), name))
+        ).stream().map(Violation::name).collect(Collectors.toList());
+    }
+}

--- a/src/test/resources/com/qulice/pmd/InlineCloseableMethodChain.java
+++ b/src/test/resources/com/qulice/pmd/InlineCloseableMethodChain.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.io.Closeable;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Iterator;
+
+@SuppressWarnings({
+    "PMD.AvoidFileStream",
+    "PMD.RelianceOnDefaultCharset",
+    "PMD.UnusedPrivateMethod"
+})
+public final class InlineCloseableMethodChain {
+
+    public Iterator<String> read(final Path path) throws IOException {
+        return this.parse(new FileReader(path.toFile())).iterator();
+    }
+
+    private Parser parse(final FileReader reader) {
+        return new Parser(reader);
+    }
+
+    private static final class Parser implements Closeable {
+
+        private final FileReader reader;
+
+        Parser(final FileReader reader) {
+            this.reader = reader;
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.reader.close();
+        }
+
+        Iterator<String> iterator() {
+            return Collections.emptyIterator();
+        }
+    }
+}

--- a/src/test/resources/com/qulice/pmd/InlineCloseableTryWithResources.java
+++ b/src/test/resources/com/qulice/pmd/InlineCloseableTryWithResources.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.io.Closeable;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Iterator;
+
+@SuppressWarnings({
+    "PMD.AvoidFileStream",
+    "PMD.RelianceOnDefaultCharset",
+    "PMD.UnusedPrivateMethod"
+})
+public final class InlineCloseableTryWithResources {
+
+    public Iterator<String> read(final Path path) throws IOException {
+        try (
+            FileReader reader = new FileReader(path.toFile());
+            Parser parser = this.parse(reader)
+        ) {
+            return parser.iterator();
+        }
+    }
+
+    private Parser parse(final FileReader reader) {
+        return new Parser(reader);
+    }
+
+    private static final class Parser implements Closeable {
+
+        private final FileReader reader;
+
+        Parser(final FileReader reader) {
+            this.reader = reader;
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.reader.close();
+        }
+
+        Iterator<String> iterator() {
+            return Collections.emptyIterator();
+        }
+    }
+}


### PR DESCRIPTION
Closes #1592.

Changes:
- Added `CloseInlineResourceRule` to flag inline `AutoCloseable` constructor calls and resource-propagating method-call chains that are consumed outside local/resource boundaries.
- Registered the rule in the Qulice PMD ruleset.
- Added fixtures for the leaking `FileReader`/parser method chain and an allowed try-with-resources case.

Validation:
- `mise x java@temurin-21 maven@3.9 -- mvn -q -Dtest=CloseInlineResourceRuleTest test`
- `mise x java@temurin-21 maven@3.9 -- mvn -q -DskipITs test`
- `mise x java@temurin-21 maven@3.9 -- mvn -B --no-transfer-progress verify -Pqulice -DskipTests -DskipITs`
- `git diff --cached --check`
- `git diff --cached --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1`