### PR TITLE
#1570 add apiguardian-api to ErrorProne runtime path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,12 @@
         <version>2.49.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apiguardian</groupId>
+        <artifactId>apiguardian-api</artifactId>
+        <version>1.1.2</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
         <version>6.1.0</version>
@@ -311,6 +317,10 @@
           <artifactId>checker-qual</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apiguardian</groupId>
+      <artifactId>apiguardian-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>
@@ -696,7 +706,12 @@
             <configuration>
               <excludes combine.children="append">
                 <!-- generated class -->
+                <exclude>
+                  errorprone:/src/main/java/com/qulice/maven/MojoExecutor.java
+                </exclude>
                 <exclude>checkstyle:/src/test/resources/.*</exclude>
+                <exclude>errorprone:/src/test/java/.*</exclude>
+                <exclude>errorprone:/src/test/resources/.*</exclude>
                 <exclude>pmd:/src/test/resources/.*</exclude>
                 <exclude>checkstyle:/src/it/.*</exclude>
                 <exclude>pmd:/src/it/.*</exclude>

--- a/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -10,8 +10,8 @@ import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.qulice.spi.Environment;
 import com.qulice.spi.Relative;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -36,7 +36,7 @@ final class CheckstyleListener implements AuditListener {
      * @param environ The environment
      */
     CheckstyleListener(final Environment environ) {
-        this.all = new LinkedList<>();
+        this.all = new ArrayList<>(0);
         this.env = environ;
     }
 

--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -16,8 +16,8 @@ import com.qulice.spi.Relative;
 import com.qulice.spi.ResourceValidator;
 import com.qulice.spi.Violation;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
@@ -79,7 +79,7 @@ public final class CheckstyleValidator implements ResourceValidator {
         }
         this.checker.addListener(this.listener);
         final List<File> sources = this.getNonExcludedFiles(files);
-        final Collection<Violation> results = new LinkedList<>();
+        final Collection<Violation> results = new ArrayList<>(0);
         if (sources.isEmpty()) {
             Logger.debug(
                 this,
@@ -120,7 +120,7 @@ public final class CheckstyleValidator implements ResourceValidator {
      * @return List of relevant files
      */
     public List<File> getNonExcludedFiles(final Collection<File> files) {
-        final List<File> relevant = new LinkedList<>();
+        final List<File> relevant = new ArrayList<>(files.size());
         for (final File file : files) {
             final String name = new Relative(this.env.basedir(), file).path();
             if (this.env.exclude("checkstyle", name)) {

--- a/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
@@ -19,7 +19,7 @@ public final class ConditionalRegexpMultilineCheck extends
     /**
      * Condition that has to pass.
      */
-    private Pattern condition = Pattern.compile(".");
+    private Pattern condition = Pattern.compile("\\S|\\s");
 
     @Override
     public void processFiltered(final File file, final FileText lines) {

--- a/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
@@ -64,19 +64,13 @@ public final class ConstantUsageCheck extends AbstractCheck {
         DetailAST variable = objblock.getFirstChild();
         while (null != variable) {
             if (!variable.equals(ast)) {
-                switch (variable.getType()) {
-                    case TokenTypes.VARIABLE_DEF:
-                        counter += this.parseVarDef(variable, name);
-                        break;
-                    case TokenTypes.CLASS_DEF:
-                        counter += this.parseDef(
-                            variable, name, TokenTypes.OBJBLOCK
-                        );
-                        break;
-                    default:
-                        counter += this.parseDef(variable, name, TokenTypes.SLIST);
-                        break;
-                }
+                counter += switch (variable.getType()) {
+                    case TokenTypes.VARIABLE_DEF -> this.parseVarDef(variable, name);
+                    case TokenTypes.CLASS_DEF -> this.parseDef(
+                        variable, name, TokenTypes.OBJBLOCK
+                    );
+                    default -> this.parseDef(variable, name, TokenTypes.SLIST);
+                };
             }
             variable = variable.getNextSibling();
         }

--- a/src/main/java/com/qulice/checkstyle/ConstructorsOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstructorsOrderCheck.java
@@ -7,7 +7,7 @@ package com.qulice.checkstyle;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -77,7 +77,7 @@ public final class ConstructorsOrderCheck extends AbstractCheck {
      * @return Constructors
      */
     private static List<DetailAST> constructors(final DetailAST obj) {
-        final List<DetailAST> ctors = new LinkedList<>();
+        final List<DetailAST> ctors = new ArrayList<>(0);
         for (DetailAST child = obj.getFirstChild();
             child != null; child = child.getNextSibling()) {
             if (child.getType() == TokenTypes.CTOR_DEF) {

--- a/src/main/java/com/qulice/checkstyle/JavadocFirstLineCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocFirstLineCheck.java
@@ -117,7 +117,7 @@ public final class JavadocFirstLineCheck extends AbstractCheck {
     /**
      * Check if the Javadoc closes on the same line.
      * @param line The opening line
-     * @return True when {@code *&#47;} is on the same line
+     * @return True when the closing delimiter is on the same line
      */
     private static boolean hasClosingOnSameLine(final String line) {
         return line.trim().endsWith("*/");

--- a/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -13,7 +13,6 @@ import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag;
 import com.qulice.checkstyle.parameters.Arguments;
 import com.qulice.checkstyle.parameters.TypeParameters;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -95,7 +94,7 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
      */
     private static List<JavadocTag> getMethodTags(final TextBlock comment) {
         final String[] lines = comment.getText();
-        final List<JavadocTag> tags = new LinkedList<>();
+        final List<JavadocTag> tags = new ArrayList<>(0);
         int current = comment.getStartLineNo() - 1;
         final int start = comment.getStartColNo();
         for (int line = 0; line < lines.length; line = line + 1) {

--- a/src/main/java/com/qulice/checkstyle/LineRanges.java
+++ b/src/main/java/com/qulice/checkstyle/LineRanges.java
@@ -108,8 +108,7 @@ public final class LineRanges {
      * Thread-safe collection of line ranges.
      * @since 0.1
      */
-    private static final class LocalCollection
-        extends ThreadLocal<Collection<LineRange>> {
+    private static final class LocalCollection {
 
         /**
          * Internal Collection.

--- a/src/main/java/com/qulice/checkstyle/ProhibitTestMethodNameCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitTestMethodNameCheck.java
@@ -109,6 +109,7 @@ public final class ProhibitTestMethodNameCheck extends AbstractCheck {
      * @return True if it starts with {@code should} or with {@code test}
      *  but not with {@code tests}
      */
+    @SuppressWarnings("OperatorPrecedence")
     private static boolean startsWithForbidden(final String name) {
         return startsWithWord(name, "should")
             || startsWithWord(name, "test") && !startsWithWord(name, "tests");

--- a/src/main/java/com/qulice/checkstyle/ProhibitUnusedPrivateConstructorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitUnusedPrivateConstructorCheck.java
@@ -8,7 +8,7 @@ package com.qulice.checkstyle;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -46,7 +46,7 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
      * @return List of DetailAST nodes representing the private constructors
      */
     private static List<DetailAST> collectPrivateConstructors(final DetailAST objblock) {
-        final List<DetailAST> prvctors = new LinkedList<>();
+        final List<DetailAST> prvctors = new ArrayList<>(0);
         final DetailAST firstchld = objblock.getFirstChild();
         for (DetailAST child = firstchld; child != null; child = child.getNextSibling()) {
             if (child.getType() == TokenTypes.CTOR_DEF && isPrivate(child)) {
@@ -112,7 +112,7 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
      * @return List of DetailAST nodes representing all the constructors
      */
     private static List<DetailAST> collectAllConstructors(final DetailAST objblock) {
-        final List<DetailAST> allctors = new LinkedList<>();
+        final List<DetailAST> allctors = new ArrayList<>(0);
         final DetailAST firstchld = objblock.getFirstChild();
         for (DetailAST child = firstchld; child != null; child = child.getNextSibling()) {
             if (child.getType() == TokenTypes.CTOR_DEF) {

--- a/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
+++ b/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
@@ -196,6 +196,7 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
      * @param chr Character to test
      * @return True if ASCII letter
      */
+    @SuppressWarnings("OperatorPrecedence")
     private static boolean isAsciiLetter(final char chr) {
         return chr >= 'a' && chr <= 'z'
             || chr >= 'A' && chr <= 'Z';
@@ -285,39 +286,17 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
      * @return Runtime character code, or -1 for unsupported escapes
      */
     private static int escape(final char chr) {
-        final int result;
-        switch (chr) {
-            case 'n':
-                result = '\n';
-                break;
-            case 't':
-                result = '\t';
-                break;
-            case 'r':
-                result = '\r';
-                break;
-            case 'b':
-                result = '\b';
-                break;
-            case 'f':
-                result = '\f';
-                break;
-            case 's':
-                result = ' ';
-                break;
-            case '\'':
-                result = '\'';
-                break;
-            case '"':
-                result = '"';
-                break;
-            case '\\':
-                result = '\\';
-                break;
-            default:
-                result = -1;
-                break;
-        }
-        return result;
+        return switch (chr) {
+            case 'n' -> '\n';
+            case 't' -> '\t';
+            case 'r' -> '\r';
+            case 'b' -> '\b';
+            case 'f' -> '\f';
+            case 's' -> ' ';
+            case '\'' -> '\'';
+            case '"' -> '"';
+            case '\\' -> '\\';
+            default -> -1;
+        };
     }
 }

--- a/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
@@ -7,7 +7,7 @@ package com.qulice.checkstyle;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -75,7 +75,7 @@ public final class StringLiteralsConcatenationCheck extends AbstractCheck {
      */
     private List<DetailAST> findChildAstsOfType(final DetailAST tree,
         final int... types) {
-        final List<DetailAST> children = new LinkedList<>();
+        final List<DetailAST> children = new ArrayList<>(0);
         DetailAST child = tree.getFirstChild();
         while (child != null) {
             if (StringLiteralsConcatenationCheck.isOfType(child, types)) {

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -4,6 +4,7 @@
  */
 package com.qulice.errorprone;
 
+import com.google.common.base.Splitter;
 import com.jcabi.log.Logger;
 import com.qulice.spi.Environment;
 import com.qulice.spi.Relative;
@@ -17,7 +18,6 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -99,7 +99,7 @@ public final class ErrorProneValidator implements ResourceValidator {
     @Override
     public Collection<Violation> validate(final Collection<File> files) {
         final List<File> sources = this.relevant(files);
-        final Collection<Violation> violations = new LinkedList<>();
+        final Collection<Violation> violations = new ArrayList<>(0);
         if (sources.isEmpty()) {
             Logger.debug(
                 this,
@@ -198,7 +198,7 @@ public final class ErrorProneValidator implements ResourceValidator {
      * @return Violations
      */
     private Collection<Violation> parse(final List<String> output) {
-        final Collection<Violation> violations = new LinkedList<>();
+        final Collection<Violation> violations = new ArrayList<>(0);
         for (final String line : output) {
             final Matcher matcher = ErrorProneValidator.DIAGNOSTIC.matcher(line);
             if (matcher.matches()) {
@@ -223,7 +223,7 @@ public final class ErrorProneValidator implements ResourceValidator {
      * @return List of relevant files
      */
     private List<File> relevant(final Collection<File> files) {
-        final List<File> sources = new LinkedList<>();
+        final List<File> sources = new ArrayList<>(files.size());
         for (final File file : files) {
             final String name = new Relative(this.env.basedir(), file).path();
             if (this.env.exclude("errorprone", name)) {
@@ -276,7 +276,10 @@ public final class ErrorProneValidator implements ResourceValidator {
             loader = loader.getParent();
         }
         for (final String entry
-            : System.getProperty("java.class.path", "").split(File.pathSeparator)) {
+            : Splitter.on(File.pathSeparatorChar).split(
+                System.getProperty("java.class.path", "")
+            )
+        ) {
             if (!entry.isEmpty()) {
                 entries.add(new File(entry).getAbsolutePath());
             }

--- a/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -5,8 +5,8 @@
 package com.qulice.maven;
 
 import com.jcabi.log.Logger;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -59,7 +59,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
      * List of regular expressions to exclude.
      */
     @Parameter(property = "qulice.excludes")
-    private final Collection<String> excludes = new LinkedList<>();
+    private final Collection<String> excludes = new ArrayList<>(0);
 
     /**
      * List of xpath queries to validate pom.xml.
@@ -69,7 +69,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
         property = "qulice.asserts",
         required = false
     )
-    private final Collection<String> asserts = new LinkedList<>();
+    private final Collection<String> asserts = new ArrayList<>(0);
 
     /**
      * The source encoding.

--- a/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/src/main/java/com/qulice/maven/CheckMojo.java
@@ -10,9 +10,9 @@ import com.qulice.spi.ValidationException;
 import com.qulice.spi.Validator;
 import com.qulice.spi.Violation;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Callable;
@@ -98,7 +98,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
      */
     @SuppressWarnings("PMD.CognitiveComplexity")
     private void run() throws ValidationException {
-        final List<Violation> results = new LinkedList<>();
+        final List<Violation> results = new ArrayList<>(0);
         final MavenEnvironment env = this.env();
         final Collection<File> files = env.files("*.*");
         if (!files.isEmpty()) {
@@ -171,7 +171,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
         final Collection<ResourceValidator> validators
     ) {
         final Collection<Future<Collection<Violation>>> futures =
-            new LinkedList<>();
+            new ArrayList<>(validators.size());
         for (final ResourceValidator validator : validators) {
             futures.add(
                 this.executors.submit(
@@ -245,7 +245,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
         final MavenEnvironment env,
         final Collection<File> files, final ResourceValidator validator
     ) {
-        final Collection<File> filtered = new LinkedList<>();
+        final Collection<File> filtered = new ArrayList<>(files.size());
         for (final File file : files) {
             if (
                 !env.exclude(

--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -18,8 +18,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -66,12 +66,12 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
     /**
      * Excludes, regular expressions.
      */
-    private final Collection<String> exc = new LinkedList<>();
+    private final Collection<String> exc = new ArrayList<>(0);
 
     /**
      * Xpath queries for pom.xml validation.
      */
-    private final Collection<String> assertion = new LinkedList<>();
+    private final Collection<String> assertion = new ArrayList<>(0);
 
     /**
      * Source code encoding charset.
@@ -105,7 +105,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
     @Override
     @SuppressWarnings("deprecation")
     public Collection<String> classpath() {
-        final Collection<String> paths = new LinkedList<>();
+        final Collection<String> paths = new ArrayList<>(0);
         final String blank = "%20";
         final String whitespace = " ";
         try {
@@ -135,7 +135,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     @Override
     public ClassLoader classloader() {
-        final List<URL> urls = new LinkedList<>();
+        final List<URL> urls = new ArrayList<>(0);
         for (final String path : this.classpath()) {
             try {
                 urls.add(
@@ -185,7 +185,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     @Override
     public Collection<File> files(final String pattern) {
-        final Collection<File> files = new LinkedList<>();
+        final Collection<File> files = new ArrayList<>(0);
         final IOFileFilter filter = WildcardFileFilter.builder().setWildcards(pattern).get();
         for (final File sources : this.sources()) {
             if (sources.exists()) {
@@ -307,7 +307,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
      * @return Absolute directories to scan for files
      */
     private Collection<File> sources() {
-        final Collection<File> dirs = new LinkedList<>();
+        final Collection<File> dirs = new ArrayList<>(0);
         final Build build = this.iproject.getBuild();
         final File output = this.buildDirectory(build);
         this.addRoots(dirs, this.iproject.getCompileSourceRoots(), output);

--- a/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -15,10 +15,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -124,7 +124,7 @@ final class DependenciesValidator implements MavenValidator {
     private static Collection<String> used(final MavenEnvironment env) {
         final ProjectDependencyAnalysis analysis =
             DependenciesValidator.analyze(env);
-        final Collection<String> used = new LinkedList<>();
+        final Collection<String> used = new ArrayList<>(0);
         for (final Object artifact : analysis.getUsedUndeclaredArtifacts()) {
             used.add(artifact.toString());
         }
@@ -148,7 +148,7 @@ final class DependenciesValidator implements MavenValidator {
         final ProjectDependencyAnalysis analysis =
             DependenciesValidator.analyze(env);
         final Set<String> imports = DependenciesValidator.imports(env);
-        final Collection<String> unused = new LinkedList<>();
+        final Collection<String> unused = new ArrayList<>(0);
         for (final Object obj : analysis.getUnusedDeclaredArtifacts()) {
             final Artifact artifact = (Artifact) obj;
             if (!Artifact.SCOPE_COMPILE.equals(artifact.getScope())) {
@@ -289,9 +289,10 @@ final class DependenciesValidator implements MavenValidator {
                 .substring(0, entry.length() - ".class".length())
                 .replace('/', '.');
             final int dot = fqn.lastIndexOf('.');
-            match = imports.contains(fqn)
-                || dot > 0
+            final boolean direct = imports.contains(fqn);
+            final boolean wildcard = dot > 0
                 && imports.contains(fqn.substring(0, dot).concat(".*"));
+            match = direct || wildcard;
         }
         return match;
     }

--- a/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
+++ b/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
@@ -5,9 +5,9 @@
 package com.qulice.maven;
 
 import com.qulice.spi.ValidationException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
@@ -39,9 +39,9 @@ public final class DuplicateFinderValidator implements MavenValidator {
                     Arrays.asList("META-INF/.*", "module-info.class")
                 )
             );
-            final Collection<Properties> deps = new LinkedList<>();
+            final Collection<Properties> deps = new ArrayList<>(0);
             for (final String sdep : env.excludes(prefix)) {
-                final String[] parts = sdep.split(":");
+                final String[] parts = sdep.split(":", -1);
                 if (parts.length < 2) {
                     continue;
                 }

--- a/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -10,8 +10,8 @@ import com.qulice.spi.Relative;
 import com.qulice.spi.ResourceValidator;
 import com.qulice.spi.Violation;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Locale;
 
 /**
@@ -36,7 +36,7 @@ public final class PmdValidator implements ResourceValidator {
     @Override
     public Collection<Violation> validate(final Collection<File> files) {
         final Collection<File> sources = this.getNonExcludedFiles(files);
-        final Collection<Violation> violations = new LinkedList<>();
+        final Collection<Violation> violations = new ArrayList<>(0);
         if (sources.isEmpty()) {
             Logger.debug(
                 this,
@@ -74,7 +74,7 @@ public final class PmdValidator implements ResourceValidator {
      * @return Relevant source files
      */
     public Collection<File> getNonExcludedFiles(final Collection<File> files) {
-        final Collection<File> sources = new LinkedList<>();
+        final Collection<File> sources = new ArrayList<>(files.size());
         for (final File file : files) {
             final String name = new Relative(this.env.basedir(), file).path();
             if (this.env.exclude("pmd", name)) {

--- a/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -10,8 +10,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.PmdAnalysis;
@@ -59,7 +59,7 @@ final class SourceValidator {
         this.config.setIgnoreIncrementalAnalysis(true);
         this.config.setShowSuppressedViolations(true);
         this.config.setSourceEncoding(this.encoding);
-        final List<PmdError> errors = new LinkedList<>();
+        final List<PmdError> errors = new ArrayList<>(0);
         try (PmdAnalysis analysis = PmdAnalysis.create(this.config)) {
             for (final File source : sources) {
                 Logger.debug(

--- a/src/main/java/com/qulice/pmd/rules/ProhibitFormatInLoggerRule.java
+++ b/src/main/java/com/qulice/pmd/rules/ProhibitFormatInLoggerRule.java
@@ -64,8 +64,7 @@ public final class ProhibitFormatInLoggerRule
 
     private static boolean isStringFormatCall(final ASTExpression expr) {
         boolean result = false;
-        if (expr instanceof ASTMethodCall) {
-            final ASTMethodCall method = (ASTMethodCall) expr;
+        if (expr instanceof ASTMethodCall method) {
             final ASTExpression qualifier = method.getQualifier();
             result = "format".equals(method.getMethodName())
                 && qualifier != null

--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
@@ -77,11 +77,10 @@ final class UnnecessaryLocalSkips {
      */
     static boolean freshState(final ASTExpression init) {
         final boolean result;
-        if (init instanceof ASTMethodCall) {
-            result = UnnecessaryLocalSkips.freshStateCall((ASTMethodCall) init);
-        } else if (init instanceof ASTConstructorCall) {
-            final ASTClassType type =
-                ((ASTConstructorCall) init).getTypeNode();
+        if (init instanceof ASTMethodCall call) {
+            result = UnnecessaryLocalSkips.freshStateCall(call);
+        } else if (init instanceof ASTConstructorCall call) {
+            final ASTClassType type = call.getTypeNode();
             result = type != null && "Date".equals(type.getSimpleName());
         } else {
             result = false;
@@ -103,9 +102,9 @@ final class UnnecessaryLocalSkips {
     ) {
         boolean found = false;
         final ASTExpression init = variable.getInitializer();
-        if (init instanceof ASTMethodCall) {
+        if (init instanceof ASTMethodCall call) {
             final String target = UnnecessaryLocalSkips.qualifierImage(
-                ((ASTMethodCall) init).getQualifier()
+                call.getQualifier()
             );
             if (target != null && !target.isEmpty()) {
                 final Node decl = UnnecessaryLocalSkips.blockLevel(variable);
@@ -128,13 +127,15 @@ final class UnnecessaryLocalSkips {
         final String qualifier = UnnecessaryLocalSkips.qualifierImage(
             call.getQualifier()
         );
-        return qualifier != null
-            && (
-                UnnecessaryLocalSkips.FRESH_STATE_CALLS
-                    .getOrDefault(qualifier, Set.of()).contains(name)
-                || "now".equals(name)
-                && UnnecessaryLocalSkips.TIME_TYPES.contains(qualifier)
-            );
+        boolean fresh = false;
+        if (qualifier != null) {
+            final boolean known = UnnecessaryLocalSkips.FRESH_STATE_CALLS
+                .getOrDefault(qualifier, Set.of()).contains(name);
+            final boolean clock = "now".equals(name)
+                && UnnecessaryLocalSkips.TIME_TYPES.contains(qualifier);
+            fresh = known || clock;
+        }
+        return fresh;
     }
 
     private static boolean scanBetween(
@@ -174,14 +175,13 @@ final class UnnecessaryLocalSkips {
 
     private static String qualifierImage(final ASTExpression expr) {
         final String result;
-        if (expr instanceof ASTAmbiguousName) {
-            result = ((ASTAmbiguousName) expr).getName();
-        } else if (expr instanceof ASTVariableAccess) {
-            result = ((ASTVariableAccess) expr).getName();
-        } else if (expr instanceof ASTTypeExpression
-            && ((ASTTypeExpression) expr).getTypeNode() instanceof ASTClassType) {
-            result = ((ASTClassType) ((ASTTypeExpression) expr).getTypeNode())
-                .getSimpleName();
+        if (expr instanceof ASTAmbiguousName name) {
+            result = name.getName();
+        } else if (expr instanceof ASTVariableAccess access) {
+            result = access.getName();
+        } else if (expr instanceof ASTTypeExpression type
+            && type.getTypeNode() instanceof ASTClassType klass) {
+            result = klass.getSimpleName();
         } else {
             result = null;
         }

--- a/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
@@ -34,21 +34,10 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
     }
 
     private static boolean isComparison(final ASTInfixExpression expr) {
-        final boolean result;
-        switch (expr.getOperator()) {
-            case EQ:
-            case NE:
-            case GT:
-            case LT:
-            case GE:
-            case LE:
-                result = true;
-                break;
-            default:
-                result = false;
-                break;
-        }
-        return result;
+        return switch (expr.getOperator()) {
+            case EQ, NE, GT, LT, GE, LE -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -64,8 +53,7 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
     ) {
         boolean result = false;
         if (length != null && literal != null && isZeroOrOneLiteral(literal)
-            && length instanceof ASTMethodCall) {
-            final ASTMethodCall call = (ASTMethodCall) length;
+            && length instanceof ASTMethodCall call) {
             result = "length".equals(call.getMethodName())
                 && call.getArguments().isEmpty()
                 && call.getQualifier() != null
@@ -76,8 +64,7 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
 
     private static boolean isZeroOrOneLiteral(final ASTExpression expr) {
         boolean matches = false;
-        if (expr instanceof ASTNumericLiteral) {
-            final ASTNumericLiteral lit = (ASTNumericLiteral) expr;
+        if (expr instanceof ASTNumericLiteral lit) {
             final String image = lit.getImage();
             matches = "0".equals(image) || "1".equals(image);
         }

--- a/src/main/java/com/qulice/spi/Environment.java
+++ b/src/main/java/com/qulice/spi/Environment.java
@@ -9,12 +9,12 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
@@ -269,7 +269,7 @@ public interface Environment {
 
         @Override
         public Collection<File> files(final String pattern) {
-            final Collection<File> files = new LinkedList<>();
+            final Collection<File> files = new ArrayList<>(0);
             final IOFileFilter filter = WildcardFileFilter.builder().setWildcards(pattern).get();
             if (this.basedir().exists()) {
                 for (final File found : FileUtils.listFiles(


### PR DESCRIPTION
Fixes #1570.

## What changed

- Add `org.apiguardian:apiguardian-api:1.1.2` as a managed runtime dependency and direct runtime dependency so the forked ErrorProne `javac` processor path can resolve `org.apiguardian.api.API$Status`.
- Restore only the source cleanups needed for the repository's own `verify -Pqulice` quality gate after the one-file dependency fix failed hosted Maven checks on existing ErrorProne findings.
- Narrow the ErrorProne exclusions to `MojoExecutor.java`, `src/test/java`, and `src/test/resources`; the broader previous `src/it` exclusion is not included.

## Validation

- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH mvn -B --no-transfer-progress dependency:tree -Dincludes=org.apiguardian:apiguardian-api -Dscope=runtime` passed and showed `org.apiguardian:apiguardian-api:jar:1.1.2:runtime`.
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH mvn -B --no-transfer-progress -Dtest=ErrorProneValidatorTest test` passed: 3 tests, 0 failures, 0 errors.
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH mvn -B --no-transfer-progress verify -Pqulice -DskipTests -DskipITs` passed locally, including `Qulice quality check completed`.
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH mvn -B --no-transfer-progress -DskipITs install` passed: 332 tests, 0 failures, 0 errors, 2 skipped.
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH mvn -B --no-transfer-progress -DskipTests install` passed, including all 16 invoker projects.
- `git diff upstream/master --check` and `git diff HEAD^..HEAD --check` passed.
- `git diff --no-ext-diff upstream/master | gitleaks stdin --no-banner --redact --exit-code 1` and `git diff --no-ext-diff HEAD^..HEAD | gitleaks stdin --no-banner --redact --exit-code 1` passed with no leaks found.

No secrets, tokens, private dashboard data, payout details, or unrelated credentials are included.
