### PR TITLE
fix: #1630 align pom.xml license declaration with MIT canonical sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
   </organization>
   <licenses>
     <license>
-      <name>BSD</name>
-      <url>https://www.qulice.com/LICENSE.txt</url>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
The `<license>` block in `pom.xml` at lines 27-32 declares this artifact under `BSD` with URL `https://www.qulice.com/LICENSE.txt`, while every authoritative SPDX-tracked source in the repository names MIT. `REUSE.toml` carries `SPDX-License-Identifier: MIT`, the only file under `LICENSES/` is `MIT.txt`, and the README badge points at MIT. Maven Central, license scanners, SBOM generators, and IDEs all read the `<licenses>` block in `pom.xml`, so the mismatch propagates downstream: anyone consuming `com.qulice:qulice` sees BSD attached to the artifact even though the source tree is published under MIT.

This change rewrites the single `<license>` entry: `<name>` becomes `MIT` and `<url>` becomes `https://opensource.org/licenses/MIT`, the canonical OSI link the SPDX MIT identifier resolves to. Nothing else in the POM, the source tree, or the build moves. `REUSE.toml`, `LICENSES/MIT.txt`, and the README badge are already on MIT and stay as-is. The artifact metadata now agrees with the rest of the repository.

I have not run the full `mvn install` / `verify -Pqulice` matrix locally — the diff is a two-line text edit inside `<licenses>` with no Java, no resource, and no plugin configuration touched. The repository's existing `mvn (ubuntu-24.04, 21)`, `mvn (windows-2025, 21)`, `mvn (macos-15, 21)`, and `reuse` GitHub Actions jobs cover the build and the licensing audit; their results on this PR are the authoritative gate. Fixes #1630.
