### PR TITLE
Never report TooManyMethods in test classes

### DIFF
--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -181,26 +181,37 @@
   </rule>
   <!--
   TooManyMethods is excluded from the bulk import above and re-enabled
-  here with a violationSuppressXPath that skips unit-test classes
-  (those whose simple name ends with 'Test', 'IT', 'TestCase' or
-  'ITCase'). Splitting asserts into one-assert-per-test methods (as
-  required by UnitTestContainsTooManyAsserts) inflates the method
-  count and would otherwise push test classes past the threshold.
-  The rule fires on the ClassBody node, so the XPath must reach the
-  enclosing ClassDeclaration via parent::ClassDeclaration to read
-  @SimpleName.
+  here with a violationSuppressXPath that skips test classes.
+  Splitting asserts into one-assert-per-test methods (as required by
+  UnitTestContainsTooManyAsserts) inflates the method count and would
+  otherwise push test classes past the threshold. A type counts as a
+  test when its simple name ends with 'Test', 'Tests', 'IT',
+  'TestCase' or 'ITCase', or when it carries a test annotation
+  anywhere inside, which covers classes named by other conventions
+  and TestNG classes annotated at class level. The rule fires on the
+  ClassBody node, so the XPath walks ancestor-or-self to reach every
+  enclosing type, which also exempts @Nested inner classes.
   Downstream: https://github.com/yegor256/qulice/issues/1605
+  Downstream: https://github.com/yegor256/qulice/issues/1647
   -->
   <rule ref="category/java/design.xml/TooManyMethods">
     <properties>
       <property name="violationSuppressXPath">
         <value><![CDATA[
           .[
-            parent::ClassDeclaration[
+            ancestor-or-self::*[
               ends-with(@SimpleName,'Test')
+              or ends-with(@SimpleName,'Tests')
               or ends-with(@SimpleName,'IT')
               or ends-with(@SimpleName,'TestCase')
               or ends-with(@SimpleName,'ITCase')
+              or .//Annotation[
+                ends-with(@SimpleName,'Test')
+                or @SimpleName='TestFactory'
+                or @SimpleName='TestTemplate'
+                or @SimpleName='Theory'
+                or @SimpleName='Nested'
+              ]
             ]
           ]
         ]]></value>

--- a/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
@@ -6,33 +6,33 @@ package com.qulice.pmd;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link PmdValidator}'s handling of the
- * {@code TooManyMethods} rule, which is disabled for unit test
+ * {@code TooManyMethods} rule, which is disabled for test
  * classes so that splitting asserts into separate {@code @Test}
  * methods (required by {@code UnitTestContainsTooManyAsserts})
  * does not push the class past the threshold.
  * Regression test for https://github.com/yegor256/qulice/issues/1605
+ * and https://github.com/yegor256/qulice/issues/1647
  * @since 1.0
  */
 final class PmdTooManyMethodsTest {
 
-    @Test
-    void allowsManyMethodsInTestClass() throws Exception {
-        new PmdAssert(
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
             "ManyMethodsTest.java",
-            Matchers.any(Boolean.class),
-            Matchers.not(
-                Matchers.containsString("TooManyMethods")
-            )
-        ).assertOk();
-    }
-
-    @Test
-    void allowsManyMethodsInIntegrationTestClass() throws Exception {
-        new PmdAssert(
             "ManyMethodsIT.java",
+            "ManyMethodsNestedTest.java",
+            "ManyMethodsChecks.java"
+        }
+    )
+    void allowsManyMethodsInTestClass(final String file) throws Exception {
+        new PmdAssert(
+            file,
             Matchers.any(Boolean.class),
             Matchers.not(
                 Matchers.containsString("TooManyMethods")

--- a/src/test/resources/com/qulice/pmd/ManyMethodsChecks.java
+++ b/src/test/resources/com/qulice/pmd/ManyMethodsChecks.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+final class ManyMethodsChecks {
+
+    @Test
+    void firstCheck() {
+        MatcherAssert.assertThat("first", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void secondCheck() {
+        MatcherAssert.assertThat("second", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void thirdCheck() {
+        MatcherAssert.assertThat("third", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void fourthCheck() {
+        MatcherAssert.assertThat("fourth", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void fifthCheck() {
+        MatcherAssert.assertThat("fifth", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void sixthCheck() {
+        MatcherAssert.assertThat("sixth", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void seventhCheck() {
+        MatcherAssert.assertThat("seventh", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void eighthCheck() {
+        MatcherAssert.assertThat("eighth", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void ninthCheck() {
+        MatcherAssert.assertThat("ninth", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void tenthCheck() {
+        MatcherAssert.assertThat("tenth", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void eleventhCheck() {
+        MatcherAssert.assertThat("eleventh", "x", Matchers.equalTo("x"));
+    }
+
+    @Test
+    void twelfthCheck() {
+        MatcherAssert.assertThat("twelfth", "x", Matchers.equalTo("x"));
+    }
+
+}

--- a/src/test/resources/com/qulice/pmd/ManyMethodsNestedTest.java
+++ b/src/test/resources/com/qulice/pmd/ManyMethodsNestedTest.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class ManyMethodsNestedTest {
+
+    @Nested
+    final class Inner {
+
+        @Test
+        void firstCheck() {
+            MatcherAssert.assertThat("first", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void secondCheck() {
+            MatcherAssert.assertThat("second", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void thirdCheck() {
+            MatcherAssert.assertThat("third", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void fourthCheck() {
+            MatcherAssert.assertThat("fourth", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void fifthCheck() {
+            MatcherAssert.assertThat("fifth", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void sixthCheck() {
+            MatcherAssert.assertThat("sixth", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void seventhCheck() {
+            MatcherAssert.assertThat("seventh", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void eighthCheck() {
+            MatcherAssert.assertThat("eighth", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void ninthCheck() {
+            MatcherAssert.assertThat("ninth", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void tenthCheck() {
+            MatcherAssert.assertThat("tenth", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void eleventhCheck() {
+            MatcherAssert.assertThat("eleventh", "x", Matchers.equalTo("x"));
+        }
+
+        @Test
+        void twelfthCheck() {
+            MatcherAssert.assertThat("twelfth", "x", Matchers.equalTo("x"));
+        }
+
+    }
+}


### PR DESCRIPTION
The `TooManyMethods` suppression for test classes now recognises a lot
more of them. Before, the XPath looked only at the class immediately
enclosing the flagged body and only at four name suffixes, so the rule
still fired on `@Nested` inner classes and on test classes named by
other conventions. It now walks every enclosing type, accepts the
`Tests` suffix too, and treats any type carrying a test annotation
(`@Test`, `@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`,
`@TestTemplate`, `@Theory`, `@Nested`) as a test class.

Test classes hit the method threshold for a reason we impose ourselves:
one assert per test method, which is what
`UnitTestContainsTooManyAsserts` demands. Punishing a class for
obeying another rule is not useful, so the exemption should cover all
test classes and not just the ones named the way we happen to expect.

Two fixtures came along with it, one for the nested case and one for a
test class named `ManyMethodsChecks`, both of which failed before the
change. Production classes are still flagged as before.

Closes #1647