### PR TITLE
Replace PMD TooManyMethods with a custom rule

### DIFF
--- a/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
+++ b/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
@@ -33,7 +33,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * @since 0.3
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
+@SuppressWarnings("PMD.GodClass")
 public final class BracketsStructureCheck extends AbstractCheck {
 
     @Override

--- a/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd.rules;
+
+import java.util.Set;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+
+/**
+ * Rule to check that a class does not expose too many methods. Unlike the
+ * PMD built-in {@code TooManyMethods} rule, this implementation counts
+ * only public and protected methods, because private and package-private
+ * ones are implementation detail and say nothing about how large the
+ * contract of the class is. Test classes are skipped altogether, since
+ * one assertion per test method inflates their method count beyond any
+ * useful threshold. Skipping them here instead of through a
+ * {@code violationSuppressXPath} keeps a redundant
+ * {@code @SuppressWarnings("PMD.TooManyMethods")} visible to
+ * {@code UnnecessaryWarningSuppression}, which PMD credits to the
+ * annotation whenever the annotation suppressor runs first.
+ * @since 1.0
+ */
+public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
+
+    /**
+     * The largest number of public and protected methods a class may have.
+     */
+    private static final int MAX = 10;
+
+    /**
+     * Simple-name suffixes that mark a type as a test.
+     */
+    private static final Set<String> SUFFIXES = Set.of(
+        "Test",
+        "Tests",
+        "IT",
+        "TestCase",
+        "ITCase"
+    );
+
+    /**
+     * Annotations that mark a type as a test even when its name follows
+     * another convention. Names ending with {@code Test} are recognised
+     * separately, which covers {@code @Test}, {@code @ParameterizedTest},
+     * {@code @RepeatedTest} and their third-party equivalents.
+     */
+    private static final Set<String> ANNOTATIONS = Set.of(
+        "TestFactory",
+        "TestTemplate",
+        "Theory",
+        "Nested"
+    );
+
+    public TooManyMethodsRule() {
+        super(ASTClassDeclaration.class);
+    }
+
+    @Override
+    public Object visit(final ASTClassDeclaration type, final Object data) {
+        if (!TooManyMethodsRule.tested(type)
+            && TooManyMethodsRule.exposed(type) > TooManyMethodsRule.MAX) {
+            this.asCtx(data).addViolation(type);
+        }
+        return data;
+    }
+
+    private static int exposed(final ASTClassDeclaration type) {
+        return type.getDeclarations(ASTMethodDeclaration.class)
+            .filter(TooManyMethodsRule::visible)
+            .count();
+    }
+
+    private static boolean visible(final ASTMethodDeclaration method) {
+        return method.getVisibility()
+            .isAtLeast(ModifierOwner.Visibility.V_PROTECTED);
+    }
+
+    private static boolean tested(final ASTClassDeclaration type) {
+        return type.ancestorsOrSelf()
+            .filterIs(ASTTypeDeclaration.class)
+            .any(TooManyMethodsRule::marked);
+    }
+
+    private static boolean marked(final ASTTypeDeclaration type) {
+        return TooManyMethodsRule.named(type.getSimpleName())
+            || type.descendants(ASTAnnotation.class).any(
+                TooManyMethodsRule::testing
+            );
+    }
+
+    private static boolean named(final String simple) {
+        return TooManyMethodsRule.SUFFIXES.stream().anyMatch(simple::endsWith);
+    }
+
+    private static boolean testing(final ASTAnnotation annotation) {
+        return annotation.getSimpleName().endsWith("Test")
+            || TooManyMethodsRule.ANNOTATIONS.contains(
+                annotation.getSimpleName()
+            );
+    }
+}

--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -167,6 +167,23 @@
     <exclude name="ExcessiveImports"/>
     <exclude name="CyclomaticComplexity"/>
     <exclude name="FinalFieldCouldBeStatic"/>
+    <!--
+    TooManyMethods is excluded because it counts every method in the
+    class body and cannot be told to skip test classes, where one
+    assertion per test method (as required by
+    UnitTestContainsTooManyAsserts) inflates the count past any useful
+    threshold. Disabling it for test classes through a
+    violationSuppressXPath is not an option either: PMD consults the
+    @SuppressWarnings suppressor before the XPath one, so a redundant
+    @SuppressWarnings("PMD.TooManyMethods") in a test class is credited
+    with the suppression and never reported by
+    UnnecessaryWarningSuppression. We use our own TooManyMethodsRule
+    instead, which skips test classes outright and counts only public
+    and protected methods.
+    Downstream: https://github.com/yegor256/qulice/issues/1605
+    Downstream: https://github.com/yegor256/qulice/issues/1647
+    Downstream: https://github.com/yegor256/qulice/issues/1656
+    -->
     <exclude name="TooManyMethods"/>
     <!--
     ExceptionAsFlowControl is excluded because it flags legitimate
@@ -178,45 +195,6 @@
     Downstream: https://github.com/yegor256/qulice/issues/1609
     -->
     <exclude name="ExceptionAsFlowControl"/>
-  </rule>
-  <!--
-  TooManyMethods is excluded from the bulk import above and re-enabled
-  here with a violationSuppressXPath that skips test classes.
-  Splitting asserts into one-assert-per-test methods (as required by
-  UnitTestContainsTooManyAsserts) inflates the method count and would
-  otherwise push test classes past the threshold. A type counts as a
-  test when its simple name ends with 'Test', 'Tests', 'IT',
-  'TestCase' or 'ITCase', or when it carries a test annotation
-  anywhere inside, which covers classes named by other conventions
-  and TestNG classes annotated at class level. The rule fires on the
-  ClassBody node, so the XPath walks ancestor-or-self to reach every
-  enclosing type, which also exempts @Nested inner classes.
-  Downstream: https://github.com/yegor256/qulice/issues/1605
-  Downstream: https://github.com/yegor256/qulice/issues/1647
-  -->
-  <rule ref="category/java/design.xml/TooManyMethods">
-    <properties>
-      <property name="violationSuppressXPath">
-        <value><![CDATA[
-          .[
-            ancestor-or-self::*[
-              ends-with(@SimpleName,'Test')
-              or ends-with(@SimpleName,'Tests')
-              or ends-with(@SimpleName,'IT')
-              or ends-with(@SimpleName,'TestCase')
-              or ends-with(@SimpleName,'ITCase')
-              or .//Annotation[
-                ends-with(@SimpleName,'Test')
-                or @SimpleName='TestFactory'
-                or @SimpleName='TestTemplate'
-                or @SimpleName='Theory'
-                or @SimpleName='Nested'
-              ]
-            ]
-          ]
-        ]]></value>
-      </property>
-    </properties>
   </rule>
   <rule ref="category/java/documentation.xml">
     <exclude name="CommentRequired"/>
@@ -286,6 +264,19 @@
       are also not counted, so a test that wraps
       assertThrows(...).getMessage() inside an assertThat to verify the
       thrown exception's message is not flagged.
+    </description>
+    <priority>3</priority>
+  </rule>
+  <rule name="TooManyMethods" message="This class has too many public and protected methods, consider refactoring it." language="java" class="com.qulice.pmd.rules.TooManyMethodsRule">
+    <description>
+      A class with too many methods is probably a good suspect for
+      refactoring, in order to reduce its complexity and find a way to
+      have more fine grained objects. Unlike PMD's TooManyMethods rule,
+      this variant counts only public and protected methods, since
+      private and package-private ones are implementation detail rather
+      than part of the contract of the class. Test classes are not
+      checked at all, because one assertion per test method inflates
+      their method count beyond any useful threshold.
     </description>
     <priority>3</priority>
   </rule>

--- a/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.params.provider.ValueSource;
  * {@code TooManyMethods} rule, which is disabled for test
  * classes so that splitting asserts into separate {@code @Test}
  * methods (required by {@code UnitTestContainsTooManyAsserts})
- * does not push the class past the threshold.
- * Regression test for https://github.com/yegor256/qulice/issues/1605
- * and https://github.com/yegor256/qulice/issues/1647
+ * does not push the class past the threshold, and which counts
+ * only public and protected methods.
+ * Regression test for https://github.com/yegor256/qulice/issues/1605,
+ * https://github.com/yegor256/qulice/issues/1647
+ * and https://github.com/yegor256/qulice/issues/1656
  * @since 1.0
  */
 final class PmdTooManyMethodsTest {
@@ -27,7 +29,8 @@ final class PmdTooManyMethodsTest {
             "ManyMethodsTest.java",
             "ManyMethodsIT.java",
             "ManyMethodsNestedTest.java",
-            "ManyMethodsChecks.java"
+            "ManyMethodsChecks.java",
+            "ManyPublicMethodsTest.java"
         }
     )
     void allowsManyMethodsInTestClass(final String file) throws Exception {
@@ -46,6 +49,35 @@ final class PmdTooManyMethodsTest {
             "ManyMethods.java",
             Matchers.is(false),
             Matchers.containsString("TooManyMethods")
+        ).assertOk();
+    }
+
+    @Test
+    void reportsTooManyProtectedMethods() throws Exception {
+        new PmdAssert(
+            "ManyProtectedMethods.java",
+            Matchers.is(false),
+            Matchers.containsString("TooManyMethods")
+        ).assertOk();
+    }
+
+    @Test
+    void ignoresPrivateMethods() throws Exception {
+        new PmdAssert(
+            "ManyPrivateMethods.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("TooManyMethods")
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void reportsRedundantSuppressionInTestClass() throws Exception {
+        new PmdAssert(
+            "ManyMethodsSuppressedTest.java",
+            Matchers.is(false),
+            Matchers.containsString("UnnecessaryWarningSuppression")
         ).assertOk();
     }
 }

--- a/src/test/resources/com/qulice/pmd/ManyMethodsSuppressedTest.java
+++ b/src/test/resources/com/qulice/pmd/ManyMethodsSuppressedTest.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.TooManyMethods")
+final class ManyMethodsSuppressedTest {
+
+    @Test
+    void firstCheck() {
+        MatcherAssert.assertThat("a", "a", Matchers.equalTo("a"));
+    }
+
+    @Test
+    void secondCheck() {
+        MatcherAssert.assertThat("b", "b", Matchers.equalTo("b"));
+    }
+
+    @Test
+    void thirdCheck() {
+        MatcherAssert.assertThat("c", "c", Matchers.equalTo("c"));
+    }
+
+    @Test
+    void fourthCheck() {
+        MatcherAssert.assertThat("d", "d", Matchers.equalTo("d"));
+    }
+
+    @Test
+    void fifthCheck() {
+        MatcherAssert.assertThat("e", "e", Matchers.equalTo("e"));
+    }
+
+    @Test
+    void sixthCheck() {
+        MatcherAssert.assertThat("f", "f", Matchers.equalTo("f"));
+    }
+
+    @Test
+    void seventhCheck() {
+        MatcherAssert.assertThat("g", "g", Matchers.equalTo("g"));
+    }
+
+    @Test
+    void eighthCheck() {
+        MatcherAssert.assertThat("h", "h", Matchers.equalTo("h"));
+    }
+
+    @Test
+    void ninthCheck() {
+        MatcherAssert.assertThat("i", "i", Matchers.equalTo("i"));
+    }
+
+    @Test
+    void tenthCheck() {
+        MatcherAssert.assertThat("j", "j", Matchers.equalTo("j"));
+    }
+
+    @Test
+    void eleventhCheck() {
+        MatcherAssert.assertThat("k", "k", Matchers.equalTo("k"));
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ManyPrivateMethods.java
+++ b/src/test/resources/com/qulice/pmd/ManyPrivateMethods.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class ManyPrivateMethods {
+
+    public void everything() {
+        this.first();
+        this.second();
+        this.third();
+        this.fourth();
+        this.fifth();
+        this.sixth();
+        this.seventh();
+        this.eighth();
+        this.ninth();
+        this.tenth();
+        this.eleventh();
+    }
+
+    private void first() {
+        throw new IllegalStateException("never");
+    }
+
+    private void second() {
+        throw new IllegalStateException("never");
+    }
+
+    private void third() {
+        throw new IllegalStateException("never");
+    }
+
+    private void fourth() {
+        throw new IllegalStateException("never");
+    }
+
+    private void fifth() {
+        throw new IllegalStateException("never");
+    }
+
+    private void sixth() {
+        throw new IllegalStateException("never");
+    }
+
+    private void seventh() {
+        throw new IllegalStateException("never");
+    }
+
+    private void eighth() {
+        throw new IllegalStateException("never");
+    }
+
+    private void ninth() {
+        throw new IllegalStateException("never");
+    }
+
+    private void tenth() {
+        throw new IllegalStateException("never");
+    }
+
+    private void eleventh() {
+        throw new IllegalStateException("never");
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ManyProtectedMethods.java
+++ b/src/test/resources/com/qulice/pmd/ManyProtectedMethods.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public class ManyProtectedMethods {
+
+    protected void first() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void second() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void third() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void fourth() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void fifth() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void sixth() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void seventh() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void eighth() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void ninth() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void tenth() {
+        throw new IllegalStateException("never");
+    }
+
+    protected void eleventh() {
+        throw new IllegalStateException("never");
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ManyPublicMethodsTest.java
+++ b/src/test/resources/com/qulice/pmd/ManyPublicMethodsTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public final class ManyPublicMethodsTest {
+
+    @Test
+    public void firstCheck() {
+        MatcherAssert.assertThat("a", "a", Matchers.equalTo("a"));
+    }
+
+    @Test
+    public void secondCheck() {
+        MatcherAssert.assertThat("b", "b", Matchers.equalTo("b"));
+    }
+
+    @Test
+    public void thirdCheck() {
+        MatcherAssert.assertThat("c", "c", Matchers.equalTo("c"));
+    }
+
+    @Test
+    public void fourthCheck() {
+        MatcherAssert.assertThat("d", "d", Matchers.equalTo("d"));
+    }
+
+    @Test
+    public void fifthCheck() {
+        MatcherAssert.assertThat("e", "e", Matchers.equalTo("e"));
+    }
+
+    @Test
+    public void sixthCheck() {
+        MatcherAssert.assertThat("f", "f", Matchers.equalTo("f"));
+    }
+
+    @Test
+    public void seventhCheck() {
+        MatcherAssert.assertThat("g", "g", Matchers.equalTo("g"));
+    }
+
+    @Test
+    public void eighthCheck() {
+        MatcherAssert.assertThat("h", "h", Matchers.equalTo("h"));
+    }
+
+    @Test
+    public void ninthCheck() {
+        MatcherAssert.assertThat("i", "i", Matchers.equalTo("i"));
+    }
+
+    @Test
+    public void tenthCheck() {
+        MatcherAssert.assertThat("j", "j", Matchers.equalTo("j"));
+    }
+
+    @Test
+    public void eleventhCheck() {
+        MatcherAssert.assertThat("k", "k", Matchers.equalTo("k"));
+    }
+}


### PR DESCRIPTION
The test-class exemption for `TooManyMethods` used to live in a `violationSuppressXPath`. This moves it into a custom `com.qulice.pmd.rules.TooManyMethodsRule`, which skips test classes outright, and while at it the rule now counts only public and protected methods — private and package-private ones are implementation detail, not part of the contract of the class.

The XPath approach worked for suppressing the rule, but it hid dead suppressions. PMD hands a violation to the `@SuppressWarnings` suppressor before the XPath one, so a `@SuppressWarnings("PMD.TooManyMethods")` sitting in a test class got credited with a suppression it never needed, and `UnnecessaryWarningSuppression` said nothing about it. With the exemption inside the rule there is no violation to claim, so the dead annotation shows up. `BracketsStructureCheck` had one of those, and it is dropped here.

Worth knowing: the same blind spot still applies to the other rules disabled through `violationSuppressXPath` — `AvoidUsingHardCodedIP`, `UnusedPrivateField`, `TestClassWithoutTestCases`, `UnitTestShouldUseTestAnnotation`. They are left alone for now.

Closes #1656