### PR TITLE
Report @checkstyle suppressions of checks we do not enable

### DIFF
--- a/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -17,7 +17,6 @@ import java.util.List;
 /**
  * Listener of Checkstyle events.
  * @since 0.3
- * @checkstyle ClassDataAbstractionCoupling (260 lines)
  */
 final class CheckstyleListener implements AuditListener {
 

--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -27,7 +27,6 @@ import org.xml.sax.InputSource;
 /**
  * Validator with Checkstyle.
  * @since 0.3
- * @checkstyle ClassDataAbstractionCoupling (260 lines)
  */
 public final class CheckstyleValidator implements ResourceValidator {
 

--- a/src/main/java/com/qulice/checkstyle/ConfiguredChecks.java
+++ b/src/main/java/com/qulice/checkstyle/ConfiguredChecks.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.PropertiesExpander;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Properties;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * Names of the checks that {@code checks.xml} enables.
+ *
+ * <p>Every {@code @checkstyle} suppression comment names its target with
+ * a regular expression that Checkstyle matches against the fully
+ * qualified class name of the check. A name matching none of the enabled
+ * checks suppresses nothing at all, which is what
+ * {@link UnknownSuppressionCheck} reports. Both the short name of a
+ * module and its name with the {@code Check} suffix count as enabled,
+ * since either of them matches the class name of the check.
+ *
+ * @since 1.0
+ */
+final class ConfiguredChecks {
+
+    /**
+     * Names of the enabled checks, read from {@code checks.xml} once.
+     */
+    private final Unchecked<Collection<String>> names = new Unchecked<>(
+        new Sticky<>(ConfiguredChecks::load)
+    );
+
+    /**
+     * Is any of the enabled checks named by this suppression?
+     *
+     * <p>The filters capture the name as {@code \w+}, which holds no
+     * regular expression metacharacter, so their pattern matching comes
+     * down to a search for the name inside the name of a check.
+     *
+     * @param name Name from a {@code @checkstyle} suppression comment
+     * @return True if the name matches at least one enabled check
+     */
+    boolean covers(final String name) {
+        return this.names.value().stream().anyMatch(known -> known.contains(name));
+    }
+
+    /**
+     * Read the names of the enabled checks from {@code checks.xml}.
+     *
+     * <p>The cache file plays no part here, but {@code checks.xml}
+     * demands the property, hence the empty value for it.
+     *
+     * @return Names of the checks, with and without the {@code Check} suffix
+     * @throws Exception If the configuration cannot be read
+     */
+    private static Collection<String> load() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("cache.file", "");
+        return ConfiguredChecks.modules(
+            ConfigurationLoader.loadConfiguration(
+                ConfiguredChecks.class.getResource("checks.xml").toString(),
+                new PropertiesExpander(props),
+                ConfigurationLoader.IgnoredModulesOptions.OMIT
+            )
+        );
+    }
+
+    /**
+     * Names of this module and of all modules nested in it.
+     * @param config Configuration of a module
+     * @return Names of the modules, with and without the suffix
+     */
+    private static Collection<String> modules(final Configuration config) {
+        final Collection<String> found = new HashSet<>(0);
+        final String name = config.getName();
+        final String simple = name.substring(name.lastIndexOf('.') + 1);
+        found.add(simple);
+        if (!simple.endsWith("Check")) {
+            found.add(String.format("%sCheck", simple));
+        }
+        for (final Configuration child : config.getChildren()) {
+            found.addAll(ConfiguredChecks.modules(child));
+        }
+        return found;
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/UnknownSuppressionCheck.java
+++ b/src/main/java/com/qulice/checkstyle/UnknownSuppressionCheck.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Checks that every {@code @checkstyle} suppression names an enabled check.
+ *
+ * <p>A comment like {@code @checkstyle LineLength (2 lines)} tells the
+ * suppression filters to ignore violations of {@code LineLength} nearby.
+ * When the name belongs to no enabled check, because it is misspelled or
+ * because the check has left {@code checks.xml} since, the comment
+ * suppresses nothing and stays in the source as a lie about the code.
+ * PMD reports the same mistake in {@code @SuppressWarnings} annotations.
+ *
+ * @since 1.0
+ * @todo #1658:60min Report the suppressions that name an enabled check
+ *  but cover no violation of it, the way PMD does with
+ *  UnnecessaryWarningSuppression. Checkstyle reports no unused
+ *  suppressions of its own, so CheckstyleValidator has to collect the
+ *  events with the suppression filters removed and match the influence
+ *  ranges itself, leaving alone the files that come from the cache.
+ */
+public final class UnknownSuppressionCheck extends AbstractCheck {
+
+    /**
+     * The forms of suppression that the filters of {@code checks.xml} honor.
+     */
+    private static final Pattern TAG = Pattern.compile(
+        "@checkstyle (\\w+) (?:\\(\\d+ lines?\\)|disable|enable)"
+    );
+
+    /**
+     * Checks that {@code checks.xml} enables.
+     */
+    private final ConfiguredChecks checks = new ConfiguredChecks();
+
+    @Override
+    public boolean isCommentNodesRequired() {
+        return true;
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[]{TokenTypes.COMMENT_CONTENT};
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        final String text = ast.getText();
+        final Matcher matcher = UnknownSuppressionCheck.TAG.matcher(text);
+        while (matcher.find()) {
+            final String name = matcher.group(1);
+            if (!this.checks.covers(name)) {
+                this.log(
+                    ast.getLineNo()
+                        + UnknownSuppressionCheck.breaks(text, matcher.start()),
+                    String.format(
+                        "Check \"%s\" is not enabled, this suppression has no effect",
+                        name
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * How many lines of the comment precede this position?
+     * @param text Text of the comment
+     * @param position Position of the suppression inside the text
+     * @return Number of line breaks before the position
+     */
+    private static int breaks(final String text, final int position) {
+        int count = 0;
+        for (int idx = 0; idx < position; ++idx) {
+            if (text.charAt(idx) == '\n') {
+                ++count;
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -38,7 +38,6 @@ import org.codehaus.plexus.context.Context;
 /**
  * Environment, passed from MOJO to validators.
  * @since 0.3
- * @checkstyle ClassDataAbstractionCouplingCheck (300 lines)
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
 public final class DefaultMavenEnvironment implements MavenEnvironment {

--- a/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
+++ b/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
@@ -18,7 +18,6 @@ import java.util.Set;
 /**
  * Provider of validators.
  * @since 0.3
- * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
 final class DefaultValidatorsProvider implements ValidatorsProvider {
 

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -404,6 +404,13 @@
     <module name="com.qulice.checkstyle.QualifyInnerClassCheck"/>
     <module name="com.qulice.checkstyle.FinalSemicolonInTryWithResourcesCheck"/>
     <module name="com.qulice.checkstyle.ExtraSemicolonCheck"/>
+    <!--
+    Every `@checkstyle Name (N lines)` comment consumed by the suppression
+    filters above must name a check that this file enables, the way PMD
+    demands of every @SuppressWarnings("PMD.Foo") annotation.
+    See https://github.com/yegor256/qulice/issues/1658
+    -->
+    <module name="com.qulice.checkstyle.UnknownSuppressionCheck"/>
     <module name="com.qulice.checkstyle.JavadocEmptyLineCheck"/>
     <module name="com.qulice.checkstyle.JavadocEmptyLineBeforeTagCheck"/>
     <module name="com.qulice.checkstyle.JavadocFirstLineCheck"/>

--- a/src/test/java/com/qulice/checkstyle/UnknownSuppressionCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/UnknownSuppressionCheckTest.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.IoCheckedText;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CheckstyleValidator}'s handling of
+ * {@link UnknownSuppressionCheck}.
+ * @since 1.0
+ */
+final class UnknownSuppressionCheckTest {
+
+    @Test
+    void rejectsSuppressionOfCheckThatIsNotConfigured() throws Exception {
+        final String file = "UnknownSuppression.java";
+        final String name = "UnknownSuppressionCheck";
+        MatcherAssert.assertThat(
+            "Misspelled and absent check names must be reported",
+            this.runValidation(file, false),
+            Matchers.hasItems(
+                new ViolationMatcher("LineLenght", file, "4", name),
+                new ViolationMatcher(
+                    "ClassDataAbstractionCoupling", file, "11", name
+                )
+            )
+        );
+    }
+
+    @Test
+    void rejectsPlainTextSuppressionOfUnknownCheck() throws Exception {
+        final String file = "DisabledUnknownSuppression.java";
+        MatcherAssert.assertThat(
+            "Disabling a check that does not exist must be reported",
+            this.runValidation(file, false),
+            Matchers.hasItem(
+                new ViolationMatcher(
+                    "Bogus", file, "4", "UnknownSuppressionCheck"
+                )
+            )
+        );
+    }
+
+    @Test
+    void acceptsSuppressionOfConfiguredCheck() throws Exception {
+        Assertions.assertDoesNotThrow(
+            () -> this.runValidation("KnownSuppression.java", true)
+        );
+    }
+
+    private Collection<Violation> runValidation(final String file,
+        final boolean passes) throws IOException {
+        final Environment.Mock mock = new Environment.Mock();
+        final Environment env = mock.withParam(
+            "license",
+            String.format(
+                "file:%s",
+                new License().savePackageInfo(
+                    new File(mock.basedir(), "src/main/java/foo")
+                ).withLines("Hello.")
+                    .withEol(String.valueOf('\n')).file()
+            )
+        ).withFile(
+            String.format("src/main/java/foo/%s", file),
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf(
+                        new FormattedText("com/qulice/checkstyle/%s", file)
+                    )
+                )
+            ).asString()
+        );
+        final Collection<Violation> results =
+            new CheckstyleValidator(env).validate(env.files(file));
+        MatcherAssert.assertThat(
+            "validation result should match expected state",
+            results.isEmpty(),
+            Matchers.is(passes)
+        );
+        return results;
+    }
+}

--- a/src/test/java/com/qulice/checkstyle/UnknownSuppressionCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/UnknownSuppressionCheckTest.java
@@ -30,10 +30,10 @@ final class UnknownSuppressionCheckTest {
         final String file = "UnknownSuppression.java";
         final String name = "UnknownSuppressionCheck";
         MatcherAssert.assertThat(
-            "Misspelled and absent check names must be reported",
+            "Invented and absent check names must be reported",
             this.runValidation(file, false),
             Matchers.hasItems(
-                new ViolationMatcher("LineLenght", file, "4", name),
+                new ViolationMatcher("FooBar", file, "4", name),
                 new ViolationMatcher(
                     "ClassDataAbstractionCoupling", file, "11", name
                 )

--- a/src/test/resources/com/qulice/checkstyle/DisabledUnknownSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/DisabledUnknownSuppression.java
@@ -1,0 +1,13 @@
+/*
+ * Hello.
+ */
+// @checkstyle Bogus disable
+// @checkstyle Bogus enable
+package foo;
+
+/**
+ * Sample class disabling a check that does not exist at all.
+ * @since 1.0
+ */
+public interface DisabledUnknownSuppression {
+}

--- a/src/test/resources/com/qulice/checkstyle/KnownSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/KnownSuppression.java
@@ -1,0 +1,15 @@
+/*
+ * Hello.
+ */
+// @checkstyle LineLengthCheck (2 lines)
+// This comment suppresses a check that checks.xml configures.
+package foo;
+
+/**
+ * Sample class mentioning @checkstyle in prose and suppressing
+ * a configured check by its short name.
+ * @since 1.0
+ * @checkstyle ParameterNumber (2 lines)
+ */
+public interface KnownSuppression {
+}

--- a/src/test/resources/com/qulice/checkstyle/UnknownSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/UnknownSuppression.java
@@ -1,0 +1,14 @@
+/*
+ * Hello.
+ */
+// @checkstyle LineLenght (2 lines)
+// This comment suppresses a check whose name is misspelled.
+package foo;
+
+/**
+ * Sample class suppressing a check that is absent from checks.xml.
+ * @since 1.0
+ * @checkstyle ClassDataAbstractionCoupling (2 lines)
+ */
+public interface UnknownSuppression {
+}

--- a/src/test/resources/com/qulice/checkstyle/UnknownSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/UnknownSuppression.java
@@ -1,8 +1,8 @@
 /*
  * Hello.
  */
-// @checkstyle LineLenght (2 lines)
-// This comment suppresses a check whose name is misspelled.
+// @checkstyle FooBar (2 lines)
+// This comment suppresses a check that never existed.
 package foo;
 
 /**


### PR DESCRIPTION
This adds `UnknownSuppressionCheck`. It reads the comments for the two suppression forms our filters honor, `@checkstyle Name (N lines)` and `@checkstyle Name disable|enable`, and complains when the name belongs to no check that `checks.xml` enables. `ConfiguredChecks` collects those names from `checks.xml` once, counting the short name and the name with the `Check` suffix, because either of them matches the class name of a check.

Until now such a comment was free to name anything. The filters match the name against the class name of a check, so a typo, or a check that has left `checks.xml` since, leaves behind a comment that suppresses nothing and lies about the code. PMD has been catching the same mistake in `@SuppressWarnings` for a while. Four of these leftovers were sitting in our own source naming `ClassDataAbstractionCoupling`, which we have never enabled, and they are gone in this branch.

Downstream projects will likely see a few new violations the first time they run with this, which is the whole point of the check. The second half of the issue, suppressions that name an enabled check but cover no violation of it, needs unfiltered events out of `CheckstyleValidator` and is left as a `@todo` puzzle.

Closes #1658
