### PR TITLE
fix(pmd): #1660 skip try-with-resources in UnnecessaryLocalRule

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -8,6 +8,7 @@ import java.util.List;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTLoopStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTResource;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
@@ -28,7 +29,8 @@ public final class UnnecessaryLocalRule extends AbstractJavaRulechainRule {
         final ASTVariableDeclarator variable,
         final Object data
     ) {
-        if (variable.getInitializer() != null) {
+        if (variable.getInitializer() != null
+            && variable.ancestors(ASTResource.class).first() == null) {
             final String name = UnnecessaryLocalRule.variableName(variable);
             if (!name.isEmpty()) {
                 this.asCtx(data).addViolation(variable, name);

--- a/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
@@ -85,6 +85,15 @@ final class UnnecessaryLocalRuleTest {
         );
     }
 
+    @Test
+    void doesNotFireOnTryWithResourcesResource() throws Exception {
+        MatcherAssert.assertThat(
+            "UnnecessaryLocalRule should not fire on a try-with-resources resource variable",
+            this.violations("UnnecessaryLocalTryWithResources.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
+        );
+    }
+
     private List<String> violations(final String file) throws Exception {
         final String name = String.format(UnnecessaryLocalRuleTest.PATH, file);
         final Environment env = new Environment.Mock().withFile(

--- a/src/test/resources/com/qulice/pmd/UnnecessaryLocalTryWithResources.java
+++ b/src/test/resources/com/qulice/pmd/UnnecessaryLocalTryWithResources.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public final class UnnecessaryLocalTryWithResources {
+
+    public int free() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (final IOException exception) {
+            throw new IllegalStateException(
+                "Could not find a free port", exception
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #1660.

## Problem

`UnnecessaryLocalRule` reported the resource variable of a try-with-resources statement:

```java
private static int free() {
    try (ServerSocket socket = new ServerSocket(0)) {
        return socket.getLocalPort();
    } catch (final IOException exception) {
        throw new IllegalStateException("Could not find a free port", exception);
    }
}
```

The message was `Avoid creating unnecessary local variables like 'socket'`. The rule visits every `ASTVariableDeclarator` that has an initializer and reports it when its only use sits inside a `return`, without asking whether the declarator belongs to a `try` resource list.

This is a false positive that cannot be fixed in the analysed code: JLS 14.20.3 requires a resource to be either a variable declaration or a reference to a final variable, so `try (new ServerSocket(0))` does not compile. The only workaround was `@SuppressWarnings("PMD.UnnecessaryLocalRule")`.

## Fix

In `UnnecessaryLocalRule.visit`, skip the declarator when it sits inside a resource list, i.e. bail out when `variable.ancestors(ASTResource.class).first() != null`.

## Tests

Added `UnnecessaryLocalTryWithResources.java` fixture (reproducing the issue snippet) and a `doesNotFireOnTryWithResourcesResource` test asserting the rule no longer fires. All 7 tests in `UnnecessaryLocalRuleTest` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_017HduJR3XBsTV3oYsdp3cVF)_