### PR TITLE
fix(pmd): #1663 pair operator with literal in UseStringIsEmptyRule

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
@@ -107,11 +107,13 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
      * @return True if it is a {@code String.length()} call
      */
     private static boolean isStringLength(final ASTExpression expr) {
-        return expr instanceof ASTMethodCall call
-            && "length".equals(call.getMethodName())
-            && call.getArguments().isEmpty()
-            && call.getQualifier() != null
-            && isStringExpression(call.getQualifier());
+        boolean result = false;
+        if (expr instanceof ASTMethodCall call && call.getQualifier() != null) {
+            result = "length".equals(call.getMethodName())
+                && call.getArguments().isEmpty()
+                && isStringExpression(call.getQualifier());
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
@@ -8,12 +8,22 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTNumericLiteral;
+import net.sourceforge.pmd.lang.java.ast.BinaryOp;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 
 /**
  * Rule to prohibit use of String.length() when checking for empty string.
  * String.isEmpty() should be used instead.
+ *
+ * <p>Only comparisons that have an exact {@code isEmpty()} equivalent are
+ * flagged. With {@code length()} on the left, those are {@code == 0},
+ * {@code != 0}, {@code > 0}, {@code <= 0}, {@code < 1} and {@code >= 1};
+ * the same six are recognised when the operands are swapped. Comparisons
+ * against {@code 1} such as {@code length() == 1} or {@code length() > 1}
+ * describe single-character strings and have no {@code isEmpty()}
+ * counterpart, so they are left alone.
+ *
  * @since 0.18
  */
 public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
@@ -24,51 +34,84 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(final ASTInfixExpression expr, final Object data) {
-        if (isComparison(expr)
-            && (matchesLengthCheck(expr.getLeftOperand(), expr.getRightOperand())
-                || matchesLengthCheck(expr.getRightOperand(), expr.getLeftOperand()))
+        final ASTExpression left = expr.getLeftOperand();
+        final ASTExpression right = expr.getRightOperand();
+        if (isEmptyEquivalent(expr.getOperator(), left, right)
+            || isEmptyEquivalent(mirror(expr.getOperator()), right, left)
         ) {
             asCtx(data).addViolation(expr);
         }
         return data;
     }
 
-    private static boolean isComparison(final ASTInfixExpression expr) {
-        return switch (expr.getOperator()) {
-            case EQ, NE, GT, LT, GE, LE -> true;
-            default -> false;
-        };
-    }
-
     /**
-     * Checks if length is length() or literal is 0 or 1.
-     * @param length The method
-     * @param literal The number
-     * @return True if matches, false otherwise
-     * @checkstyle BooleanExpressionComplexityCheck (20 lines)
+     * Is this an {@code isEmpty()}-equivalent comparison, assuming the
+     * {@code length()} call is the left operand and the literal is the right?
+     * @param operator The comparison operator
+     * @param length The candidate {@code String.length()} call
+     * @param literal The candidate numeric literal
+     * @return True if the comparison can be rewritten with {@code isEmpty()}
      */
-    private static boolean matchesLengthCheck(
+    private static boolean isEmptyEquivalent(
+        final BinaryOp operator,
         final ASTExpression length,
         final ASTExpression literal
     ) {
+        return isStringLength(length) && isWhitelisted(operator, literal);
+    }
+
+    /**
+     * Is the pair of operator and literal one of the six allowed
+     * {@code isEmpty()} equivalents ({@code == 0}, {@code != 0}, {@code > 0},
+     * {@code <= 0}, {@code < 1}, {@code >= 1})?
+     * @param operator The comparison operator
+     * @param literal The candidate numeric literal
+     * @return True if the pairing matches the whitelist
+     */
+    private static boolean isWhitelisted(
+        final BinaryOp operator,
+        final ASTExpression literal
+    ) {
         boolean result = false;
-        if (length != null && literal != null && isZeroOrOneLiteral(literal)
-            && length instanceof ASTMethodCall call) {
-            result = "length".equals(call.getMethodName())
-                && call.getArguments().isEmpty()
-                && call.getQualifier() != null
-                && isStringExpression(call.getQualifier());
+        if (literal instanceof ASTNumericLiteral lit) {
+            final String image = lit.getImage();
+            result = switch (operator) {
+                case EQ, NE, GT, LE -> "0".equals(image);
+                case LT, GE -> "1".equals(image);
+                default -> false;
+            };
         }
         return result;
     }
 
-    private static boolean isZeroOrOneLiteral(final ASTExpression expr) {
-        boolean matches = false;
-        if (expr instanceof ASTNumericLiteral lit) {
-            final String image = lit.getImage();
-            matches = "0".equals(image) || "1".equals(image);
-        }
-        return matches;
+    /**
+     * Mirror an operator so a {@code literal OP length()} comparison can be
+     * evaluated as if {@code length()} were on the left.
+     * @param operator The operator as written
+     * @return The operator with its operands swapped
+     */
+    private static BinaryOp mirror(final BinaryOp operator) {
+        return switch (operator) {
+            case GT -> BinaryOp.LT;
+            case LT -> BinaryOp.GT;
+            case GE -> BinaryOp.LE;
+            case LE -> BinaryOp.GE;
+            default -> operator;
+        };
+    }
+
+    /**
+     * Is the expression a no-argument {@code length()} call on a
+     * {@link String}?
+     * @param expr The expression to check
+     * @return True if it is a {@code String.length()} call
+     */
+    private static boolean isStringLength(final ASTExpression expr) {
+        return expr instanceof ASTMethodCall call
+            && "length".equals(call.getMethodName())
+            && call.getArguments().isEmpty()
+            && call.getQualifier() != null
+            && isStringExpression(call.getQualifier());
     }
 
     /**

--- a/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
@@ -29,7 +29,6 @@ final class UseStringIsEmptyRuleTest {
     @ValueSource(
         strings = {
             "StringLengthGreaterThanZero.java",
-            "StringLengthGreaterOrEqualZero.java",
             "StringLengthGreaterOrEqualOne.java",
             "StringLengthLessThanOne.java",
             "StringLengthLessOrEqualZero.java",
@@ -45,6 +44,31 @@ final class UseStringIsEmptyRuleTest {
                 .and(containsMatcher(file, 28))
                 .and(containsMatcher(file, 32))
                 .and(containsMatcher(file, 36))
+        ).assertOk();
+    }
+
+    /**
+     * UseStringIsEmpty does not flag comparisons that have no
+     * {@code isEmpty()} equivalent, such as {@code length()} checks against
+     * {@code 1} (single-character strings) or the always-true
+     * {@code length() >= 0}.
+     * @param file File name
+     * @throws Exception If something goes wrong.
+     */
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "StringLengthEqualsOne.java",
+            "StringLengthNotEqualsOne.java",
+            "StringLengthGreaterThanOne.java",
+            "StringLengthLessOrEqualOne.java",
+            "StringLengthGreaterOrEqualZero.java"
+        }
+    )
+    void ignoresNonEmptyChecks(final String file) throws Exception {
+        new PmdAssert(
+            file, new IsEqual<>(true),
+            IsEmptyString.emptyString()
         ).assertOk();
     }
 

--- a/src/test/resources/com/qulice/pmd/StringLengthEqualsOne.java
+++ b/src/test/resources/com/qulice/pmd/StringLengthEqualsOne.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class StringLengthEqualsOne {
+
+    private final String somestring;
+
+    public StringLengthEqualsOne(final String str) {
+        this.somestring = str;
+    }
+
+    public String someMethod() {
+        return this.somestring;
+    }
+
+    public boolean lengthOnMethodWithThis() {
+        return this.someMethod().length() == 1;
+    }
+
+    public boolean lengthOnMethodWithThisInversed() {
+        return 1 == this.someMethod().length();
+    }
+
+    public boolean lengthOnFieldWithThis() {
+        return this.somestring.length() == 1;
+    }
+
+    public boolean lengthOnFieldWithThisInversed() {
+        return 1 == this.somestring.length();
+    }
+
+    public boolean lengthOnVariable(final String somestring) {
+        return somestring.length() == 1;
+    }
+
+}

--- a/src/test/resources/com/qulice/pmd/StringLengthGreaterThanOne.java
+++ b/src/test/resources/com/qulice/pmd/StringLengthGreaterThanOne.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class StringLengthGreaterThanOne {
+
+    private final String somestring;
+
+    public StringLengthGreaterThanOne(final String str) {
+        this.somestring = str;
+    }
+
+    public String someMethod() {
+        return this.somestring;
+    }
+
+    public boolean lengthOnMethodWithThis() {
+        return this.someMethod().length() > 1;
+    }
+
+    public boolean lengthOnMethodWithThisInversed() {
+        return 1 < this.someMethod().length();
+    }
+
+    public boolean lengthOnFieldWithThis() {
+        return this.somestring.length() > 1;
+    }
+
+    public boolean lengthOnFieldWithThisInversed() {
+        return 1 < this.somestring.length();
+    }
+
+    public boolean lengthOnVariable(final String somestring) {
+        return somestring.length() > 1;
+    }
+
+}

--- a/src/test/resources/com/qulice/pmd/StringLengthLessOrEqualOne.java
+++ b/src/test/resources/com/qulice/pmd/StringLengthLessOrEqualOne.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class StringLengthLessOrEqualOne {
+
+    private final String somestring;
+
+    public StringLengthLessOrEqualOne(final String str) {
+        this.somestring = str;
+    }
+
+    public String someMethod() {
+        return this.somestring;
+    }
+
+    public boolean lengthOnMethodWithThis() {
+        return this.someMethod().length() <= 1;
+    }
+
+    public boolean lengthOnMethodWithThisInversed() {
+        return 1 >= this.someMethod().length();
+    }
+
+    public boolean lengthOnFieldWithThis() {
+        return this.somestring.length() <= 1;
+    }
+
+    public boolean lengthOnFieldWithThisInversed() {
+        return 1 >= this.somestring.length();
+    }
+
+    public boolean lengthOnVariable(final String somestring) {
+        return somestring.length() <= 1;
+    }
+
+}

--- a/src/test/resources/com/qulice/pmd/StringLengthNotEqualsOne.java
+++ b/src/test/resources/com/qulice/pmd/StringLengthNotEqualsOne.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class StringLengthNotEqualsOne {
+
+    private final String somestring;
+
+    public StringLengthNotEqualsOne(final String str) {
+        this.somestring = str;
+    }
+
+    public String someMethod() {
+        return this.somestring;
+    }
+
+    public boolean lengthOnMethodWithThis() {
+        return this.someMethod().length() != 1;
+    }
+
+    public boolean lengthOnMethodWithThisInversed() {
+        return 1 != this.someMethod().length();
+    }
+
+    public boolean lengthOnFieldWithThis() {
+        return this.somestring.length() != 1;
+    }
+
+    public boolean lengthOnFieldWithThisInversed() {
+        return 1 != this.somestring.length();
+    }
+
+    public boolean lengthOnVariable(final String somestring) {
+        return somestring.length() != 1;
+    }
+
+}


### PR DESCRIPTION
Fixes #1663.

## Problem

`UseStringIsEmptyRule` split its check into two independent halves: `isComparison` accepted any of `EQ NE GT LT GE LE`, and `isZeroOrOneLiteral` accepted `0` or `1`. Because the operator was never paired with the literal (or with the side the literal sat on), **every** combination fired. Comparisons with no `isEmpty()` equivalent — `length() == 1`, `!= 1`, `> 1`, `<= 1` (single-character-string checks) — were reported as false positives. This is what forced the `@SuppressWarnings("PMD.UseStringIsEmptyRule")` on `ChSource.hash()` in objectionary/eo. Issue #1510 reported the `> 1` variant; the PR that closed it (#1513) only aligned PMD versions and left the rule untouched.

## Fix

Replace the two independent checks with a single whitelist of the six `isEmpty()`-equivalent `(operator, literal)` pairs, mirrored when the literal is the left operand:

| length on left | equivalent |
|---|---|
| `== 0` | `isEmpty()` |
| `!= 0` | `!isEmpty()` |
| `> 0`  | `!isEmpty()` |
| `<= 0` | `isEmpty()` |
| `< 1`  | `isEmpty()` |
| `>= 1` | `!isEmpty()` |

The mirrored form (`0 == length()`, `0 < length()`, `1 > length()`, …) is handled by swapping the operator via `mirror(...)` and applying the same whitelist.

### Verdict on the `>= 0` fixture

As the issue flagged, `StringLengthGreaterOrEqualZero.java` expected `length() >= 0` to be flagged, but that comparison is always true and has no `isEmpty()` replacement. It is now **not** flagged; the fixture moves to a new negative test.

## Tests

- Positive detection test keeps `> 0`, `>= 1`, `< 1`, `<= 0`, `== 0`, `!= 0` (both operand orders).
- New `ignoresNonEmptyChecks` parameterized test asserts zero violations for `== 1`, `!= 1`, `> 1`, `<= 1`, and `>= 0` (new fixtures + the repurposed `>= 0` fixture).

All `UseStringIsEmptyRuleTest` (12) and `PmdUseStringIsEmptyNpeTest` (1) cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV73VdKkTHF2bEWR1ZzbzP)_