### PR TITLE
fix(pmd): #1664 keep a local captured before an unrelated side-effecting call

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
@@ -89,29 +89,24 @@ final class UnnecessaryLocalSkips {
     }
 
     /**
-     * The initialiser is a method call on some target, and a later statement
-     * (before the local is read) calls a method on that same target. Inlining
-     * would read the post-mutation value.
+     * The initialiser is a method call and at least one statement sits between
+     * the declaration and its single use in the same block. A call whose result
+     * is read only after other statements cannot be inlined without reordering
+     * side effects, so the local is pinning evaluation order and must stay.
      * @param variable The variable declarator
      * @param use The single use of the variable
-     * @return True if an intervening statement calls the initialiser's target
+     * @return True if a statement intervenes between the call and its use
      */
     static boolean interveningCall(
         final ASTVariableDeclarator variable,
         final ASTVariableAccess use
     ) {
         boolean found = false;
-        final ASTExpression init = variable.getInitializer();
-        if (init instanceof ASTMethodCall call) {
-            final String target = UnnecessaryLocalSkips.qualifierImage(
-                call.getQualifier()
-            );
-            if (target != null && !target.isEmpty()) {
-                final Node decl = UnnecessaryLocalSkips.blockLevel(variable);
-                final Node consumer = UnnecessaryLocalSkips.blockLevel(use);
-                found = UnnecessaryLocalSkips.sameBlock(decl, consumer)
-                    && UnnecessaryLocalSkips.scanBetween(decl, consumer, target);
-            }
+        if (variable.getInitializer() instanceof ASTMethodCall) {
+            final Node decl = UnnecessaryLocalSkips.blockLevel(variable);
+            final Node consumer = UnnecessaryLocalSkips.blockLevel(use);
+            found = UnnecessaryLocalSkips.sameBlock(decl, consumer)
+                && consumer.getIndexInParent() > decl.getIndexInParent() + 1;
         }
         return found;
     }
@@ -136,33 +131,6 @@ final class UnnecessaryLocalSkips {
             fresh = known || clock;
         }
         return fresh;
-    }
-
-    private static boolean scanBetween(
-        final Node decl,
-        final Node consumer,
-        final String target
-    ) {
-        final Node block = decl.getParent();
-        final int last = consumer.getIndexInParent();
-        boolean found = false;
-        for (int idx = decl.getIndexInParent() + 1; idx < last && !found;
-            idx += 1) {
-            found = block.getChild(idx).descendants(ASTMethodCall.class)
-                .crossFindBoundaries()
-                .toStream()
-                .anyMatch(call -> UnnecessaryLocalSkips.callsTarget(call, target));
-        }
-        return found;
-    }
-
-    private static boolean callsTarget(
-        final ASTMethodCall call,
-        final String target
-    ) {
-        return target.equals(
-            UnnecessaryLocalSkips.qualifierImage(call.getQualifier())
-        );
     }
 
     private static Node blockLevel(final Node node) {

--- a/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
@@ -86,6 +86,15 @@ final class UnnecessaryLocalRuleTest {
     }
 
     @Test
+    void doesNotFireWhenLocalCapturedBeforeUnrelatedCall() throws Exception {
+        MatcherAssert.assertThat(
+            "UnnecessaryLocalRule should not fire when the local pins evaluation order before an unrelated side-effecting call",
+            this.violations("UnnecessaryLocalCapturedBeforeCall.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
+        );
+    }
+
+    @Test
     void doesNotFireOnTryWithResourcesResource() throws Exception {
         MatcherAssert.assertThat(
             "UnnecessaryLocalRule should not fire on a try-with-resources resource variable",

--- a/src/test/resources/com/qulice/pmd/UnnecessaryLocalCapturedBeforeCall.java
+++ b/src/test/resources/com/qulice/pmd/UnnecessaryLocalCapturedBeforeCall.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public final class UnnecessaryLocalCapturedBeforeCall {
+
+    private final Path path;
+
+    private final Origin origin;
+
+    public UnnecessaryLocalCapturedBeforeCall(final Path dst, final Origin org) {
+        this.path = dst;
+        this.origin = org;
+    }
+
+    public String apply(final int position) {
+        final long start = System.currentTimeMillis();
+        final String out = this.origin.apply(position);
+        try {
+            Files.write(
+                this.path,
+                String.format(
+                    "%s,%d%n", out, System.currentTimeMillis() - start
+                ).getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.APPEND, StandardOpenOption.CREATE
+            );
+        } catch (final IOException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+        return out;
+    }
+
+    public interface Origin {
+        String apply(int position);
+    }
+}


### PR DESCRIPTION
Closes #1664.

## Problem

`UnnecessaryLocalRule` fired on a local that captures a method-call result which is read only *after* an unrelated side-effecting call, e.g. `StMeasured.apply` in `objectionary/eo`:

```java
final long start = System.currentTimeMillis();
final XML out = this.origin.apply(position, xml);
try {
    Files.write(this.path, ...);   // measures elapsed time
} catch (final IOException ex) { ... }
return out;
```

Inlining `out` into the `return` would move `this.origin.apply()` after `Files.write()`, corrupting the measured duration. The local exists to pin evaluation order.

`UnnecessaryLocalSkips.interveningCall` was meant to cover this family (case 3 of #1607), but it only vetoed a report when a later statement called a method on the **same qualifier** as the initialiser. When the initialiser's qualifier is a field access (`this.origin`), `qualifierImage` did not resolve it, so `target` was null and the guard bailed out before scanning.

## Fix

In `interveningCall`, drop the qualifier comparison entirely. Veto the report whenever the initialiser is a method call **and** at least one statement sits between the declaration and its single use in the same block — a call whose result is read only after other statements cannot be inlined without reordering side effects. The rule's real target, `final X y = foo(); return y;`, stays flagged because nothing intervenes there. The now-unused `scanBetween`/`callsTarget` helpers were removed.

## Tests

Added `UnnecessaryLocalCapturedBeforeCall.java` fixture (mirrors the `StMeasured` scenario, with the intervening call on a *different* qualifier) and a test asserting the rule does not fire. All 8 `UnnecessaryLocalRuleTest` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01887HERo6F2tY8vZ3w7ayWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01887HERo6F2tY8vZ3w7ayWX)_