### PR TITLE
Ignore @Override methods in TooManyMethods

### DIFF
--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -39,7 +39,7 @@ import org.codehaus.plexus.context.Context;
  * Environment, passed from MOJO to validators.
  * @since 0.3
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
+@SuppressWarnings("PMD.GodClass")
 public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     /**

--- a/src/main/java/com/qulice/maven/MavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/MavenEnvironment.java
@@ -16,7 +16,6 @@ import org.codehaus.plexus.context.Context;
  * Environment, passed from MOJO to validators.
  * @since 0.3
  */
-@SuppressWarnings("PMD.TooManyMethods")
 interface MavenEnvironment extends Environment {
 
     /**

--- a/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
@@ -17,7 +17,9 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * PMD built-in {@code TooManyMethods} rule, this implementation counts
  * only public and protected methods, because private and package-private
  * ones are implementation detail and say nothing about how large the
- * contract of the class is. Test classes are skipped altogether, since
+ * contract of the class is. Methods annotated with {@code @Override} are
+ * skipped too, since a supertype dictates them and the class has no say
+ * in how many of them there are. Test classes are skipped altogether, since
  * one assertion per test method inflates their method count beyond any
  * useful threshold. Skipping them here instead of through a
  * {@code violationSuppressXPath} keeps a redundant
@@ -78,7 +80,8 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
 
     private static boolean visible(final ASTMethodDeclaration method) {
         return method.getVisibility()
-            .isAtLeast(ModifierOwner.Visibility.V_PROTECTED);
+            .isAtLeast(ModifierOwner.Visibility.V_PROTECTED)
+            && !method.isAnnotationPresent(Override.class);
     }
 
     private static boolean tested(final ASTClassDeclaration type) {

--- a/src/main/java/com/qulice/spi/Environment.java
+++ b/src/main/java/com/qulice/spi/Environment.java
@@ -26,7 +26,6 @@ import org.apache.commons.io.filefilter.WildcardFileFilter;
  * Environment.
  * @since 0.3
  */
-@SuppressWarnings("PMD.TooManyMethods")
 public interface Environment {
 
     /**

--- a/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
+++ b/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
@@ -28,7 +28,6 @@ import org.slf4j.impl.StaticLoggerBinder;
  * Mocker of {@link MavenProject}.
  * @since 0.4
  */
-@SuppressWarnings("PMD.TooManyMethods")
 public final class MavenEnvironmentMocker {
 
     /**

--- a/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
@@ -15,10 +15,12 @@ import org.junit.jupiter.params.provider.ValueSource;
  * classes so that splitting asserts into separate {@code @Test}
  * methods (required by {@code UnitTestContainsTooManyAsserts})
  * does not push the class past the threshold, and which counts
- * only public and protected methods.
+ * only public and protected methods that the class itself
+ * introduces.
  * Regression test for https://github.com/yegor256/qulice/issues/1605,
- * https://github.com/yegor256/qulice/issues/1647
- * and https://github.com/yegor256/qulice/issues/1656
+ * https://github.com/yegor256/qulice/issues/1647,
+ * https://github.com/yegor256/qulice/issues/1656
+ * and https://github.com/yegor256/qulice/issues/1667
  * @since 1.0
  */
 final class PmdTooManyMethodsTest {
@@ -65,6 +67,17 @@ final class PmdTooManyMethodsTest {
     void ignoresPrivateMethods() throws Exception {
         new PmdAssert(
             "ManyPrivateMethods.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("TooManyMethods")
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void ignoresOverriddenMethods() throws Exception {
+        new PmdAssert(
+            "ManyOverriddenMethods.java",
             Matchers.any(Boolean.class),
             Matchers.not(
                 Matchers.containsString("TooManyMethods")

--- a/src/test/resources/com/qulice/pmd/ManyOverriddenMethods.java
+++ b/src/test/resources/com/qulice/pmd/ManyOverriddenMethods.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public class ManyOverriddenMethods implements Wide {
+
+    @Override
+    public void first() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void second() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void third() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void fourth() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void fifth() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void sixth() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void seventh() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void eighth() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void ninth() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void tenth() {
+        throw new IllegalStateException("never");
+    }
+
+    @Override
+    public void eleventh() {
+        throw new IllegalStateException("never");
+    }
+}


### PR DESCRIPTION
The custom `TooManyMethodsRule` no longer counts a method that carries `@Override`. The check for that sits next to the visibility test in `visible()`, and there is a new fixture with eleven overridden public methods to hold the behaviour down.

A supertype decides that an overridden method exists, not the class. Counting it means a class that implements a wide interface gets flagged for something its author cannot shrink, while the rule is meant to measure the contract the class itself introduces.

Four `@SuppressWarnings("PMD.TooManyMethods")` annotations in this repo turned redundant once the rule stopped counting overrides, so they are gone too; `UnnecessaryWarningSuppression` was flagging all four.

Closes #1667