### PR TITLE
Suppress TypeName for test classes

### DIFF
--- a/src/main/resources/com/qulice/checkstyle/suppressions.xml
+++ b/src/main/resources/com/qulice/checkstyle/suppressions.xml
@@ -6,4 +6,5 @@
 <!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN" "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
   <suppress checks="JavadocMethod" files=".+(Test|ITCase|IT).java"/>
+  <suppress checks="TypeName" files=".+(Test|ITCase|IT).java"/>
 </suppressions>

--- a/src/test/java/com/qulice/checkstyle/CheckstyleTypeNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleTypeNameTest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.IoCheckedText;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CheckstyleValidator}'s handling of the
+ * stock {@code TypeName} check.
+ * @since 0.73.2
+ */
+final class CheckstyleTypeNameTest {
+
+    @Test
+    void rejectsUnderscoredNameInProductionClass() throws Exception {
+        final String file = "Underscored_Name.java";
+        MatcherAssert.assertThat(
+            "Underscored production type name cannot pass",
+            this.runValidation(file, false),
+            Matchers.hasItem(
+                new ViolationMatcher(
+                    "must match pattern",
+                    file,
+                    "10",
+                    "TypeNameCheck"
+                )
+            )
+        );
+    }
+
+    @Test
+    void acceptsUnderscoredNameInUnitTestClass() throws Exception {
+        MatcherAssert.assertThat(
+            "Underscored unit test type name cannot fail",
+            this.runValidation("Underscored_NameTest.java", true),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void acceptsUnderscoredNameInIntegrationTestClass() throws Exception {
+        MatcherAssert.assertThat(
+            "Underscored integration test type name cannot fail",
+            this.runValidation("Underscored_NameIT.java", true),
+            Matchers.empty()
+        );
+    }
+
+    private Collection<Violation> runValidation(final String file,
+        final boolean passes) throws IOException {
+        final Environment.Mock mock = new Environment.Mock();
+        final Environment env = mock.withParam(
+            "license",
+            String.format(
+                "file:%s",
+                new License().savePackageInfo(
+                    new File(mock.basedir(), "src/main/java/foo")
+                ).withLines("Hello.")
+                    .withEol(String.valueOf('\n')).file()
+            )
+        ).withFile(
+            String.format("src/main/java/foo/%s", file),
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf(
+                        new FormattedText("com/qulice/checkstyle/%s", file)
+                    )
+                )
+            ).asString()
+        );
+        final Collection<Violation> results =
+            new CheckstyleValidator(env).validate(env.files(file));
+        MatcherAssert.assertThat(
+            "validation result should match expected state",
+            results.isEmpty(),
+            Matchers.is(passes)
+        );
+        return results;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/Underscored_Name.java
+++ b/src/test/resources/com/qulice/checkstyle/Underscored_Name.java
@@ -1,0 +1,19 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Production class with an underscore in its name.
+ * @since 1.0
+ */
+public final class Underscored_Name {
+
+    /**
+     * Any action.
+     * @return Any string
+     */
+    public String action() {
+        return "something";
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/Underscored_NameIT.java
+++ b/src/test/resources/com/qulice/checkstyle/Underscored_NameIT.java
@@ -1,0 +1,19 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Integration test class with an underscore in its name.
+ * @since 1.0
+ */
+public final class Underscored_NameIT {
+
+    /**
+     * Any action.
+     * @return Any string
+     */
+    public String action() {
+        return "something";
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/Underscored_NameTest.java
+++ b/src/test/resources/com/qulice/checkstyle/Underscored_NameTest.java
@@ -1,0 +1,19 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Unit test class with an underscore in its name.
+ * @since 1.0
+ */
+public final class Underscored_NameTest {
+
+    /**
+     * Any action.
+     * @return Any string
+     */
+    public String action() {
+        return "something";
+    }
+}


### PR DESCRIPTION
The stock Checkstyle `TypeName` module in `checks.xml` used to run on every Java file, so test classes with underscored names (a common readability convention) failed validation. This adds a suppression in `suppressions.xml` for `*Test.java`, `*ITCase.java`, and `*IT.java`, next to the existing `JavadocMethod` exemption for the same file set.

The change comes with `CheckstyleTypeNameTest` and three fixtures: an underscored production class that still triggers `TypeNameCheck`, plus underscored unit and integration test classes that now pass clean.

Closes #1674