### PR TITLE
Spare constructors that only take attributes

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -5,7 +5,11 @@
 name: xcop
 'on':
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 jobs:
   xcop:
     timeout-minutes: 15

--- a/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Number of parameters, tolerant to constructors that only take attributes.
+ *
+ * <p>The stock {@code ParameterNumber} check treats a constructor as it
+ * treats a method, while a constructor has no choice: it must accept a
+ * value for every attribute of its class. A long list of parameters there
+ * is a symptom of a class with too many attributes, and the class is what
+ * has to be blamed, not its constructor. That's why a constructor with no
+ * more parameters than the number of attributes of its class passes here,
+ * no matter how big the limit is.
+ *
+ * @since 1.0
+ */
+public final class ParameterNumberCheck
+    extends com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck {
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        if (ast.getType() != TokenTypes.CTOR_DEF
+            || ParameterNumberCheck.parameters(ast) > ParameterNumberCheck.attributes(ast)) {
+            super.visitToken(ast);
+        }
+    }
+
+    /**
+     * How many parameters does this constructor take?
+     * @param ctor The CTOR_DEF node
+     * @return Number of parameters
+     */
+    private static int parameters(final DetailAST ctor) {
+        return ctor.findFirstToken(TokenTypes.PARAMETERS)
+            .getChildCount(TokenTypes.PARAMETER_DEF);
+    }
+
+    /**
+     * How many attributes does the class of this constructor have?
+     *
+     * <p>Static fields stay out of the count, since they belong to the
+     * class and not to its objects. Components of a record count in, as
+     * they are the attributes the canonical constructor has to take.</p>
+     *
+     * @param ctor The CTOR_DEF node
+     * @return Number of attributes
+     */
+    private static long attributes(final DetailAST ctor) {
+        final DetailAST block = ctor.getParent();
+        return ParameterNumberCheck.components(block.getParent())
+            + new ChildStream(block).children().filter(
+                node -> node.getType() == TokenTypes.VARIABLE_DEF
+                    && node.findFirstToken(TokenTypes.MODIFIERS)
+                        .findFirstToken(TokenTypes.LITERAL_STATIC) == null
+            ).count();
+    }
+
+    /**
+     * How many components does this type declare, if it is a record?
+     * @param type The node of the type declaration
+     * @return Number of record components
+     */
+    private static int components(final DetailAST type) {
+        final DetailAST components = type.findFirstToken(TokenTypes.RECORD_COMPONENTS);
+        final int count;
+        if (components == null) {
+            count = 0;
+        } else {
+            count = components.getChildCount(TokenTypes.RECORD_COMPONENT_DEF);
+        }
+        return count;
+    }
+}

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -360,7 +360,12 @@
       <property name="max" value="20"/>
     </module>
     <module name="MethodLength"/>
-    <module name="ParameterNumber">
+    <!--
+    Same as the stock ParameterNumber, but silent about a constructor that
+    takes no more parameters than the number of attributes of its class.
+    See https://github.com/yegor256/qulice/issues/1677
+    -->
+    <module name="com.qulice.checkstyle.ParameterNumberCheck">
       <property name="max" value="3"/>
       <property name="ignoreOverriddenMethods" value="true"/>
     </module>

--- a/src/main/resources/com/qulice/checkstyle/messages.properties
+++ b/src/main/resources/com/qulice/checkstyle/messages.properties
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+maxParam=More than {0,number,integer} parameters (found {1,number,integer})

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -232,7 +232,8 @@ final class ChecksTest {
             "StaticAccessViaInstanceCheck",
             "SingleSpaceSeparatorCheck",
             "SimpleStringSplitCheck",
-            "ProhibitFieldsInTestClassesCheck"
+            "ProhibitFieldsInTestClassesCheck",
+            "ParameterNumberCheck"
         ).map(s -> String.format("ChecksTest/%s", s));
     }
 }

--- a/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.IoCheckedText;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CheckstyleValidator}'s handling of the
+ * {@code ParameterNumber} check.
+ * @since 1.0
+ */
+final class CheckstyleParameterNumberTest {
+
+    @Test
+    void acceptsConstructorTakingAllAttributes() throws Exception {
+        MatcherAssert.assertThat(
+            "Constructor with as many parameters as attributes cannot fail",
+            this.runValidation("FourAttributes.java", true),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void rejectsMethodWithTooManyParameters() throws Exception {
+        final String file = "FourParameters.java";
+        MatcherAssert.assertThat(
+            "Method with four parameters cannot pass",
+            this.runValidation(file, false),
+            Matchers.hasItem(
+                new ViolationMatcher(
+                    "More than 3 parameters (found 4)",
+                    file,
+                    "20",
+                    "ParameterNumberCheck"
+                )
+            )
+        );
+    }
+
+    private Collection<Violation> runValidation(final String file,
+        final boolean passes) throws IOException {
+        final Environment.Mock mock = new Environment.Mock();
+        final Environment env = mock.withParam(
+            "license",
+            String.format(
+                "file:%s",
+                new License().savePackageInfo(
+                    new File(mock.basedir(), "src/main/java/foo")
+                ).withLines("Hello.")
+                    .withEol(String.valueOf('\n')).file()
+            )
+        ).withFile(
+            String.format("src/main/java/foo/%s", file),
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf(
+                        new FormattedText("com/qulice/checkstyle/%s", file)
+                    )
+                )
+            ).asString()
+        );
+        final Collection<Violation> results =
+            new CheckstyleValidator(env).validate(env.files(file));
+        MatcherAssert.assertThat(
+            "validation result should match expected state",
+            results.isEmpty(),
+            Matchers.is(passes)
+        );
+        return results;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/Invalid.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle.ChecksTest.ParameterNumberCheck;
+
+/**
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public final class Invalid {
+    private final int first;
+    private final int second;
+    public Invalid(final int one, final int two, final int three, final int four) {
+        this.first = one + two;
+        this.second = three + four;
+    }
+    public void update(final int one, final int two, final int three, final int four) {
+        System.out.println(one + two + three + four);
+    }
+}
+
+class OnlyConstants {
+    private static final int FIRST = 1;
+    private static final int SECOND = 2;
+    private static final int THIRD = 3;
+    private static final int FOURTH = 4;
+    private final int total;
+    OnlyConstants(final int one, final int two, final int three, final int four) {
+        this.total = one + two + three + four;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/Valid.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle.ChecksTest.ParameterNumberCheck;
+
+/**
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public final class Valid {
+    private final int first;
+    private final int second;
+    private final int third;
+    private final int fourth;
+    public Valid(final int one, final int two, final int three, final int four) {
+        this.first = one;
+        this.second = two;
+        this.third = three;
+        this.fourth = four;
+    }
+    public int sum(final int one, final int two, final int three) {
+        return this.first + this.second + this.third + this.fourth + one + two + three;
+    }
+}
+
+class FewerParamsThanAttributes {
+    private final int alpha;
+    private final int beta;
+    private final int gamma;
+    private final int delta;
+    FewerParamsThanAttributes(final int one, final int two) {
+        this.alpha = one;
+        this.beta = two;
+        this.gamma = 0;
+        this.delta = 0;
+    }
+}
+
+record Coordinates(int first, int second, int third, int fourth) {
+    Coordinates(final int first, final int second, final int third, final int fourth) {
+        this.first = first;
+        this.second = second;
+        this.third = third;
+        this.fourth = fourth;
+    }
+}
+
+class Overriding {
+    @Override
+    public void accept(final int one, final int two, final int three, final int four) {
+    }
+}
+
+class StaticsAndAttributes {
+    private static final int LIMIT = 10;
+    private final int alpha;
+    private final int beta;
+    private final int gamma;
+    private final int delta;
+    StaticsAndAttributes(final int one, final int two, final int three, final int four) {
+        this.alpha = one;
+        this.beta = two;
+        this.gamma = three;
+        this.delta = four;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.ParameterNumberCheck">
+      <property name="max" value="3"/>
+      <property name="ignoreOverriddenMethods" value="true"/>
+    </module>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/violations.txt
@@ -1,0 +1,3 @@
+14:More than 3 parameters (found 4)
+18:More than 3 parameters (found 4)
+29:More than 3 parameters (found 4)

--- a/src/test/resources/com/qulice/checkstyle/FourAttributes.java
+++ b/src/test/resources/com/qulice/checkstyle/FourAttributes.java
@@ -1,0 +1,53 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Class with four attributes.
+ * @since 1.0
+ */
+public final class FourAttributes {
+
+    /**
+     * First number.
+     */
+    private final int first;
+
+    /**
+     * Second number.
+     */
+    private final int second;
+
+    /**
+     * Third number.
+     */
+    private final int third;
+
+    /**
+     * Fourth number.
+     */
+    private final int fourth;
+
+    /**
+     * Constructor.
+     * @param one First number
+     * @param two Second number
+     * @param three Third number
+     * @param four Fourth number
+     */
+    public FourAttributes(final int one, final int two, final int three, final int four) {
+        this.first = one;
+        this.second = two;
+        this.third = three;
+        this.fourth = four;
+    }
+
+    /**
+     * Sum of all numbers.
+     * @return The sum
+     */
+    public int sum() {
+        return this.first + this.second + this.third + this.fourth;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/FourParameters.java
+++ b/src/test/resources/com/qulice/checkstyle/FourParameters.java
@@ -1,0 +1,23 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Class with a method of four parameters.
+ * @since 1.0
+ */
+public final class FourParameters {
+
+    /**
+     * Sum of all numbers.
+     * @param one First number
+     * @param two Second number
+     * @param three Third number
+     * @param four Fourth number
+     * @return The sum
+     */
+    public int sum(final int one, final int two, final int three, final int four) {
+        return one + two + three + four;
+    }
+}


### PR DESCRIPTION
The stock `ParameterNumber` module in `checks.xml` is replaced by `com.qulice.checkstyle.ParameterNumberCheck`, which delegates everything to the stock check but keeps quiet about a constructor whose parameter count is not greater than the number of attributes of its class. Record components count as attributes, static fields do not. Methods still get flagged above three parameters.

A constructor has no choice about its parameters: it must accept a value for every attribute it assigns. When such a constructor gets reported, the real problem sits in the class and its attribute count, so the report points at the wrong place and the only way out today is a suppression comment that also blinds the check where it does help.

One side effect worth knowing: since the check now lives in our package, the `maxParam` message comes from a new `com/qulice/checkstyle/messages.properties`, and it lost its trailing period to match the wording of our other messages. Existing `@checkstyle ParameterNumber` comments keep suppressing it, because the name still matches the class.

Closes #1677