### PR TITLE
fix(checkstyle): #1683 allow comment as sole line of an empty block

### DIFF
--- a/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
@@ -102,10 +102,30 @@ public final class MethodBodyCommentsCheck extends AbstractCheck {
             final String line = lines[pos].trim();
             if (line.startsWith("//") || line.startsWith("/*")) {
                 final String comment = line.substring(2).trim();
-                if (!comment.startsWith("@checkstyle") && !oneliner) {
+                if (!comment.startsWith("@checkstyle") && !oneliner
+                    && !MethodBodyCommentsCheck.alone(lines, pos)) {
                     this.log(pos + 1, "Comments in method body are prohibited");
                 }
             }
         }
+    }
+
+    /**
+     * Is the comment on the given line the only line inside its
+     * immediately enclosing braces?
+     *
+     * <p>A comment sitting alone between an opening and a closing brace
+     * documents an otherwise empty block. Some Checkstyle modules, such
+     * as {@code EmptyCatchBlock}, require exactly such a comment, so it
+     * must not be reported as a prohibited in-body comment.
+     *
+     * @param lines All lines of the file being checked
+     * @param pos Zero-based index of the comment line
+     * @return TRUE if the comment is alone between its enclosing braces
+     */
+    private static boolean alone(final String[] lines, final int pos) {
+        return pos > 0 && pos + 1 < lines.length
+            && lines[pos - 1].trim().endsWith("{")
+            && lines[pos + 1].trim().startsWith("}");
     }
 }

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Invalid.java
@@ -38,4 +38,13 @@ public final class Invalid {
             }
         };
     }
+
+    void nonEmptyCatch() {
+        try {
+            this.run();
+        } catch (final RuntimeException ex) {
+            // recover from the failure
+            this.recover();
+        }
+    }
 }

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Valid.java
@@ -68,6 +68,17 @@ public final class Valid {
             }
         });
     }
+    /**
+     * Empty catch block documented by a single comment, as required by
+     * checkstyle's EmptyCatchBlock module.
+     */
+    public void emptyCatch() {
+        try {
+            this.accept(this.server.accept());
+        } catch (final SocketTimeoutException ignored) {
+            // timeout is expected, the loop continues
+        }
+    }
 }
 
 /**

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/violations.txt
@@ -5,3 +5,4 @@
 22:Comments in method body are prohibited
 27:Comments in method body are prohibited
 36:Comments in method body are prohibited
+46:Comments in method body are prohibited


### PR DESCRIPTION
Closes #1683.

## Problem

`checks.xml` enables checkstyle's `EmptyCatchBlock` module with default properties, so an intentionally empty catch block can only pass that check by containing a comment (the default `exceptionVariableName` pattern `^$` never matches). At the same time `MethodBodyCommentsCheck` reports "Comments in method body are prohibited" for any non-`@checkstyle` comment in a method body. The two checks contradict each other: the code below violates `MethodBodyCommentsCheck`, while removing the comment violates `EmptyCatchBlock`.

```java
try {
    this.back.accept(server.accept());
} catch (final SocketTimeoutException ignored) {
    // timeout is expected, the loop continues
}
```

## Fix

`checkMethod` already exempts a whole one-line method body via the `oneliner` flag, but that exemption did not reach comments nested in inner blocks. This change adds a per-block exemption: a comment that is the only line inside its immediately enclosing braces (previous non-brace line ends with `{`, next starts with `}`) is no longer reported. Such a comment documents an otherwise empty block — exactly what `EmptyCatchBlock` demands — rather than smelling inside real code.

## Tests

- `Valid.java`: added an empty catch block documented by a single comment; it must produce no violations.
- `Invalid.java` / `violations.txt`: added a catch block whose comment has a sibling statement; it must still be reported (guards against over-exemption).

Verified locally: `ChecksTest` passes (82 tests) and the `-Pqulice` self-check passes on the modified source.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1VBWtToFpk6WrcnmVbM3i)_