### PR TITLE
fix(pmd): #1686 ignore internal PMD rule crashes instead of failing the build

### DIFF
--- a/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -93,7 +93,8 @@ final class SourceValidator {
      * crash as a warning and keeps going, so it is a bug in the tool, not a
      * problem in the code under analysis. We do the same here: log it as a
      * warning and do not turn it into a build-breaking violation, since the
-     * user cannot fix it in their code.
+     * user cannot fix it in their code. The full stack trace is logged too,
+     * so the crash can still be diagnosed and reported upstream.
      * @param error The processing error to inspect
      * @return True if it must be reported, false if it is an internal crash
      */
@@ -102,9 +103,10 @@ final class SourceValidator {
         if (crash) {
             Logger.warn(
                 this,
-                "PMD rule crashed on %s and was ignored: %s",
+                "PMD rule crashed on %s and was ignored: %s%n%s",
                 error.getFileId().getAbsolutePath(),
-                error.getMsg()
+                error.getMsg(),
+                error.getDetail()
             );
         }
         return !crash;

--- a/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -73,6 +73,7 @@ final class SourceValidator {
             report.getConfigurationErrors().stream()
                 .map(PmdError.OfConfigError::new).forEach(errors::add);
             report.getProcessingErrors().stream()
+                .filter(this::reportable)
                 .map(PmdError.OfProcessingError::new).forEach(errors::add);
             report.getViolations().stream()
                 .filter(violation -> !SourceValidator.suppressesItself(violation))
@@ -80,6 +81,53 @@ final class SourceValidator {
                 .forEach(errors::add);
         }
         return errors;
+    }
+
+    /**
+     * Tells whether a processing error should be reported as a violation.
+     * Some PMD rules crash internally with an {@link IllegalStateException}
+     * while analyzing perfectly valid Java. For example {@code
+     * UseDiamondOperator} throws {@code "overload resolution is not
+     * complete"} when it probes an overloaded method reference such as
+     * {@code BigDecimal::multiply} (see #1686). PMD itself only logs such a
+     * crash as a warning and keeps going, so it is a bug in the tool, not a
+     * problem in the code under analysis. We do the same here: log it as a
+     * warning and do not turn it into a build-breaking violation, since the
+     * user cannot fix it in their code.
+     * @param error The processing error to inspect
+     * @return True if it must be reported, false if it is an internal crash
+     */
+    private boolean reportable(final Report.ProcessingError error) {
+        final boolean crash = SourceValidator.crashed(error.getError());
+        if (crash) {
+            Logger.warn(
+                this,
+                "PMD rule crashed on %s and was ignored: %s",
+                error.getFileId().getAbsolutePath(),
+                error.getMsg()
+            );
+        }
+        return !crash;
+    }
+
+    /**
+     * Tells whether a throwable is (or was caused by) an internal PMD rule
+     * crash, recognized by an {@link IllegalStateException} anywhere in its
+     * cause chain.
+     * @param error The throwable to inspect
+     * @return True if the cause chain contains an IllegalStateException
+     */
+    private static boolean crashed(final Throwable error) {
+        boolean crash = false;
+        Throwable cause = error;
+        while (cause != null) {
+            if (cause instanceof IllegalStateException) {
+                crash = true;
+                break;
+            }
+            cause = cause.getCause();
+        }
+        return crash;
     }
 
     /**

--- a/src/test/java/com/qulice/pmd/PmdMethodReferencesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdMethodReferencesTest.java
@@ -25,4 +25,15 @@ final class PmdMethodReferencesTest {
             )
         ).assertOk();
     }
+
+    @Test
+    void ignoresRuleCrashOnMethodReference() throws Exception {
+        new PmdAssert(
+            "UseDiamondOperatorMethodRef.java",
+            Matchers.is(true),
+            Matchers.not(
+                Matchers.containsString("(ProcessingError)")
+            )
+        ).assertOk();
+    }
 }

--- a/src/test/resources/com/qulice/pmd/UseDiamondOperatorMethodRef.java
+++ b/src/test/resources/com/qulice/pmd/UseDiamondOperatorMethodRef.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.math.BigDecimal;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.number.NumberOfScalars;
+import org.cactoos.scalar.Constant;
+import org.cactoos.scalar.Reduced;
+
+public final class UseDiamondOperatorMethodRef {
+
+    public Number make(final Iterable<? extends Number> src) {
+        return new NumberOfScalars(
+            new Reduced<BigDecimal>(
+                BigDecimal::multiply,
+                new Mapped<>(
+                    n -> new Constant<>(new BigDecimal(n.toString())),
+                    src
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
Closes #1686.

## Problem

PMD's `UseDiamondOperator` rule crashes with `IllegalStateException: overload resolution is not complete` (from `MethodRefMirrorImpl.isEquivalentToUnderlyingAst`, via `UseDiamondOperatorRule.inferenceSucceedsWithoutTypeArgs`) while probing an overloaded method reference such as `BigDecimal::multiply` — for example in cactoos' `MultiplicationOf.java`:

```java
new Reduced<BigDecimal>(
    BigDecimal::multiply,
    new Mapped<>(n -> new Constant<>(new BigDecimal(n.toString())), src)
)
```

This is a bug in PMD (see pmd/pmd#4357), not in the analyzed code. PMD only logs it as a warning and keeps going, but qulice turned the resulting `ProcessingError` into a build-breaking violation (`MultiplicationOf.java[unknown]: ContextedRuntimeException: ...`) that the user cannot fix in their code — the file had to be excluded via a `pmd:` exclude as a workaround.

## Fix

`SourceValidator` now inspects each PMD `ProcessingError`: when its cause chain contains an `IllegalStateException` (the signature of an internal rule crash), it is logged as a warning and **not** reported as a violation. Genuine processing errors are still reported unchanged.

## Testing

- Added `UseDiamondOperatorMethodRef.java` test resource that faithfully reproduces the crash (confirmed to raise the exact `IllegalStateException` against PMD 7.26.0 without the fix).
- Added `PmdMethodReferencesTest#ignoresRuleCrashOnMethodReference`, asserting the build passes and no `(ProcessingError)` violation is emitted.
- Full test suite (370 tests) passes, and `mvn verify -Pqulice` (qulice's own strict self-check) passes on the changed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBiMRH1hdmX68og1KgBcTw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBiMRH1hdmX68og1KgBcTw)_