### PR TITLE
fix(pmd): #1685 suppress UseDiamondOperator false positives

### DIFF
--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -218,6 +218,46 @@
     one Qulice asks for, so this rule loses. It fires 299 times here.
     -->
     <exclude name="UnnecessaryFullyQualifiedName"/>
+    <!--
+    UseDiamondOperator is excluded from the bulk import here and re-enabled
+    below with a violationSuppressXPath, because PMD's type inference does
+    not always agree with javac and the rule reports diamonds that do not
+    compile. Re-enable the bulk form (drop the block below) once PMD's
+    inference matches javac.
+    Downstream: https://github.com/yegor256/qulice/issues/1685
+    -->
+    <exclude name="UseDiamondOperator"/>
+  </rule>
+  <!--
+  UseDiamondOperator suggests replacing explicit constructor type
+  arguments with a diamond '<>', but PMD only reports where it believes
+  the diamond is a compilable replacement, and its inference diverges
+  from javac's in three shapes seen in cactoos: a constructor whose
+  arguments include an implicitly-typed lambda (javac loses the wildcard
+  capture that flows through the lambda), a constructor whose arguments
+  include a method reference (the diamond makes an overloaded constructor
+  ambiguous), and a constructor that is the body of a lambda (its target
+  type is an as-yet-uninferred type variable, so the diamond cannot be
+  pinned). In all three the explicit type arguments are the only thing
+  that makes inference succeed, so the advice is impossible to follow.
+  The violationSuppressXPath below skips those three shapes and keeps the
+  rule for the plain case, such as 'new ArrayList<String>()'. This is the
+  PMD 7 successor of #1242.
+  Downstream: https://github.com/yegor256/qulice/issues/1685
+  Downstream: https://github.com/yegor256/qulice/issues/1242
+  -->
+  <rule ref="category/java/codestyle.xml/UseDiamondOperator">
+    <properties>
+      <property name="violationSuppressXPath">
+        <value><![CDATA[
+          .[
+            ../../ArgumentList/LambdaExpression[@ExplicitlyTyped = false()]
+            or ../../ArgumentList/MethodReference
+            or ../../parent::LambdaExpression
+          ]
+        ]]></value>
+      </property>
+    </properties>
   </rule>
   <rule ref="category/java/design.xml">
     <!--

--- a/src/test/java/com/qulice/pmd/PmdUseDiamondOperatorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdUseDiamondOperatorTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link PmdValidator}'s handling of the
+ * {@code UseDiamondOperator} rule.
+ * @since 1.0
+ */
+final class PmdUseDiamondOperatorTest {
+
+    @Test
+    void forbidsExplicitTypeArgumentsThatDiamondCanReplace() throws Exception {
+        new PmdAssert(
+            "UseDiamondOperator.java",
+            Matchers.is(false),
+            Matchers.containsString("(UseDiamondOperator)")
+        ).assertOk();
+    }
+
+    @Test
+    void allowsExplicitTypeArgumentsRequiredForInference() throws Exception {
+        new PmdAssert(
+            "UseDiamondOperatorInference.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("(UseDiamondOperator)")
+            )
+        ).assertOk();
+    }
+}

--- a/src/test/resources/com/qulice/pmd/UseDiamondOperatorInference.java
+++ b/src/test/resources/com/qulice/pmd/UseDiamondOperatorInference.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.util.Iterator;
+import java.util.Map;
+import org.cactoos.Func;
+import org.cactoos.Scalar;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.iterator.IteratorOf;
+import org.cactoos.scalar.Constant;
+import org.cactoos.scalar.Equals;
+import org.cactoos.scalar.Ternary;
+
+public final class UseDiamondOperatorInference<X> {
+
+    public Iterable<X> paged(final Iterable<? extends X> first,
+        final Func<? super Iterable<? extends X>, ? extends Iterable<? extends X>> next) {
+        return new IterableOf<>(
+            () -> new org.cactoos.iterator.Paged<X>(
+                first.iterator(),
+                page -> next.apply(new IterableOf<>(page)).iterator()
+            )
+        );
+    }
+
+    public Scalar<Boolean> ambiguous(final Map.Entry<Integer, Integer> entry) {
+        return new Equals<Integer, Integer>(
+            entry::getValue, new Constant<>(Integer.MIN_VALUE)
+        );
+    }
+
+    public Iterator<String> ternary(final Iterator<Iterator<String>> pages) {
+        return new org.cactoos.iterator.Paged<>(
+            pages.next(),
+            page -> new Ternary<>(
+                pages::hasNext, pages::next, () -> new IteratorOf<String>()
+            ).value()
+        );
+    }
+}


### PR DESCRIPTION
Closes #1685.

## Problem

The PMD `UseDiamondOperator` rule reported violations on explicit constructor type arguments that `javac` cannot infer, so the advice was impossible to follow. Three shapes surfaced in `yegor256/cactoos`:

1. A constructor whose arguments include an **implicitly-typed lambda** — `new org.cactoos.iterator.Paged<X>(first.iterator(), page -> ...)`; with `<>` javac fails (`Iterator cannot be converted to Iterator`), because the wildcard capture that flows through the lambda is lost.
2. A constructor whose arguments include a **method reference** — `new Equals<Integer, Integer>(entry::getValue, new Constant<>(...))`; with `<>` javac fails (`reference to Equals is ambiguous`), because the diamond makes an overloaded constructor ambiguous.
3. A constructor that is the **body of a lambda** — `() -> new IteratorOf<String>()` as a branch of `new Ternary<>(...)`; with `<>` javac fails (`cannot infer type-variable(s) X`), because the target type is an as-yet-uninferred type variable.

In all three cases the explicit type arguments are the only thing making inference succeed. This is the PMD 7 successor of #1242.

## Fix

Exclude `UseDiamondOperator` from the bulk `category/java/codestyle.xml` import and re-enable it with a `violationSuppressXPath` that skips exactly those three shapes:

```
../../ArgumentList/LambdaExpression[@ExplicitlyTyped = false()]
or ../../ArgumentList/MethodReference
or ../../parent::LambdaExpression
```

The rule (whose reported node is the `TypeArguments`) still fires for the plain case such as `new ArrayList<String>()`, so the useful coverage is preserved. Over-suppression only produces false negatives (a missed diamond opportunity), never impossible advice.

## Verification

Each pattern was reproduced against real cactoos types with PMD 7.26.0: confirmed that the explicit form compiles, the diamond form does **not** compile, and PMD flags the explicit form. With the new `violationSuppressXPath` all three are suppressed while `new ArrayList<String>()` is still reported.

## Changes

- `src/main/resources/com/qulice/pmd/ruleset.xml` — exclude + re-enable `UseDiamondOperator` with the suppress XPath, documented inline.
- `src/test/resources/com/qulice/pmd/UseDiamondOperatorInference.java` — a self-contained fixture reproducing the three false positives.
- `src/test/java/com/qulice/pmd/PmdUseDiamondOperatorTest.java` — asserts the plain case is still flagged and the three inference cases are not.

All 127 tests in the `com.qulice.pmd` package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93jJ9HPTtoiMdC3sSsNC4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M93jJ9HPTtoiMdC3sSsNC4)_