### PR TITLE
Enforce JavadocParagraph check

### DIFF
--- a/src/main/java/com/qulice/checkstyle/BranchContains.java
+++ b/src/main/java/com/qulice/checkstyle/BranchContains.java
@@ -10,7 +10,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
  * Utility class that checks the existence
  * of tokens of specific type in the AST node subtree.
  *
- * Some checks used branchContains() method in DetailAST
+ * <p>Some checks used branchContains() method in DetailAST
  * which recursively searched node subtree for the child of a given type.
  * However, this method was deprecated in upstream due to unintended too
  * deep scanning. It is recommended to write traversal implementation

--- a/src/main/java/com/qulice/checkstyle/ChildStream.java
+++ b/src/main/java/com/qulice/checkstyle/ChildStream.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 /**
  * Utility class which simplifies traversing DetailAST objects.
  *
- * DetailAST APIs for working with child nodes require writing
+ * <p>DetailAST APIs for working with child nodes require writing
  * imperative code, which generally looks less readable then
  * declarative Stream manipulations. This class integrates DetailAST
  * with Java Streams.
@@ -37,7 +37,7 @@ class ChildStream {
      * children. Any two streams returned by this method are
      * independent.
      *
-     * Implementation may be simplified using Stream.iterate when Java 8 support
+     * <p>Implementation may be simplified using Stream.iterate when Java 8 support
      * is dropped.
      *
      * @return Stream of children

--- a/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
+++ b/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
@@ -22,7 +22,7 @@ import java.util.List;
  * };
  * </pre>
  *
- * or
+ * <p>or
  *
  * <pre>
  * String[] array = new String[] {"first", "second"};

--- a/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
@@ -18,17 +18,21 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  *     private List&lt;Number&gt; numbers = new ArrayList&lt;Integer&gt;(); // error
  * </pre>
+ *
  * <p>will return compilation error (because <code>ArrayList&lt;Integer&gt;</code> is not
  * a subclass of <code>List&lt;Number&gt;</code>).</p>
+ *
  * <p>Hence, the only possible way to create a generic instance is copying type arguments from
  * the variable declaration.</p>
  * <pre>
  *     private List&lt;Number&gt; numbers = new ArrayList&lt;Number&gt;();
  * </pre>
+ *
  * <p>In that case, Diamond Operator should always be used.</p>
  * <pre>
  *     private List&lt;Number&gt; numbers = new ArrayList&lt;&gt;();
  * </pre>
+ *
  * <p>Exceptions to the rule above are wildcards, with them it's possible
  * to have different type parameters for left and right parts of variable declaration.</p>
  * <pre>
@@ -36,6 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     private List&lt;? extends Number&gt; numbers = new ArrayList&lt;Integer&gt;();
  *     private List&lt;? super Integer&gt; list = new ArrayList&lt;Number&gt;();
  *</pre>
+ *
  * <p>Although, this is not considered as good codestyle,
  * so it's better to use diamond operator here either.</p>
  *

--- a/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
@@ -39,7 +39,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     // will compile
  *     private List&lt;? extends Number&gt; numbers = new ArrayList&lt;Integer&gt;();
  *     private List&lt;? super Integer&gt; list = new ArrayList&lt;Number&gt;();
- *</pre>
+ * </pre>
  *
  * <p>Although, this is not considered as good codestyle,
  * so it's better to use diamond operator here either.</p>

--- a/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
@@ -19,7 +19,7 @@ import java.util.stream.StreamSupport;
  * your code and make it more cohesive and readable. The bottom line is
  * that every method should look solid and do just <b>one thing</b>.
  *
- * This class is not thread safe. It builds a list of line ranges by visiting
+ * <p>This class is not thread safe. It builds a list of line ranges by visiting
  * each method definition and each anonymous inner type, keeps them in
  * instance fields until finishTree() reports and clears them, so a single
  * instance must not be shared between threads.

--- a/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * Checks the order of methods declaration.
  *
- * Right order is: public, protected and private
+ * <p>Right order is: public, protected and private
  *
  * @since 0.6
  */

--- a/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -18,11 +18,11 @@ import java.util.regex.Pattern;
  * <p>If your method doesn't need {@code this} than why it is not
  * {@code static}?
  *
- * The exception here is when method has {@code @Override} annotation. There's
+ * <p>The exception here is when method has {@code @Override} annotation. There's
  * no concept of inheritance and polymorphism for static methods even if they
  * don't need {@code this} to perform the actual work.
  *
- * Another exception is when method is {@code abstract} or {@code native}.
+ * <p>Another exception is when method is {@code abstract} or {@code native}.
  * Such methods don't have body so detection based on {@code this} doesn't
  * make sense for them.
  *

--- a/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
@@ -16,12 +16,14 @@ import org.cactoos.text.UncheckedText;
 /**
  * Checks that classes are declared as final. Doesn't check for classes nested
  *  in interfaces or annotations, as they are always {@code final} there.
+ *
  * <p>
  * An example of how to configure the check is:
  * </p>
  * <pre>
  * &lt;module name="ProhibitNonFinalClassesCheck"/&gt;
  * </pre>
+ *
  * @since 0.19
  */
 public final class ProhibitNonFinalClassesCheck extends AbstractCheck {

--- a/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
+++ b/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 /**
  * Check the required JavaDoc tag in the lines.
+ *
  * <p>Correct format is the following (of a class javadoc):
  *
  * <pre>

--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -495,7 +495,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
     /**
      * Converts a checker exclude into exclude param.
      *
-     * E.g. "checkstyle:.*" will become ".*".
+     * <p>E.g. "checkstyle:.*" will become ".*".
      *
      * @since 0.1
      */

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -493,6 +493,7 @@
     <module name="JavadocContentLocation"/>
     <module name="JavadocLeadingAsteriskAlign"/>
     <module name="JavadocMissingLeadingAsterisk"/>
+    <module name="JavadocParagraph"/>
     <module name="LambdaParameterName"/>
     <module name="MissingJavadocPackage"/>
     <module name="MissingJavadocType"/>
@@ -670,10 +671,6 @@
     </module>
     <module name="JavadocMissingWhitespaceAfterAsterisk">
       <!-- 1 violation -->
-      <property name="severity" value="ignore"/>
-    </module>
-    <module name="JavadocParagraph">
-      <!-- 16 violations -->
       <property name="severity" value="ignore"/>
     </module>
     <module name="MagicNumber">

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -493,8 +493,10 @@
     <module name="JavadocContentLocation"/>
     <module name="JavadocLeadingAsteriskAlign"/>
     <module name="JavadocMissingLeadingAsterisk"/>
+    <module name="JavadocMissingWhitespaceAfterAsterisk"/>
     <module name="JavadocParagraph"/>
     <module name="LambdaParameterName"/>
+    <module name="MissingJavadocMethod"/>
     <module name="MissingJavadocPackage"/>
     <module name="MissingJavadocType"/>
     <module name="MissingNullCaseInSwitch"/>
@@ -669,16 +671,8 @@
       <!-- 80 violations -->
       <property name="severity" value="ignore"/>
     </module>
-    <module name="JavadocMissingWhitespaceAfterAsterisk">
-      <!-- 1 violation -->
-      <property name="severity" value="ignore"/>
-    </module>
     <module name="MagicNumber">
       <!-- 40 violations -->
-      <property name="severity" value="ignore"/>
-    </module>
-    <module name="MissingJavadocMethod">
-      <!-- 9 violations -->
       <property name="severity" value="ignore"/>
     </module>
     <module name="MultipleStringLiterals">

--- a/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
@@ -25,8 +25,10 @@ final class PmdAssertionsTest {
      * PmdValidator can prohibit plain JUnit assertion in import block like
      * import static org.junit.Assert.assert* import static
      * junit.framework.Assert.assert*.
+     *
      * <p>
      * Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -43,8 +45,10 @@ final class PmdAssertionsTest {
     /**
      * PmdValidator can prohibit plain JUnit assertion in test methods like
      * Assert.assertEquals.
+     *
      * <p>
      * Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -60,8 +64,10 @@ final class PmdAssertionsTest {
 
     /**
      * PmdValidator can allow Assert.fail().
+     *
      * <p>
      * Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test


### PR DESCRIPTION
The `JavadocParagraph` checkstyle module was declared with `severity=ignore`, so multi-paragraph Javadoc missing an opening `<p>` tag, or `<p>` tags glued to the previous paragraph, went unreported.

This drops the ignore override, moves the module into the alphabetical block where every fully-enabled Checkstyle module is listed, and fixes the 19 violations that turned up across Qulice's own sources (a couple of comments/utility classes and a few tests).

Closes #1692