### PR TITLE
fix(#1691): use test classpath so ErrorProne sees transitive test deps

### DIFF
--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -28,7 +28,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Resource;
@@ -112,29 +111,18 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public Collection<String> classpath() {
         final Collection<String> paths = new ArrayList<>(0);
         final String blank = "%20";
         final String whitespace = " ";
         try {
             for (final String name
-                : this.iproject.getRuntimeClasspathElements()) {
+                : this.iproject.getTestClasspathElements()) {
                 paths.add(
                     name.replace(
                         File.separatorChar, '/'
                     ).replaceAll(whitespace, blank)
                 );
-            }
-            for (final Artifact artifact
-                : this.iproject.getDependencyArtifacts()) {
-                if (artifact.getFile() != null) {
-                    paths.add(
-                        artifact.getFile().getAbsolutePath()
-                            .replace(File.separatorChar, '/')
-                            .replaceAll(whitespace, blank)
-                    );
-                }
             }
         } catch (final DependencyResolutionRequiredException ex) {
             throw new IllegalStateException("Failed to read classpath", ex);

--- a/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -94,15 +94,46 @@ final class DefaultMavenEnvironmentTest {
     void passPathsWithWhitespaces() throws Exception {
         final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
         final MavenProjectStub project = new MavenProjectStub();
-        project.setRuntimeClasspathElements(
+        project.setTestClasspathElements(
             Collections.singletonList("/Users/Carlos Miranda/git")
         );
-        project.setDependencyArtifacts(Collections.emptySet());
         env.setProject(project);
         MatcherAssert.assertThat(
             "ClassPath should be returned",
             env.classloader(),
             Matchers.notNullValue()
+        );
+    }
+
+    /**
+     * DefaultMavenEnvironment.classpath() should return the fully-resolved
+     * test classpath (compile + runtime + test scope, transitives included)
+     * so that ErrorProne, which compiles test sources too, can access
+     * transitive test-scope dependencies such as {@code opentest4j}
+     * (see <a href="https://github.com/yegor256/qulice/issues/1691">
+     * issue #1691</a>).
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    void classpathIncludesTransitiveTestDependencies() throws Exception {
+        final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
+        final MavenProjectStub project = new MavenProjectStub();
+        project.setTestClasspathElements(
+            ImmutableList.of(
+                "/repo/junit-jupiter-api.jar",
+                "/repo/opentest4j.jar",
+                "/repo/apiguardian-api.jar"
+            )
+        );
+        env.setProject(project);
+        MatcherAssert.assertThat(
+            "Transitive test dependencies must be on the classpath",
+            env.classpath(),
+            Matchers.containsInAnyOrder(
+                "/repo/junit-jupiter-api.jar",
+                "/repo/opentest4j.jar",
+                "/repo/apiguardian-api.jar"
+            )
         );
     }
 


### PR DESCRIPTION
Fixes #1691.

## Problem

`DefaultMavenEnvironment#classpath()` built the classpath from `MavenProject#getRuntimeClasspathElements()` (compile + runtime scope only, no test scope) plus `MavenProject#getDependencyArtifacts()` (direct dependencies only, no transitives). `ErrorProneValidator` passes this same collection as `-classpath` to a forked `javac -Xplugin:ErrorProne` that compiles **main and test sources together**.

That is wrong whenever a test-scope dependency has its own transitive dependencies. For example `org.junit.jupiter:junit-jupiter-api` pulls in `org.opentest4j:opentest4j` and `org.apiguardian:apiguardian-api` transitively — those never made it onto qulice's classpath. As soon as test code called `Assumptions.assumeFalse(...)` or `Assertions.assertAll(...)`, the forked javac failed with `class file for org.opentest4j.TestAbortedException not found`, and `qulice:check` reported it as a violation even though the code compiles fine under Maven's own lifecycle.

## Fix

Replace the `getRuntimeClasspathElements()` + `getDependencyArtifacts()` pair with a single call to `MavenProject#getTestClasspathElements()`, which returns the fully-resolved test classpath (compile + runtime + test scope, transitives included) — exactly what `mvn test-compile` uses. `CheckMojo` already declares `requiresDependencyResolution = ResolutionScope.TEST`, so these elements are resolved and available.

The now-unused `Artifact` import and the `@SuppressWarnings("deprecation")` annotation (only needed for the deprecated `getDependencyArtifacts()`) are removed.

## Tests

- Added `DefaultMavenEnvironmentTest#classpathIncludesTransitiveTestDependencies` verifying the test classpath elements are returned by `classpath()`.
- Updated `passPathsWithWhitespaces` to seed the test classpath instead of the runtime classpath.
- Full `DefaultMavenEnvironmentTest` suite passes (13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpTLBbJvfvPC7GANns1n7W

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpTLBbJvfvPC7GANns1n7W)_