### PR TITLE
fix(pmd): #1690 suppress UseDiamondOperator on anonymous classes

### DIFF
--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -231,18 +231,23 @@
   <!--
   UseDiamondOperator suggests replacing explicit constructor type
   arguments with a diamond '<>', but PMD only reports where it believes
-  the diamond is a compilable replacement, and its inference diverges
-  from javac's in three shapes seen in cactoos: a constructor whose
-  arguments include an implicitly-typed lambda (javac loses the wildcard
-  capture that flows through the lambda), a constructor whose arguments
-  include a method reference (the diamond makes an overloaded constructor
-  ambiguous), and a constructor that is the body of a lambda (its target
-  type is an as-yet-uninferred type variable, so the diamond cannot be
-  pinned). In all three the explicit type arguments are the only thing
-  that makes inference succeed, so the advice is impossible to follow.
-  The violationSuppressXPath below skips those three shapes and keeps the
-  rule for the plain case, such as 'new ArrayList<String>()'. This is the
-  PMD 7 successor of #1242.
+  the diamond is a compilable replacement, and it reports four shapes
+  where the replacement does not compile. Three are javac inference
+  divergences seen in cactoos: a constructor whose arguments include an
+  implicitly-typed lambda (javac loses the wildcard capture that flows
+  through the lambda), a constructor whose arguments include a method
+  reference (the diamond makes an overloaded constructor ambiguous), and
+  a constructor that is the body of a lambda (its target type is an
+  as-yet-uninferred type variable, so the diamond cannot be pinned); in
+  all three the explicit type arguments are the only thing that makes
+  inference succeed. The fourth is an anonymous class instantiation, such
+  as 'new Supplier<String>() { ... }': '<>' on an anonymous class body is
+  only legal at source level 9+, so the advice breaks the '-source 8'
+  builds that qulice/jcabi-parent projects commonly target. The
+  violationSuppressXPath below skips those four shapes and keeps the rule
+  for the plain case, such as 'new ArrayList<String>()'. This is the PMD 7
+  successor of #1242.
+  Downstream: https://github.com/yegor256/qulice/issues/1690
   Downstream: https://github.com/yegor256/qulice/issues/1685
   Downstream: https://github.com/yegor256/qulice/issues/1242
   -->
@@ -254,6 +259,7 @@
             ../../ArgumentList/LambdaExpression[@ExplicitlyTyped = false()]
             or ../../ArgumentList/MethodReference
             or ../../parent::LambdaExpression
+            or ../../AnonymousClassDeclaration
           ]
         ]]></value>
       </property>

--- a/src/test/java/com/qulice/pmd/PmdUseDiamondOperatorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdUseDiamondOperatorTest.java
@@ -33,4 +33,15 @@ final class PmdUseDiamondOperatorTest {
             )
         ).assertOk();
     }
+
+    @Test
+    void allowsExplicitTypeArgumentsOnAnonymousClass() throws Exception {
+        new PmdAssert(
+            "UseDiamondOperatorAnonymous.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("(UseDiamondOperator)")
+            )
+        ).assertOk();
+    }
 }

--- a/src/test/resources/com/qulice/pmd/UseDiamondOperatorAnonymous.java
+++ b/src/test/resources/com/qulice/pmd/UseDiamondOperatorAnonymous.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.util.function.Supplier;
+
+public final class UseDiamondOperatorAnonymous {
+
+    public Supplier<String> make() {
+        return new Supplier<String>() {
+            @Override
+            public String get() {
+                return "";
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #1690.

## Problem

PMD's `UseDiamondOperator` reports a violation on anonymous class instantiations such as `new Supplier<String>() { ... }`, suggesting `new Supplier<>() { ... }`. The diamond operator on an anonymous class body is only legal at source level 9+, so applying the advice under `-source 8` (inherited from `com.jcabi:parent`, common across yegor256's Java projects) fails to compile with `'<>' with anonymous inner classes is not supported in -source 8`.

The `violationSuppressXPath` added for #1685 only skipped three type-inference shapes (implicitly-typed lambda arguments, method-reference arguments, and lambda-body context). It did not check whether the diamond target is an anonymous class instantiation, so this source-8-specific case still fired.

## Fix

Extend the `violationSuppressXPath` in `src/main/resources/com/qulice/pmd/ruleset.xml` with a fourth clause, `../../AnonymousClassDeclaration`, which skips the violation when the reported `TypeArguments` node's enclosing `ConstructorCall` has an anonymous class body. The plain case (e.g. `new ArrayList<String>()`) is still reported.

The rule's explanatory comment is updated to describe the fourth shape.

## Tests

- Added `src/test/resources/com/qulice/pmd/UseDiamondOperatorAnonymous.java`, an anonymous `Supplier<String>` that reproduces the exact violation from the issue.
- Added `PmdUseDiamondOperatorTest#allowsExplicitTypeArgumentsOnAnonymousClass` asserting no `UseDiamondOperator` violation is reported for it.
- Verified the new test fails without the XPath change (PMD reports `` `new Supplier<>()` (UseDiamondOperator)``) and passes with it. All three tests in the class are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7kiv3L27DBSrx8idzuApD

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7kiv3L27DBSrx8idzuApD)_