### PR TITLE
fix(checkstyle): #1694 disable UseEnhancedSwitch below Java 14

### DIFF
--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -7,6 +7,7 @@ package com.qulice.checkstyle;
 import com.jcabi.log.Logger;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -40,6 +41,22 @@ public final class CheckstyleValidator implements ResourceValidator {
         "mf", "sh", "sql", "tokens", "g", "spec", "css", "csv", "js", "json",
         "md", "yml", "yaml", "gradle", "dtd", "scss", "html"
     );
+
+    /**
+     * Checks that suggest fixes relying on Java language features not
+     * available under {@code -source 8}/{@code -target 8} (and other
+     * pre-14 levels). Such a check must be stripped from the configuration
+     * when the project targets an older Java, otherwise it recommends code
+     * that fails to compile. {@code UseEnhancedSwitch} suggests arrow-switch
+     * syntax, which is a Java 14+ feature (see #1694).
+     */
+    private static final Set<String> MODERN = Set.of("UseEnhancedSwitch");
+
+    /**
+     * The minimum Java source level at which the {@link #MODERN} checks are
+     * applicable. Below this, they are removed from the configuration.
+     */
+    private static final int MINIMUM = 14;
 
     /**
      * Checkstyle checker.
@@ -183,6 +200,79 @@ public final class CheckstyleValidator implements ResourceValidator {
         } catch (final CheckstyleException | java.io.IOException ex) {
             throw new IllegalStateException("Failed to load config", ex);
         }
+        if (this.level() < CheckstyleValidator.MINIMUM) {
+            CheckstyleValidator.strip(config, CheckstyleValidator.MODERN);
+        }
         return config;
+    }
+
+    /**
+     * The effective Java source level of the project under validation.
+     *
+     * <p>Reads {@code maven.compiler.release} first and then falls back to
+     * {@code maven.compiler.source}, accepting both the modern ({@code "8"},
+     * {@code "17"}) and the legacy ({@code "1.8"}) forms. When neither is
+     * known, a value below {@link #MINIMUM} is returned, so that checks
+     * requiring newer language features are disabled by default rather than
+     * risking a suggestion that breaks the build.
+     *
+     * @return The source level, e.g. {@code 8}, {@code 17}, {@code 21}
+     */
+    private int level() {
+        int level = CheckstyleValidator.parse(
+            this.env.param("maven.compiler.release", "")
+        );
+        if (level < 0) {
+            level = CheckstyleValidator.parse(
+                this.env.param("maven.compiler.source", "")
+            );
+        }
+        final int result;
+        if (level < 0) {
+            result = CheckstyleValidator.MINIMUM - 1;
+        } else {
+            result = level;
+        }
+        return result;
+    }
+
+    /**
+     * Parse a Java version string into its major number.
+     * @param value Version, e.g. {@code "8"}, {@code "1.8"} or {@code "17"}
+     * @return The major version, or {@code -1} if it cannot be parsed
+     */
+    private static int parse(final String value) {
+        int result = -1;
+        if (value != null && !value.trim().isEmpty()) {
+            String txt = value.trim();
+            if (txt.startsWith("1.")) {
+                txt = txt.substring(2);
+            }
+            try {
+                result = Integer.parseInt(txt);
+            } catch (final NumberFormatException ex) {
+                result = -1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Remove, recursively and in place, the modules with the given names
+     * from a configuration tree.
+     * @param config Configuration to strip
+     * @param names Simple names of the modules to remove
+     */
+    private static void strip(final Configuration config,
+        final Set<String> names) {
+        for (final Configuration child : config.getChildren()) {
+            final String name = child.getName();
+            final String simple = name.substring(name.lastIndexOf('.') + 1);
+            if (names.contains(simple)) {
+                ((DefaultConfiguration) config).removeChild(child);
+            } else {
+                CheckstyleValidator.strip(child, names);
+            }
+        }
     }
 }

--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -243,7 +243,7 @@ public final class CheckstyleValidator implements ResourceValidator {
      */
     private static int parse(final String value) {
         int result = -1;
-        if (value != null && !value.trim().isEmpty()) {
+        if (value != null) {
             String txt = value.trim();
             if (txt.startsWith("1.")) {
                 txt = txt.substring(2);

--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -90,6 +90,9 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
     @Override
     public String param(final String name, final String value) {
         String ret = this.iproperties.getProperty(name);
+        if (ret == null && this.iproject != null) {
+            ret = this.iproject.getProperties().getProperty(name);
+        }
         if (ret == null) {
             ret = value;
         }

--- a/src/test/java/com/qulice/checkstyle/CheckstyleUseEnhancedSwitchTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleUseEnhancedSwitchTest.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.IoCheckedText;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CheckstyleValidator}'s source-level awareness of the
+ * stock {@code UseEnhancedSwitch} check. The check suggests arrow-switch
+ * syntax, a Java 14+ feature, so it must be disabled when the project targets
+ * an older Java (issue #1694).
+ * @since 1.0
+ */
+final class CheckstyleUseEnhancedSwitchTest {
+
+    /**
+     * Name of the resource holding a convertible classic switch.
+     */
+    private static final String FILE = "EnhancedSwitch.java";
+
+    /**
+     * Simple name of the stock check under test.
+     */
+    private static final String CHECK = "UseEnhancedSwitchCheck";
+
+    @Test
+    void skipsEnhancedSwitchOnSourceEight() throws Exception {
+        MatcherAssert.assertThat(
+            "UseEnhancedSwitch must not fire when source is 8",
+            this.runValidation("8"),
+            Matchers.not(
+                Matchers.hasItem(
+                    new ViolationMatcher(
+                        "", CheckstyleUseEnhancedSwitchTest.FILE, "",
+                        CheckstyleUseEnhancedSwitchTest.CHECK
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    void skipsEnhancedSwitchOnLegacySourceEight() throws Exception {
+        MatcherAssert.assertThat(
+            "UseEnhancedSwitch must not fire when source is 1.8",
+            this.runValidation("1.8"),
+            Matchers.not(
+                Matchers.hasItem(
+                    new ViolationMatcher(
+                        "", CheckstyleUseEnhancedSwitchTest.FILE, "",
+                        CheckstyleUseEnhancedSwitchTest.CHECK
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    void skipsEnhancedSwitchWhenSourceUnknown() throws Exception {
+        MatcherAssert.assertThat(
+            "UseEnhancedSwitch must not fire when source is unknown",
+            this.runValidation(null),
+            Matchers.not(
+                Matchers.hasItem(
+                    new ViolationMatcher(
+                        "", CheckstyleUseEnhancedSwitchTest.FILE, "",
+                        CheckstyleUseEnhancedSwitchTest.CHECK
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    void reportsEnhancedSwitchOnModernSource() throws Exception {
+        MatcherAssert.assertThat(
+            "UseEnhancedSwitch must fire when source is 17",
+            this.runValidation("17"),
+            Matchers.hasItem(
+                new ViolationMatcher(
+                    "", CheckstyleUseEnhancedSwitchTest.FILE, "",
+                    CheckstyleUseEnhancedSwitchTest.CHECK
+                )
+            )
+        );
+    }
+
+    /**
+     * Run the validator over the sample file with the given source level.
+     * @param source Value for {@code maven.compiler.source}, or {@code null}
+     * @return Collection of violations
+     * @throws IOException If some IO problem
+     */
+    private Collection<Violation> runValidation(final String source)
+        throws IOException {
+        final Environment.Mock mock = new Environment.Mock();
+        mock.withParam(
+            "license",
+            String.format(
+                "file:%s",
+                new License().savePackageInfo(
+                    new File(mock.basedir(), "src/main/java/foo")
+                ).withLines("Hello.")
+                    .withEol(String.valueOf('\n')).file()
+            )
+        );
+        if (source != null) {
+            mock.withParam("maven.compiler.source", source);
+        }
+        final Environment env = mock.withFile(
+            String.format(
+                "src/main/java/foo/%s",
+                CheckstyleUseEnhancedSwitchTest.FILE
+            ),
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf(
+                        new FormattedText(
+                            "com/qulice/checkstyle/%s",
+                            CheckstyleUseEnhancedSwitchTest.FILE
+                        )
+                    )
+                )
+            ).asString()
+        );
+        return new CheckstyleValidator(env).validate(
+            env.files(CheckstyleUseEnhancedSwitchTest.FILE)
+        );
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/EnhancedSwitch.java
+++ b/src/test/resources/com/qulice/checkstyle/EnhancedSwitch.java
@@ -1,0 +1,33 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Class with a classic switch statement that Checkstyle's
+ * {@code UseEnhancedSwitch} suggests rewriting into arrow-switch syntax,
+ * which only compiles under Java 14+.
+ * @since 1.0
+ */
+public final class EnhancedSwitch {
+    /**
+     * Describe the given type using a classic switch.
+     * @param type The type
+     * @return Human readable name
+     */
+    public String describe(final int type) {
+        final String result;
+        switch (type) {
+            case 1:
+                result = "one";
+                break;
+            case 2:
+                result = "two";
+                break;
+            default:
+                result = "many";
+                break;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Fixes #1694.

## Problem

Checkstyle's `UseEnhancedSwitch` (registered in `checks.xml`) fires on classic
switch statements and suggests rewriting them with arrow-switch syntax
(`case X -> ...`). That is a Java 14+ language feature, so for the many
`yegor256` libraries that compile at `-source 8`/`-target 8` (inherited from
`com.jcabi:parent`), following the suggestion produces code that fails to
compile. The check takes no properties and has no source-level awareness, so it
recommends an inapplicable fix. This is the same category of bug as #1690
(`UseDiamondOperator`).

## Fix

Make `CheckstyleValidator` source-level aware and strip source-incompatible
modules from the loaded configuration when the project targets an older Java:

- Added a `MODERN` set (currently `UseEnhancedSwitch`) of checks that require
  Java 14+, and a `MINIMUM` threshold of `14`.
- The effective source level is read from `maven.compiler.release`, falling
  back to `maven.compiler.source` (both `8` and `1.8` forms are accepted). When
  it is below 14 — or cannot be determined — the modern checks are removed from
  the configuration tree, reusing the same recursive `removeChild` approach as
  `UnusedSuppressions`. Unknown source levels default to *disabled* so a
  suggestion never breaks a build.
- `DefaultMavenEnvironment.param` now falls back to the Maven project's
  properties, so the compiler source level declared in the effective POM is
  visible to validators.

Projects on Java 14+ (including Qulice itself, which targets 21) keep enforcing
the check.

## Tests

`CheckstyleUseEnhancedSwitchTest` validates a resource file containing a
convertible classic switch:

- source `8`, `1.8`, and unknown → `UseEnhancedSwitch` is **not** reported.
- source `17` → `UseEnhancedSwitch` **is** reported (proving the check still
  fires when applicable).

All checkstyle (144) and maven-module (191) unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pyb1mTibDGByey7dPem7Kq)_