### PR TITLE
fix(errorprone): #1705 disable OperatorPrecedence, conflicts with UnnecessaryParentheses

### DIFF
--- a/src/main/java/com/qulice/checkstyle/ProhibitTestMethodNameCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitTestMethodNameCheck.java
@@ -116,7 +116,6 @@ public final class ProhibitTestMethodNameCheck extends AbstractCheck {
      * @return True if it starts with {@code should} or with {@code test}
      *  but not with {@code tests}
      */
-    @SuppressWarnings("OperatorPrecedence")
     private static boolean startsWithForbidden(final String name) {
         return startsWithWord(name, "should")
             || startsWithWord(name, "test") && !startsWithWord(name, "tests");

--- a/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
+++ b/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
@@ -203,7 +203,6 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
      * @param chr Character to test
      * @return True if ASCII letter
      */
-    @SuppressWarnings("OperatorPrecedence")
     private static boolean isAsciiLetter(final char chr) {
         return chr >= 'a' && chr <= 'z'
             || chr >= 'A' && chr <= 'Z';

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -69,6 +69,32 @@ public final class ErrorProneValidator implements ResourceValidator {
     );
 
     /**
+     * The {@code -Xplugin} value that wires ErrorProne into the forked
+     * {@code javac}, together with the bug patterns Qulice switches off.
+     *
+     * <p>{@code InvalidBlockTag} is disabled because it rejects the
+     * {@code @checkstyle} block tags this codebase writes in Javadoc.</p>
+     *
+     * <p>{@code OperatorPrecedence} is disabled because it contradicts
+     * Checkstyle's {@code UnnecessaryParentheses}: a boolean expression
+     * that mixes {@code &&} and {@code ||} can satisfy only one of them at
+     * a time. {@code OperatorPrecedence} demands grouping parentheses
+     * around the {@code &&} operands (for example
+     * {@code (a && b) || (c && d)}), while {@code UnnecessaryParentheses}
+     * flags those very parentheses as redundant, since {@code &&} already
+     * binds tighter than {@code ||}. Keeping {@code UnnecessaryParentheses}
+     * as the single arbiter lets the terse, paren-free form pass both
+     * checks. See
+     * <a href="https://github.com/yegor256/qulice/issues/1705">#1705</a>.</p>
+     */
+    private static final String PLUGIN = String.join(
+        " ",
+        "-Xplugin:ErrorProne",
+        "-Xep:InvalidBlockTag:OFF",
+        "-Xep:OperatorPrecedence:OFF"
+    );
+
+    /**
      * Standard {@code javac} diagnostic format with an ErrorProne
      * {@code [CheckName]} prefix on the message:
      * {@code path:line: warning|error: [Name] body}.
@@ -168,7 +194,7 @@ public final class ErrorProneValidator implements ResourceValidator {
         args.add("-XDaddTypeAnnotationsToSymbol=true");
         args.add("--should-stop=ifError=FLOW");
         args.add("-proc:none");
-        args.add("-Xplugin:ErrorProne -Xep:InvalidBlockTag:OFF");
+        args.add(ErrorProneValidator.PLUGIN);
         args.add("-processorpath");
         args.add(ErrorProneValidator.pluginClasspath());
         args.add("-d");

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -255,6 +255,17 @@
       <property name="checkMethods" value="true"/>
       <property name="validateOnlyOverlapping" value="false"/>
     </module>
+    <!--
+    This check and ErrorProne's 'OperatorPrecedence' pull in opposite
+    directions on a boolean expression that mixes '&&' and '||':
+    'OperatorPrecedence' wants grouping parentheses around the '&&'
+    operands, e.g. '(a && b) || (c && d)', while this check flags those
+    same parentheses as unnecessary, since '&&' already binds tighter
+    than '||'. No form of the code satisfies both. Qulice keeps this
+    check as the single arbiter and disables 'OperatorPrecedence' in
+    ErrorProneValidator, so the paren-free form passes. See
+    https://github.com/yegor256/qulice/issues/1705.
+    -->
     <module name="UnnecessaryParentheses"/>
     <module name="OneStatementPerLine"/>
     <!-- Checks for imports. -->

--- a/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
@@ -83,4 +83,38 @@ final class ErrorProneValidatorTest {
             Matchers.<Violation>empty()
         );
     }
+
+    @Test
+    void doesNotFlagMixedBooleanOperators() throws Exception {
+        final String file = "src/main/java/com/qulice/Mixed.java";
+        final Environment env = new Environment.Mock().withFile(
+            file,
+            String.join(
+                System.lineSeparator(),
+                "package com.qulice;",
+                "/**",
+                " * Sample.",
+                " * @since 1.0",
+                " */",
+                "final class Mixed {",
+                "    boolean hex(final char glyph) {",
+                "        return glyph >= '0' && glyph <= '9'",
+                "            || glyph >= 'A' && glyph <= 'F';",
+                "    }",
+                "}"
+            )
+        );
+        final java.util.Collection<Violation> violations =
+            new ErrorProneValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            );
+        MatcherAssert.assertThat(
+            String.format(
+                "Mixed && and || without parens must not trigger OperatorPrecedence: %s",
+                violations
+            ),
+            violations,
+            Matchers.<Violation>empty()
+        );
+    }
 }


### PR DESCRIPTION
Closes #1705.

## Problem

ErrorProne's `OperatorPrecedence` and Checkstyle's `UnnecessaryParentheses` contradict each other on any boolean expression that mixes `&&` and `||`:

- Without parens, `OperatorPrecedence` fires and asks for grouping parens: `(a && b) || (c && d)`.
- With those exact parens, `UnnecessaryParentheses` fires, because `&&` already binds tighter than `||`, so the parens are redundant.

There is no form of the code that satisfies both checks at once. Qulice's own source already worked around this with `@SuppressWarnings("OperatorPrecedence")` in two places.

## Fix

Following the same treatment 0.30.4 gave the analogous Javadoc contradiction (`RequireEmptyLineBeforeBlockTagGroup` vs `JavadocEmptyLineBeforeTagCheck`), one of the two checks is disabled by default with documented rationale. `OperatorPrecedence` is switched off in `ErrorProneValidator` (alongside the existing `InvalidBlockTag` disable), leaving Checkstyle's `UnnecessaryParentheses` as the single arbiter. The terse, paren-free form — the style this codebase already favors — now passes both.

## Changes

- `ErrorProneValidator`: add `-Xep:OperatorPrecedence:OFF` to the ErrorProne plugin arguments, extracted into a documented `PLUGIN` constant.
- `checks.xml`: document the contradiction next to the `UnnecessaryParentheses` module.
- Remove the now-redundant `@SuppressWarnings("OperatorPrecedence")` from `ProhibitTestMethodNameCheck` and `SimpleStringSplitCheck`.
- `ErrorProneValidatorTest`: add `doesNotFlagMixedBooleanOperators`, a regression test asserting a mixed `&&`/`||` expression without parens produces no violation.

## Testing

`mvn -Dtest=ErrorProneValidatorTest test` — 4 tests pass, including the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qy9ghDqUJCoQERkMadD3SC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy9ghDqUJCoQERkMadD3SC)_