### PR TITLE
feat(checkstyle): #1709 add JavadocCompactParagraphCheck

### DIFF
--- a/src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java
@@ -1,0 +1,254 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.Locale;
+
+/**
+ * Check for compact paragraph tags in Javadoc.
+ *
+ * <p>The built-in {@code JavadocParagraph} module governs the blank lines
+ * around {@code <p>}, but nothing stops the tag from sitting alone on its
+ * own line. This check keeps {@code <p>} glued to the text it opens and,
+ * when {@code </p>} is used at all, glued to the text it closes. So a line
+ * whose trimmed content ends with {@code <p>}, or whose trimmed content
+ * starts with {@code </p>}, is reported as a violation. See
+ * <a href="https://github.com/yegor256/qulice/issues/1709">#1709</a>.
+ *
+ * <p>The following Javadoc will be reported as a violation, since the
+ * opening tag ends a line and the closing tag starts a line:
+ * <pre>
+ * &#47;**
+ *  <span style="color:red" >* &lt;p&gt;</span>
+ *  * An example of how to configure the check is:
+ *  <span style="color:red" >* &lt;/p&gt;</span>
+ *  *&#47;
+ * </pre>
+ *
+ * <p>And this is how it should be written instead:
+ * <pre>
+ * &#47;**
+ *  * &lt;p&gt;An example of how to configure the check is:&lt;/p&gt;
+ *  *&#47;
+ * </pre>
+ *
+ * <p>Lines inside a {@code <pre>...</pre>} block or a {@code {@snippet ...}}
+ * block are skipped, since a literal {@code <p>} or {@code </p>} may appear
+ * there as example content rather than as a real tag.
+ *
+ * @since 0.73.3
+ */
+public final class JavadocCompactParagraphCheck extends AbstractCheck {
+
+    /**
+     * Message about an opening tag that ends a line.
+     */
+    private static final String MSG_OPEN =
+        "Opening paragraph tag <p> must be followed by text on the same line";
+
+    /**
+     * Message about a closing tag that starts a line.
+     */
+    private static final String MSG_CLOSE =
+        "Closing paragraph tag </p> must be preceded by text on the same line";
+
+    /**
+     * Default constructor.
+     */
+    public JavadocCompactParagraphCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+        };
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        final String[] lines = this.getLines();
+        final int current = ast.getLineNo();
+        final int start =
+            JavadocCompactParagraphCheck.findCommentStart(lines, current) + 1;
+        final int end =
+            JavadocCompactParagraphCheck.findCommentEnd(lines, current) - 1;
+        if (JavadocCompactParagraphCheck.isNodeHavingJavadoc(ast, start)
+            && start < lines.length && end >= start) {
+            this.checkParagraphs(lines, start, end);
+        }
+    }
+
+    /**
+     * Report every non-compact paragraph tag inside the comment body.
+     * @param lines All lines of the source file
+     * @param start First body line of the comment
+     * @param end Last body line of the comment
+     */
+    private void checkParagraphs(final String[] lines, final int start,
+        final int end) {
+        boolean pre = false;
+        int depth = 0;
+        for (int pos = start; pos <= end && pos < lines.length; pos += 1) {
+            final String body = JavadocCompactParagraphCheck.body(lines[pos]);
+            final String low = body.toLowerCase(Locale.ENGLISH);
+            if (depth > 0) {
+                depth += JavadocCompactParagraphCheck.braces(body);
+            } else if (low.contains("{@snippet")) {
+                depth = Math.max(0, JavadocCompactParagraphCheck.braces(body));
+            } else if (pre) {
+                pre = !low.contains("</pre>");
+            } else if (low.contains("<pre>")) {
+                pre = !low.contains("</pre>");
+            } else {
+                this.report(pos, body);
+            }
+        }
+    }
+
+    /**
+     * Log a violation for a single Javadoc body line.
+     * @param pos Zero-based index of the line
+     * @param body Trimmed body of the line, without the leading asterisk
+     */
+    private void report(final int pos, final String body) {
+        if (body.endsWith("<p>")) {
+            this.log(pos + 1, JavadocCompactParagraphCheck.MSG_OPEN);
+        }
+        if (body.startsWith("</p>")) {
+            this.log(pos + 1, JavadocCompactParagraphCheck.MSG_CLOSE);
+        }
+    }
+
+    /**
+     * Strip the leading asterisk and surrounding blanks from a Javadoc line.
+     * @param line Raw source line
+     * @return Trimmed body of the line, without the leading asterisk
+     */
+    private static String body(final String line) {
+        String trimmed = line.trim();
+        if (trimmed.startsWith("*")) {
+            trimmed = trimmed.substring(1).trim();
+        }
+        return trimmed;
+    }
+
+    /**
+     * Net brace balance of a line (opening minus closing braces).
+     * @param body Trimmed body of the line
+     * @return Number of opening braces minus number of closing braces
+     */
+    private static int braces(final String body) {
+        int delta = 0;
+        for (int pos = 0; pos < body.length(); pos += 1) {
+            final char chr = body.charAt(pos);
+            if (chr == '{') {
+                delta += 1;
+            } else if (chr == '}') {
+                delta -= 1;
+            }
+        }
+        return delta;
+    }
+
+    /**
+     * Check if node has Javadoc.
+     * @param node Node to be checked for Javadoc
+     * @param start Line number where comment starts
+     * @return True when node has Javadoc
+     */
+    private static boolean isNodeHavingJavadoc(final DetailAST node,
+        final int start) {
+        return start > JavadocCompactParagraphCheck.getLineNoOfPreviousNode(
+            node
+        );
+    }
+
+    /**
+     * Returns line number of previous node.
+     * @param node Current node
+     * @return Line number of previous node
+     */
+    private static int getLineNoOfPreviousNode(final DetailAST node) {
+        int start = 0;
+        final DetailAST previous = node.getPreviousSibling();
+        if (previous != null) {
+            start = previous.getLineNo();
+        }
+        return start;
+    }
+
+    /**
+     * Find Javadoc starting comment.
+     * @param lines List of lines to check
+     * @param start Start searching from this line number
+     * @return Line number with found starting comment or -1 otherwise
+     */
+    private static int findCommentStart(final String[] lines, final int start) {
+        return JavadocCompactParagraphCheck.findTrimmedTextUp(
+            lines, start, "/**"
+        );
+    }
+
+    /**
+     * Find Javadoc ending comment.
+     * @param lines Array of lines to check
+     * @param start Start searching from this line number
+     * @return Line number with found ending comment, or -1 if it wasn't found
+     */
+    private static int findCommentEnd(final String[] lines, final int start) {
+        int found = -1;
+        for (int pos = start - 1; pos >= 0; pos -= 1) {
+            final String trimmed = lines[pos].trim();
+            if ("*/".equals(trimmed) || "**/".equals(trimmed)) {
+                found = pos;
+                break;
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Find a text in lines, by going up.
+     * @param lines Array of lines to check
+     * @param start Start searching from this line number
+     * @param text Text to find
+     * @return Line number with found text, or -1 if it wasn't found
+     */
+    private static int findTrimmedTextUp(final String[] lines,
+        final int start, final String text) {
+        int found = -1;
+        for (int pos = start - 1; pos >= 0; pos -= 1) {
+            if (lines[pos].trim().equals(text)) {
+                found = pos;
+                break;
+            }
+        }
+        return found;
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
@@ -17,9 +17,7 @@ import org.cactoos.text.UncheckedText;
  * Checks that classes are declared as final. Doesn't check for classes nested
  *  in interfaces or annotations, as they are always {@code final} there.
  *
- * <p>
- * An example of how to configure the check is:
- * </p>
+ * <p>An example of how to configure the check is:</p>
  * <pre>
  * &lt;module name="ProhibitNonFinalClassesCheck"/&gt;
  * </pre>

--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -306,7 +306,6 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
      * live under the project's build directory (e.g.
      * {@code target/generated-sources/...}) are filtered out, since those
      * are generated build outputs and not user-authored code (issue #1560).
-     * </p>
      *
      * @return Absolute directories to scan for files
      */

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -460,6 +460,7 @@
     <module name="com.qulice.checkstyle.UnknownSuppressionCheck"/>
     <module name="com.qulice.checkstyle.JavadocEmptyLineCheck"/>
     <module name="com.qulice.checkstyle.JavadocEmptyLineBeforeTagCheck"/>
+    <module name="com.qulice.checkstyle.JavadocCompactParagraphCheck"/>
     <module name="com.qulice.checkstyle.JavadocFirstLineCheck"/>
     <module name="com.qulice.checkstyle.DiamondOperatorCheck"/>
     <module name="com.qulice.checkstyle.JavadocParameterOrderCheck"/>

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -218,6 +218,7 @@ final class ChecksTest {
             "ConstantUsageCheck",
             "JavadocEmptyLineCheck",
             "JavadocEmptyLineBeforeTagCheck",
+            "JavadocCompactParagraphCheck",
             "JavadocFirstLineCheck",
             "JavadocTagsCheck",
             "JavadocTagsDotCheck",

--- a/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
@@ -26,8 +26,7 @@ final class PmdAssertionsTest {
      * import static org.junit.Assert.assert* import static
      * junit.framework.Assert.assert*.
      *
-     * <p>
-     * Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}
      *
      * @throws Exception If something wrong happens inside.
      */
@@ -46,8 +45,7 @@ final class PmdAssertionsTest {
      * PmdValidator can prohibit plain JUnit assertion in test methods like
      * Assert.assertEquals.
      *
-     * <p>
-     * Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}
      *
      * @throws Exception If something wrong happens inside.
      */
@@ -65,8 +63,7 @@ final class PmdAssertionsTest {
     /**
      * PmdValidator can allow Assert.fail().
      *
-     * <p>
-     * Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}
      *
      * @throws Exception If something wrong happens inside.
      */

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocCompactParagraphCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocCompactParagraphCheck/Invalid.java
@@ -1,0 +1,34 @@
+/*
+ * Hello.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is not a real Java class. It won't be compiled ever.
+ *
+ * <p>
+ * Text after a lonely opening tag.
+ * </p>
+ */
+public final class Invalid {
+
+    /**
+     * A field.
+     *
+     * <p>Some paragraph here.
+     * </p>
+     */
+    private int number;
+
+    /**
+     * A method.
+     *
+     * <p>
+     * Another paragraph with a lonely opening tag.
+     *
+     * @return Nothing
+     */
+    public int method() {
+        return this.number;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocCompactParagraphCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocCompactParagraphCheck/Valid.java
@@ -1,0 +1,52 @@
+/*
+ * Hello.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is not a real Java class. It won't be compiled ever.
+ *
+ * <p>The opening tag is glued to its text, and the closing tag is glued
+ * to the text it closes.</p>
+ */
+public final class Valid {
+
+    /**
+     * A field.
+     *
+     * <p>Single paragraph without a closing tag.
+     */
+    private int number;
+
+    /**
+     * A method with a pre block that shows literal tags.
+     *
+     * <p>Example configuration:
+     * <pre>
+     * <p>
+     * some example
+     * </p>
+     * </pre>
+     *
+     * @return Nothing
+     */
+    public int first() {
+        return this.number;
+    }
+
+    /**
+     * A method with a snippet that shows literal tags.
+     *
+     * <p>Here is a snippet:
+     * {@snippet :
+     * <p>
+     * text
+     * </p>
+     * }
+     *
+     * @return Nothing
+     */
+    public int second() {
+        return this.number;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocCompactParagraphCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocCompactParagraphCheck/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.JavadocCompactParagraphCheck"/>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocCompactParagraphCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocCompactParagraphCheck/violations.txt
@@ -1,0 +1,4 @@
+9:Opening paragraph tag <p> must be followed by text on the same line
+11:Closing paragraph tag </p> must be preceded by text on the same line
+19:Closing paragraph tag </p> must be preceded by text on the same line
+26:Opening paragraph tag <p> must be followed by text on the same line


### PR DESCRIPTION
Closes #1709.

## What

Adds a new custom Checkstyle check, `JavadocCompactParagraphCheck`, that keeps the paragraph tags glued to their text:

- flags any Javadoc line whose trimmed body **ends with** `<p>` (the opening tag has nothing after it on the line), and
- flags any Javadoc line whose trimmed body **starts with** `</p>` (the closing tag has nothing before it on the line).

The intent is to enforce `<p>Some text.` and, when `</p>` is used at all, `text.</p>`.

## How

Follows the existing line-based `AbstractCheck` pattern (like `JavadocEmptyLineCheck`): it walks `getLines()` between the comment's start and end, strips the leading `*` from each line, and reports the two shapes above. Lines inside a `<pre>...</pre>` block or a `{@snippet ...}` block are skipped (tracked via a `<pre>` toggle and a brace-depth counter), since a literal tag there is example content rather than a real tag.

## Changes

- `src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java` — the new check.
- `src/main/resources/com/qulice/checkstyle/checks.xml` — registers the module next to the other Javadoc line checks.
- `src/test/java/com/qulice/checkstyle/ChecksTest.java` — wires the check into the integration test.
- `src/test/resources/.../ChecksTest/JavadocCompactParagraphCheck/` — `Valid.java`, `Invalid.java`, `config.xml`, and `violations.txt` fixtures. `Valid.java` also covers the `<pre>` and `{@snippet}` skip cases.
- Fixed the pre-existing violations the new check surfaces in the project's own sources: `ProhibitNonFinalClassesCheck.java`, `DefaultMavenEnvironment.java`, and `PmdAssertionsTest.java`.

## Verification

- `mvn test -Dtest=ChecksTest` — green (includes the new fixtures).
- `mvn test -Dtest=CheckstyleValidatorTest` — green.
- `mvn -Pqulice qulice:check` — green (0 violations; the project now validates cleanly with the new check enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3Ft15APaBnPcFmgdD6Dtq)_