### PR TITLE
feat(checkstyle): #1708 add JavadocNoIndentCheck

### DIFF
--- a/src/main/java/com/qulice/checkstyle/JavadocNoIndentCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocNoIndentCheck.java
@@ -1,0 +1,285 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.Locale;
+
+/**
+ * Checks that Javadoc body text is not over-indented.
+ *
+ * <p>Every line of a Javadoc comment must have exactly one space between the
+ * leading asterisk and the first word of the text. Extra spaces, used to
+ * push a paragraph line to the right, are not allowed:
+ *
+ * <pre>
+ * &#47;**
+ *  * This is a paragraph.
+ *  *     This line is over-indented and will be reported.
+ *  *&#47;
+ * </pre>
+ *
+ * <p>Lines inside a {@code <pre>} block or a {@code @snippet} block are left
+ * alone, since the indentation there is semantically meaningful and has to be
+ * preserved as written. Block tags and their wrapped continuation lines are
+ * also left alone, since their indentation is governed by other checks.
+ *
+ * @since 0.74
+ */
+public final class JavadocNoIndentCheck extends AbstractCheck {
+
+    /**
+     * Message about the extra indentation.
+     */
+    private static final String MESSAGE =
+        "Extra indentation is not allowed in Javadoc";
+
+    /**
+     * Default constructor.
+     */
+    public JavadocNoIndentCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+        };
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        final String[] lines = this.getLines();
+        final int current = ast.getLineNo();
+        final int start =
+            JavadocNoIndentCheck.findCommentStart(lines, current) + 1;
+        if (JavadocNoIndentCheck.isNodeHavingJavadoc(ast, start)
+            && start < lines.length) {
+            this.check(
+                lines, start,
+                JavadocNoIndentCheck.findCommentEnd(lines, current) - 1
+            );
+        }
+    }
+
+    /**
+     * Check the body of the Javadoc for extra indentation.
+     * @param lines Code of the whole class
+     * @param start First line of the Javadoc body
+     * @param end Last line of the Javadoc body
+     */
+    private void check(final String[] lines, final int start, final int end) {
+        boolean pre = false;
+        boolean tagged = false;
+        int depth = 0;
+        for (int pos = start; pos <= end; pos += 1) {
+            final String line = lines[pos];
+            final String body = JavadocNoIndentCheck.afterAsterisk(line);
+            final boolean region = JavadocNoIndentCheck.region(pre, depth, line);
+            if (!region && body.trim().startsWith("@")) {
+                tagged = true;
+            }
+            if (!region && !tagged
+                && JavadocNoIndentCheck.overIndented(body)) {
+                this.log(pos + 1, JavadocNoIndentCheck.MESSAGE);
+            }
+            pre = JavadocNoIndentCheck.nextPre(pre, line);
+            depth = JavadocNoIndentCheck.nextDepth(depth, line);
+        }
+    }
+
+    /**
+     * Is this line inside a region where indentation is preserved.
+     * @param pre Are we inside a {@code <pre>} block
+     * @param depth Current brace depth of an open {@code @snippet} block
+     * @param line The line being examined
+     * @return True when the line's indentation must be left alone
+     */
+    private static boolean region(final boolean pre, final int depth,
+        final String line) {
+        return pre || depth > 0 || line.contains("{@snippet");
+    }
+
+    /**
+     * The text that follows the leading asterisk of a Javadoc line.
+     * @param line The Javadoc line
+     * @return Everything after the first asterisk, or empty if there is none
+     */
+    private static String afterAsterisk(final String line) {
+        final int star = line.indexOf('*');
+        final String result;
+        if (star < 0) {
+            result = "";
+        } else {
+            result = line.substring(star + 1);
+        }
+        return result;
+    }
+
+    /**
+     * Does the body start with more than one space before its first word.
+     * @param body The text after the leading asterisk
+     * @return True when the body is over-indented
+     */
+    private static boolean overIndented(final String body) {
+        int spaces = 0;
+        while (spaces < body.length() && body.charAt(spaces) == ' ') {
+            spaces += 1;
+        }
+        return spaces > 1 && spaces < body.length();
+    }
+
+    /**
+     * Compute the {@code <pre>} flag for the next line.
+     * @param pre Whether the current line is inside a {@code <pre>} block
+     * @param line The current line
+     * @return Whether the next line is inside a {@code <pre>} block
+     */
+    private static boolean nextPre(final boolean pre, final String line) {
+        final String lower = line.toLowerCase(Locale.ENGLISH);
+        final boolean result;
+        if (pre) {
+            result = !lower.contains("</pre>");
+        } else {
+            result = lower.contains("<pre>") && !lower.contains("</pre>");
+        }
+        return result;
+    }
+
+    /**
+     * Compute the {@code @snippet} brace depth after this line.
+     * @param depth The brace depth before this line
+     * @param line The current line
+     * @return The brace depth after this line
+     */
+    private static int nextDepth(final int depth, final String line) {
+        final int result;
+        if (depth > 0) {
+            result = Math.max(0, depth + JavadocNoIndentCheck.braces(line));
+        } else {
+            final int idx = line.indexOf("{@snippet");
+            if (idx < 0) {
+                result = 0;
+            } else {
+                result = Math.max(
+                    0, JavadocNoIndentCheck.braces(line.substring(idx))
+                );
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Net number of opening minus closing braces in the text.
+     * @param text The text to scan
+     * @return The brace balance
+     */
+    private static int braces(final String text) {
+        int delta = 0;
+        for (int pos = 0; pos < text.length(); pos += 1) {
+            final char chr = text.charAt(pos);
+            if (chr == '{') {
+                delta += 1;
+            } else if (chr == '}') {
+                delta -= 1;
+            }
+        }
+        return delta;
+    }
+
+    /**
+     * Check if node has Javadoc.
+     * @param node Node to be checked for Javadoc
+     * @param start Line number where comment starts
+     * @return True when node has Javadoc
+     */
+    private static boolean isNodeHavingJavadoc(final DetailAST node,
+        final int start) {
+        return start > JavadocNoIndentCheck.getLineNoOfPreviousNode(node);
+    }
+
+    /**
+     * Returns line number of previous node.
+     * @param node Current node
+     * @return Line number of previous node
+     */
+    private static int getLineNoOfPreviousNode(final DetailAST node) {
+        int start = 0;
+        final DetailAST previous = node.getPreviousSibling();
+        if (previous != null) {
+            start = previous.getLineNo();
+        }
+        return start;
+    }
+
+    /**
+     * Find Javadoc starting comment.
+     * @param lines List of lines to check
+     * @param start Start searching from this line number
+     * @return Line number with found starting comment or -1 otherwise
+     */
+    private static int findCommentStart(final String[] lines, final int start) {
+        return JavadocNoIndentCheck.findTrimmedTextUp(lines, start, "/**");
+    }
+
+    /**
+     * Find Javadoc ending comment.
+     * @param lines Array of lines to check
+     * @param start Start searching from this line number
+     * @return Line number with found ending comment, or -1 if it wasn't found
+     */
+    private static int findCommentEnd(final String[] lines, final int start) {
+        int found = -1;
+        for (int pos = start - 1; pos >= 0; pos -= 1) {
+            final String trimmed = lines[pos].trim();
+            if ("*/".equals(trimmed) || "**/".equals(trimmed)) {
+                found = pos;
+                break;
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Find a text in lines, by going up.
+     * @param lines Array of lines to check
+     * @param start Start searching from this line number
+     * @param text Text to find
+     * @return Line number with found text, or -1 if it wasn't found
+     */
+    private static int findTrimmedTextUp(final String[] lines,
+        final int start, final String text) {
+        int found = -1;
+        for (int pos = start - 1; pos >= 0; pos -= 1) {
+            if (lines[pos].trim().equals(text)) {
+                found = pos;
+                break;
+            }
+        }
+        return found;
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
@@ -15,7 +15,7 @@ import org.cactoos.text.UncheckedText;
 
 /**
  * Checks that classes are declared as final. Doesn't check for classes nested
- *  in interfaces or annotations, as they are always {@code final} there.
+ * in interfaces or annotations, as they are always {@code final} there.
  *
  * <p>
  * An example of how to configure the check is:

--- a/src/main/java/com/qulice/checkstyle/Suppressions.java
+++ b/src/main/java/com/qulice/checkstyle/Suppressions.java
@@ -21,12 +21,12 @@ import java.util.regex.Pattern;
  * influences:</p>
  *
  * <ul>
- *  <li>the {@code (N lines)} form covers the {@code N} lines that follow
- *  the comment, the way {@code SuppressWithNearbyCommentFilter} and
- *  {@code SuppressWithNearbyTextFilter} read it;</li>
- *  <li>a {@code disable} comment opens a range that the matching
- *  {@code enable} comment closes, or the end of the file does, the way
- *  {@code SuppressWithPlainTextCommentFilter} reads it.</li>
+ * <li>the {@code (N lines)} form covers the {@code N} lines that follow
+ * the comment, the way {@code SuppressWithNearbyCommentFilter} and
+ * {@code SuppressWithNearbyTextFilter} read it;</li>
+ * <li>a {@code disable} comment opens a range that the matching
+ * {@code enable} comment closes, or the end of the file does, the way
+ * {@code SuppressWithPlainTextCommentFilter} reads it.</li>
  * </ul>
  *
  * <p>A tag inside a string or character literal is left alone, since it is

--- a/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
+++ b/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
@@ -52,7 +52,7 @@ public class Arguments {
 
     /**
      * Checks for consistency the order of arguments and their Javadoc
-     *  parameters.
+     * parameters.
      * @param tags Javadoc parameter tags
      * @param consumer Consumer accepts JavadocTag which is located out of
      *  order

--- a/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
+++ b/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 /**
  * Abstract parameters. Is used for Generic type parameters or
- *  method(constructor) arguments.
+ * method(constructor) arguments.
  * @since 0.18.18
  */
 public class Parameters {

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -461,6 +461,7 @@
     <module name="com.qulice.checkstyle.JavadocEmptyLineCheck"/>
     <module name="com.qulice.checkstyle.JavadocEmptyLineBeforeTagCheck"/>
     <module name="com.qulice.checkstyle.JavadocFirstLineCheck"/>
+    <module name="com.qulice.checkstyle.JavadocNoIndentCheck"/>
     <module name="com.qulice.checkstyle.DiamondOperatorCheck"/>
     <module name="com.qulice.checkstyle.JavadocParameterOrderCheck"/>
     <module name="com.qulice.checkstyle.JavadocTagsCheck"/>

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -219,6 +219,7 @@ final class ChecksTest {
             "JavadocEmptyLineCheck",
             "JavadocEmptyLineBeforeTagCheck",
             "JavadocFirstLineCheck",
+            "JavadocNoIndentCheck",
             "JavadocTagsCheck",
             "JavadocTagsDotCheck",
             "JavadocThrowsCheck",

--- a/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
@@ -74,7 +74,7 @@ final class UseStringIsEmptyRuleTest {
 
     /**
      * UseStringIsEmpty not detect when used String[].length, when checking for
-     *  empty string.
+     * empty string.
      * @throws Exception If something goes wrong.
      */
     @Test

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/Invalid.java
@@ -1,0 +1,44 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in ChecksTest.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is a paragraph.
+ *     This line is over-indented and must be reported.
+ */
+public final class Invalid {
+
+    /**
+     * First sentence.
+     *   Over-indented body line.
+     */
+    private static final int X = 0;
+
+    /**
+     * Some list of items.
+     *
+     * <ul>
+     *  <li>Over-indented list item.
+     * </ul>
+     */
+    private int field = 0;
+
+    /**
+     * Some text before a snippet.
+     *  Over-indented body line after the summary.
+     */
+    private int other = 0;
+
+    /**
+     * A method with a tag.
+     *   Over-indented line before the tag.
+     * @param arg Some argument that wraps onto the
+     *  next line with one extra space, which is fine
+     * @return Nothing at all
+     */
+    public String method(final String arg) {
+        return arg;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/Valid.java
@@ -1,0 +1,53 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in ChecksTest.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is a paragraph.
+ * This line has exactly one space of indentation.
+ */
+public final class Valid {
+
+    /**
+     * A code sample that must keep its indentation.
+     *
+     * <pre>
+     * if (x) {
+     *     y();
+     *         deeper();
+     * }
+     * </pre>
+     */
+    private static final int X = 0;
+
+    /**
+     * A snippet that must keep its indentation.
+     *
+     * {@snippet :
+     *     System.out.println("hello");
+     *         System.out.println("world");
+     * }
+     */
+    private int field = 0;
+
+    /**
+     * A method with wrapped tags.
+     * @param arg Some argument description that is long and
+     *  wraps onto the next line with one extra space
+     * @return Some value that also has a description wrapping
+     *  onto a second line, indented by one extra space
+     */
+    public String method(final String arg) {
+        return arg;
+    }
+
+    /**
+     * An inline snippet {@snippet foo} on a single line.
+     * Some more text right after it.
+     */
+    public void second() {
+        // nothing
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.JavadocNoIndentCheck"/>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/violations.txt
@@ -1,0 +1,5 @@
+9:Extra indentation is not allowed in Javadoc
+15:Extra indentation is not allowed in Javadoc
+23:Extra indentation is not allowed in Javadoc
+30:Extra indentation is not allowed in Javadoc
+36:Extra indentation is not allowed in Javadoc

--- a/src/test/resources/com/qulice/checkstyle/ValidLiteralComparisonCheck.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidLiteralComparisonCheck.java
@@ -4,27 +4,27 @@
 package foo;
 
 /**
- *  Simple.
- *  @since 1.0
+ * Simple.
+ * @since 1.0
  */
 public final class ValidLiteralComparisonCheck {
 
     /**
-     *  Some text.
+     * Some text.
      */
     private final String text;
 
     /**
-     *  Constructor.
-     *  @param  txt  Some text.
+     * Constructor.
+     * @param txt Some text
      */
     public ValidLiteralCheck(final String txt) {
         this.text = txt;
     }
 
     /**
-     *   Method using input.equals("contents")
-     *    instead of "contents".equals(input).
+     * Method using input.equals("contents")
+     * instead of "contents".equals(input).
      */
     public void validStringComparison() {
         System.out.println(this.text.equals("contents"));


### PR DESCRIPTION
Closes #1708.

## What & why

Nothing in Qulice's checks prevented a Javadoc paragraph line from carrying extra leading whitespace after the `*`. `JavadocParagraph` only governs `<p>` tag placement, so this slipped through:

```java
/**
 * This is a paragraph.
 *     This line is over-indented and nothing flagged it.
 */
```

This PR adds a new custom check, `JavadocNoIndentCheck`, that forbids it.

## How it works

For every Javadoc body line, the text after the leading `*` must start with **exactly one space** before the first non-space character; anything more is a violation. Exceptions, as agreed in the issue:

- Lines inside a `<pre>...</pre>` block (tracked with a case-insensitive `<pre>`/`</pre>` toggle).
- Lines inside a `{@snippet ...}` block, inline or multi-line (tracked with a brace-depth counter, since the block form can span lines and nest braces).
- Block tags (`@param`, `@return`, …) and their wrapped continuation lines, whose indentation is already governed by `JavadocTagContinuationIndentation` and `MultilineJavadocTagsCheck`.

Following the issue's guidance, it is a plain `AbstractCheck` operating on `this.getLines()` and reusing the comment-start/comment-end helpers already duplicated across `JavadocEmptyLineCheck` and `MultilineJavadocTagsCheck`, rather than introducing `AbstractJavadocCheck`/`DetailNode` parsing.

## Changes

- **New**: `JavadocNoIndentCheck.java`.
- **Registered** in `checks.xml` (alphabetically among the custom Javadoc checks) and in `ChecksTest`.
- **Test fixtures** under `src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocNoIndentCheck/` (`Invalid.java`, `Valid.java`, `config.xml`, `violations.txt`) covering over-indented paragraphs and `<li>` items, plus the `<pre>`, `{@snippet}`, and tag-continuation exemptions.
- **Fixed** the resulting over-indentation in Qulice's own sources (`Suppressions`, `ProhibitNonFinalClassesCheck`, `Arguments`, `Parameters`, and one test) and normalized the `ValidLiteralComparisonCheck` fixture's Javadoc.

## Verification

- `ChecksTest` (84 cases) and `CheckstyleValidatorTest` pass.
- `mvn -Pqulice verify` (Qulice validating itself with the new check enabled) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013M6kEZSnpSxLjTmXr4uZu2)_