### PR TITLE
fix(checkstyle): #1703 ignore java.lang. inside string literals

### DIFF
--- a/src/main/java/com/qulice/checkstyle/UnnecessaryJavaLangCheck.java
+++ b/src/main/java/com/qulice/checkstyle/UnnecessaryJavaLangCheck.java
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Prohibits the redundant {@code java.lang.} prefix in front of a simple
+ * class name.
+ *
+ * <p>Classes from the {@code java.lang} package are imported implicitly,
+ * so qualifying them with their package name adds nothing. A field whose
+ * type is written with the {@code java.lang.} prefix should instead be
+ * declared as {@code private final String name}, in both code and Javadoc.
+ *
+ * <p>Unlike a plain line-based regular expression, this check ignores the
+ * prefix when it appears inside a string literal or a text block. A string
+ * constant that happens to contain the {@code java.lang.} substring is data,
+ * not a type reference, and must not be reported. See
+ * <a href="https://github.com/yegor256/qulice/issues/1703">#1703</a>.
+ *
+ * @since 0.24
+ */
+public final class UnnecessaryJavaLangCheck extends AbstractCheck {
+
+    /**
+     * Matches the redundant prefix in front of a class name (a capital
+     * letter). Sub-packages such as {@code java.lang.reflect} start with a
+     * lower-case letter and are intentionally left alone.
+     */
+    private static final Pattern PREFIX =
+        Pattern.compile("\\bjava\\.lang\\.[A-Z]");
+
+    /**
+     * Line-separator character embedded in the text of a text-block node.
+     */
+    private static final char EOL = '\n';
+
+    /**
+     * Mutable copy of the file lines, with the contents of string literals
+     * and text blocks blanked out so the pattern cannot match inside them.
+     */
+    private char[][] lines;
+
+    /**
+     * Default constructor.
+     */
+    public UnnecessaryJavaLangCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {
+            TokenTypes.STRING_LITERAL,
+            TokenTypes.TEXT_BLOCK_CONTENT,
+        };
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[0];
+    }
+
+    @Override
+    public void beginTree(final DetailAST root) {
+        final String[] source = this.getLines();
+        this.lines = new char[source.length][];
+        for (int pos = 0; pos < source.length; ++pos) {
+            this.lines[pos] = source[pos].toCharArray();
+        }
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        if (ast.getType() == TokenTypes.STRING_LITERAL) {
+            this.blank(
+                ast.getLineNo(), ast.getColumnNo(), ast.getText().length()
+            );
+        } else {
+            this.blankBlock(ast);
+        }
+    }
+
+    @Override
+    public void finishTree(final DetailAST root) {
+        for (int pos = 0; pos < this.lines.length; ++pos) {
+            final Matcher matcher =
+                UnnecessaryJavaLangCheck.PREFIX.matcher(
+                    String.valueOf(this.lines[pos])
+                );
+            while (matcher.find()) {
+                this.log(
+                    pos + 1,
+                    "Unnecessary java.lang. prefix, use the simple class name"
+                );
+            }
+        }
+    }
+
+    /**
+     * Blank out every line spanned by a text-block content node. Those
+     * lines hold only string data, so the pattern must never match there.
+     * @param ast The {@code TEXT_BLOCK_CONTENT} node
+     */
+    private void blankBlock(final DetailAST ast) {
+        final String text = ast.getText();
+        int span = 0;
+        for (int pos = 0; pos < text.length(); ++pos) {
+            if (text.charAt(pos) == UnnecessaryJavaLangCheck.EOL) {
+                ++span;
+            }
+        }
+        final int first = ast.getLineNo();
+        for (int line = first; line <= first + span; ++line) {
+            final int index = line - 1;
+            if (index >= 0 && index < this.lines.length) {
+                this.blank(line, 0, this.lines[index].length);
+            }
+        }
+    }
+
+    /**
+     * Replace with spaces a run of characters on a single line, so that
+     * the {@code java.lang.} pattern cannot match inside it.
+     * @param line One-based line number
+     * @param column Zero-based column where the run starts
+     * @param length Number of characters to blank
+     */
+    private void blank(final int line, final int column, final int length) {
+        final int index = line - 1;
+        if (index >= 0 && index < this.lines.length) {
+            final char[] chars = this.lines[index];
+            final int from = Math.max(0, Math.min(column, chars.length));
+            final int upto = Math.min(column + length, chars.length);
+            for (int pos = from; pos < upto; ++pos) {
+                chars[pos] = ' ';
+            }
+        }
+    }
+}

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -431,6 +431,18 @@
     <module name="com.qulice.checkstyle.EmptyLineBeforeFirstMemberCheck"/>
     <module name="com.qulice.checkstyle.StringLiteralsConcatenationCheck"/>
     <module name="com.qulice.checkstyle.ProhibitLineSeparatorInStringsCheck"/>
+    <!--
+    Classes from the 'java.lang' package are imported implicitly,
+    so the 'java.lang.' prefix is redundant in both code and Javadoc.
+    Unlike a plain line regexp, this check skips the substring when it
+    appears inside a string literal or text block, where it is data
+    rather than a type reference.
+    See https://github.com/yegor256/qulice/issues/690
+    and https://github.com/yegor256/qulice/issues/1703
+    -->
+    <module name="com.qulice.checkstyle.UnnecessaryJavaLangCheck">
+      <property name="id" value="UnnecessaryJavaLang"/>
+    </module>
     <module name="com.qulice.checkstyle.MultilineJavadocTagsCheck"/>
     <module name="com.qulice.checkstyle.NoJavadocForOverriddenMethodsCheck"/>
     <module name="com.qulice.checkstyle.MethodBodyCommentsCheck"/>
@@ -733,17 +745,6 @@
     <property name="message" value="Lists.newArrayList should be initialized with a size parameter"/>
     <property name="id" value="GuavaNewArrayListShouldBeInitWithSize"/>
     <property name="fileExtensions" value="java"/>
-  </module>
-  <!--
-  Classes from the 'java.lang' package are imported implicitly,
-  so the 'java.lang.' prefix is redundant in both code and Javadoc.
-  See https://github.com/yegor256/qulice/issues/690
-  -->
-  <module name="RegexpSingleline">
-    <property name="format" value="\bjava\.lang\.[A-Z]"/>
-    <property name="fileExtensions" value="java"/>
-    <property name="id" value="UnnecessaryJavaLang"/>
-    <property name="message" value="Unnecessary 'java.lang.' prefix, use the simple class name"/>
   </module>
   <!--
   Checks below complete the coverage of Checkstyle 13.9.0. Every module

--- a/src/test/java/com/qulice/checkstyle/CheckstyleBannedApiTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleBannedApiTest.java
@@ -89,7 +89,7 @@ final class CheckstyleBannedApiTest {
         final String message =
             "Unnecessary java.lang. prefix, use the simple class name";
         final String file = "UnnecessaryJavaLang.java";
-        final String name = "RegexpSinglelineCheck";
+        final String name = "UnnecessaryJavaLangCheck";
         MatcherAssert.assertThat(
             "cannot find all java.lang. violations",
             this.runValidation(file, false),
@@ -98,6 +98,25 @@ final class CheckstyleBannedApiTest {
                 new ViolationMatcher(message, file, "18", name),
                 new ViolationMatcher(message, file, "23", name),
                 new ViolationMatcher(message, file, "25", name)
+            )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void ignoresJavaLangInsideStringLiterals() throws Exception {
+        final String message =
+            "Unnecessary java.lang. prefix, use the simple class name";
+        final String file = "UnnecessaryJavaLang.java";
+        final String name = "UnnecessaryJavaLangCheck";
+        MatcherAssert.assertThat(
+            "java.lang. inside a string literal or text block must be ignored",
+            this.runValidation(file, false),
+            Matchers.not(
+                Matchers.anyOf(
+                    Matchers.hasItem(new ViolationMatcher(message, file, "43", name)),
+                    Matchers.hasItem(new ViolationMatcher(message, file, "52", name))
+                )
             )
         );
     }

--- a/src/test/resources/com/qulice/checkstyle/UnnecessaryJavaLang.java
+++ b/src/test/resources/com/qulice/checkstyle/UnnecessaryJavaLang.java
@@ -34,4 +34,22 @@ public final class UnnecessaryJavaLang {
         final Method method = null;
         return this.name.length() + System.identityHashCode(method);
     }
+
+    /**
+     * Xpath query used as test data.
+     * @return Query string
+     */
+    public String xpath() {
+        return "op/name[text() = 'java.lang.String.length']";
+    }
+
+    /**
+     * Xpath query kept in a text block.
+     * @return Query string
+     */
+    public String snippet() {
+        return """
+            op/name[text() = 'java.lang.String.length']
+            """;
+    }
 }


### PR DESCRIPTION
Fixes #1703.

## Problem

The `UnnecessaryJavaLang` rule was a `RegexpSingleline` module matching the raw regex `\bjava\.lang\.[A-Z]` against every line of a `.java` file, with no awareness of string literals. It therefore fired on any string constant that merely contained the substring `java.lang.`, even when that text was data rather than a type reference — e.g. an XPath assertion like `"op/name[text() = 'java.lang.String.length']"`, where there is no type to shorten.

## Change

- Replaced the line-based `RegexpSingleline` with a new `TreeWalker` check, `UnnecessaryJavaLangCheck`. It takes a mutable copy of the file's lines, blanks out the contents of every `STRING_LITERAL` and `TEXT_BLOCK_CONTENT` node, then applies the same `\bjava\.lang\.[A-Z]` pattern to the sanitized lines.
- The result: genuine type and Javadoc references (including `@see`/`@throws` tags) are still reported exactly as before, while occurrences inside string literals and text blocks are ignored. Sub-packages such as `java.lang.reflect` remain untouched because they start with a lower-case letter.
- The module keeps the `id="UnnecessaryJavaLang"` and the same violation message, so existing suppressions and behaviour are preserved.

## Tests

- Extended the `UnnecessaryJavaLang.java` test resource with a string literal and a text block that both contain `java.lang.String.length`.
- Kept `reportsUnnecessaryJavaLangPrefix` asserting the four real violations (updated the check name to `UnnecessaryJavaLangCheck`) and added `ignoresJavaLangInsideStringLiterals` asserting the literal and text-block lines are not reported.
- The full `com.qulice.checkstyle` test package (184 tests) passes, and the new check passes qulice's own style rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144qn11GPqkCupMy4f8ggva

---
_Generated by [Claude Code](https://claude.ai/code/session_0144qn11GPqkCupMy4f8ggva)_