### PR TITLE
fix(pmd): #1704 ImplicitFunctionalInterface ignores inherited abstract methods

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/ImplicitFunctionalInterfaceRule.java
+++ b/src/main/java/com/qulice/pmd/rules/ImplicitFunctionalInterfaceRule.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd.rules;
+
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.JModifier;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.types.JClassType;
+import net.sourceforge.pmd.lang.java.types.TypeOps;
+
+/**
+ * Rule to flag an interface that is implicitly functional (declares exactly
+ * one abstract method) but is not annotated with {@code @FunctionalInterface}.
+ *
+ * <p>Unlike PMD's built-in {@code ImplicitFunctionalInterface} rule, this
+ * variant refuses to fire when the interface extends a super-interface whose
+ * type PMD cannot resolve. The built-in rule counts only the abstract methods
+ * it can see: when a super-interface is unresolved (for instance because
+ * Qulice runs PMD without an auxiliary classpath, so types declared in other
+ * files are invisible), the rule misses the abstract methods that
+ * super-interface contributes and wrongly reports the interface as functional.
+ * Adding the suggested {@code @FunctionalInterface} annotation to such an
+ * interface does not compile, because the interface really has more than one
+ * abstract method. An interface with a single visible method whose full set of
+ * inherited abstract methods cannot be computed is therefore left alone. Once
+ * the whole super-interface hierarchy resolves, the check is exactly the same
+ * as the built-in one: fire only when the interface has a single abstract
+ * method overall.</p>
+ *
+ * @since 1.0
+ */
+public final class ImplicitFunctionalInterfaceRule
+    extends AbstractJavaRulechainRule {
+
+    /**
+     * Default constructor.
+     */
+    public ImplicitFunctionalInterfaceRule() {
+        super(ASTClassDeclaration.class);
+    }
+
+    @Override
+    public Object visit(final ASTClassDeclaration node, final Object data) {
+        if (ImplicitFunctionalInterfaceRule.implicit(node)
+            && ImplicitFunctionalInterfaceRule.resolved(node.getTypeMirror())
+            && TypeOps.findFunctionalInterfaceMethod(
+                node.getTypeMirror()
+            ) != null) {
+            this.asCtx(data).addViolation(node);
+        }
+        return null;
+    }
+
+    /**
+     * Tells whether the given type is an interface that could carry a
+     * {@code @FunctionalInterface} annotation but does not, ignoring sealed
+     * interfaces that cannot be functional at all.
+     * @param node The type declaration to inspect
+     * @return True if the interface is a candidate for the annotation
+     */
+    private static boolean implicit(final ASTClassDeclaration node) {
+        return node.isRegularInterface()
+            && !node.isAnnotationPresent(FunctionalInterface.class)
+            && !node.hasModifiers(JModifier.SEALED);
+    }
+
+    /**
+     * Tells whether every super-interface in the whole hierarchy of the given
+     * type has been resolved by PMD. Only when they all resolve can the total
+     * number of inherited abstract methods be trusted.
+     * @param type The interface type to inspect
+     * @return True if the entire super-interface hierarchy is resolved
+     */
+    private static boolean resolved(final JClassType type) {
+        boolean result = true;
+        for (final JClassType parent : type.getSuperInterfaces()) {
+            if (parent.getSymbol().isUnresolved()
+                || !ImplicitFunctionalInterfaceRule.resolved(parent)) {
+                result = false;
+                break;
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -80,6 +80,19 @@
     Downstream: https://github.com/yegor256/qulice/issues/1064
     -->
     <exclude name="UnitTestShouldUseTestAnnotation"/>
+    <!--
+    ImplicitFunctionalInterface counts only the abstract methods it can
+    see, so an interface that declares one method of its own but extends
+    other interfaces adding more abstract methods is wrongly reported as
+    functional whenever those super-interfaces cannot be resolved (Qulice
+    runs PMD without an auxiliary classpath, so types declared elsewhere
+    are invisible). Adding the suggested @FunctionalInterface then fails to
+    compile. We use our own ImplicitFunctionalInterface rule instead, which
+    stays silent unless the whole super-interface hierarchy resolves and the
+    interface truly has a single abstract method overall.
+    Downstream: https://github.com/yegor256/qulice/issues/1704
+    -->
+    <exclude name="ImplicitFunctionalInterface"/>
   </rule>
   <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP">
     <properties>
@@ -509,6 +522,17 @@
     <priority>3</priority>
   </rule>
   <rule name="UnnecessaryLocalRule" message="Avoid creating unnecessary local variables like ''{0}''" language="java" class="com.qulice.pmd.rules.UnnecessaryLocalRule">
+  </rule>
+  <rule name="ImplicitFunctionalInterface" message="Annotate this interface with @FunctionalInterface or with @SuppressWarnings(&quot;PMD.ImplicitFunctionalInterface&quot;) to clarify your intent." language="java" class="com.qulice.pmd.rules.ImplicitFunctionalInterfaceRule">
+    <description>
+      An interface with a single abstract method should be annotated with
+      @FunctionalInterface to clarify intent. Unlike PMD's built-in
+      ImplicitFunctionalInterface rule, this variant does not fire when the
+      interface extends a super-interface that PMD cannot resolve, since the
+      total number of inherited abstract methods is then unknown and the
+      suggested annotation might not compile.
+    </description>
+    <priority>3</priority>
   </rule>
   <rule name="ConstructorShouldDoInitialization" message="Avoid doing field initialization outside constructor." language="java" class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
     <description>

--- a/src/test/java/com/qulice/pmd/ImplicitFunctionalInterfaceRuleTest.java
+++ b/src/test/java/com/qulice/pmd/ImplicitFunctionalInterfaceRuleTest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd;
+
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for
+ * {@link com.qulice.pmd.rules.ImplicitFunctionalInterfaceRule}.
+ * @since 1.0
+ */
+final class ImplicitFunctionalInterfaceRuleTest {
+
+    /**
+     * Name of the rule as it appears in violation reports.
+     */
+    private static final String RULE = "(ImplicitFunctionalInterface)";
+
+    @Test
+    void flagsInterfaceWithSingleAbstractMethod() throws Exception {
+        new PmdAssert(
+            "ImplicitFunctionalInterfaceSingle.java",
+            new IsEqual<>(false),
+            Matchers.containsString(
+                ImplicitFunctionalInterfaceRuleTest.RULE
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void flagsInterfaceExtendingResolvedMarker() throws Exception {
+        new PmdAssert(
+            "ImplicitFunctionalInterfaceMarkerParent.java",
+            new IsEqual<>(false),
+            Matchers.containsString(
+                ImplicitFunctionalInterfaceRuleTest.RULE
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void ignoresInterfaceExtendingUnresolvedParents() throws Exception {
+        new PmdAssert(
+            "ImplicitFunctionalInterfaceUnresolvedParent.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString(
+                    ImplicitFunctionalInterfaceRuleTest.RULE
+                )
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void ignoresInterfaceExtendingResolvedParentWithMoreMethods()
+        throws Exception {
+        new PmdAssert(
+            "ImplicitFunctionalInterfaceJdkParent.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString(
+                    ImplicitFunctionalInterfaceRuleTest.RULE
+                )
+            )
+        ).assertOk();
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ImplicitFunctionalInterfaceJdkParent.java
+++ b/src/test/resources/com/qulice/pmd/ImplicitFunctionalInterfaceJdkParent.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.util.Collection;
+
+public interface ImplicitFunctionalInterfaceJdkParent
+    extends Collection<String> {
+    String exception(String text);
+}

--- a/src/test/resources/com/qulice/pmd/ImplicitFunctionalInterfaceMarkerParent.java
+++ b/src/test/resources/com/qulice/pmd/ImplicitFunctionalInterfaceMarkerParent.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.io.Serializable;
+
+public interface ImplicitFunctionalInterfaceMarkerParent extends Serializable {
+    String exception(String text);
+}

--- a/src/test/resources/com/qulice/pmd/ImplicitFunctionalInterfaceSingle.java
+++ b/src/test/resources/com/qulice/pmd/ImplicitFunctionalInterfaceSingle.java
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public interface ImplicitFunctionalInterfaceSingle {
+    String exception(String text);
+}

--- a/src/test/resources/com/qulice/pmd/ImplicitFunctionalInterfaceUnresolvedParent.java
+++ b/src/test/resources/com/qulice/pmd/ImplicitFunctionalInterfaceUnresolvedParent.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public interface ImplicitFunctionalInterfaceUnresolvedParent
+    extends org.example.Mentioned, org.example.Signature {
+    String exception(String text);
+}


### PR DESCRIPTION
Closes #1704.

## Problem

PMD's built-in `ImplicitFunctionalInterface` rule suggests annotating an
interface with `@FunctionalInterface` whenever it can see exactly one
abstract method. It counts only the methods it manages to resolve. When an
interface declares one method of its own but *extends* other interfaces that
contribute more abstract methods, and those super-interfaces cannot be
resolved, the rule misses the inherited methods and reports a false positive.

Qulice runs PMD without an auxiliary classpath, so types declared in other
source files are invisible to PMD's type resolution. For an interface such as
requs' `Step`:

```java
public interface Step extends Mentioned, Signature {
    Flow exception(String text);
}
```

PMD sees only `exception` and reports `ImplicitFunctionalInterface`. Adding
the suggested annotation then fails to compile, because `Step` actually has
seven abstract methods:

```
error: Unexpected @FunctionalInterface annotation
  Step is not a functional interface
    multiple non-overriding abstract methods found in interface Step
```

## Fix

Exclude the built-in `ImplicitFunctionalInterface` from the `bestpractices`
bulk import and re-enable it as a custom
`com.qulice.pmd.rules.ImplicitFunctionalInterfaceRule`. The custom rule keeps
the upstream behaviour (regular, non-sealed interface, not already annotated,
single abstract method computed by `TypeOps.findFunctionalInterfaceMethod`)
but adds one guard: it walks the entire super-interface hierarchy and stays
silent if any super-interface is unresolved. When the total set of inherited
abstract methods cannot be trusted, the rule does not fire, so it never
suggests an annotation that would not compile. Once the whole hierarchy
resolves, the behaviour is identical to the built-in rule.

## Verification

New per-rule test `ImplicitFunctionalInterfaceRuleTest` covers:

- single abstract method, no supers → **flagged** (genuinely functional);
- extends a resolved marker (`Serializable`) + one method → **flagged**
  (still genuinely functional);
- extends **unresolved** super-interfaces + one method → **not flagged**
  (the #1704 false positive);
- extends a resolved parent (`java.util.Collection`) that adds methods →
  **not flagged** (more than one abstract method overall).

All 133 PMD-module tests pass and `mvn -Pqulice qulice:check` is green on the
whole codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BG9HeHLP3fd31NQDbHmYNT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BG9HeHLP3fd31NQDbHmYNT)_