### PR TITLE
fix(pmd): #1717 allow comparing Future by reference

### DIFF
--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -392,6 +392,41 @@
     -->
     <exclude name="MissingSerialVersionUID"/>
     <exclude name="TestClassWithoutTestCases"/>
+    <!--
+    CompareObjectsWithEquals is excluded from the bulk import here and
+    re-enabled below with an extended 'typesThatCompareByReference' so
+    that a 'java.util.concurrent.Future' is allowed to be compared with
+    '=='. ErrorProne's UndefinedEquals / CollectionUndefinedEquality
+    forbid calling equals() on a Future (it has no well-defined equality
+    semantics), so reference identity is the only sound way to recognise
+    the same future; without this override the two checkers contradict
+    each other on the same line. This mirrors 0.30.4 disabling
+    OperatorPrecedence for the analogous Checkstyle/ErrorProne
+    contradiction (#1705).
+    Downstream: https://github.com/yegor256/qulice/issues/1717
+    -->
+    <exclude name="CompareObjectsWithEquals"/>
+  </rule>
+  <!--
+  CompareObjectsWithEquals wants equals() for every object comparison,
+  but a 'java.util.concurrent.Future' has no meaningful equals() contract,
+  so ErrorProne's UndefinedEquals fires on 'future.equals(other)' and its
+  CollectionUndefinedEquality fires on a Future used as a Map key. Adding
+  'java.util.concurrent.Future' to 'typesThatCompareByReference' (whose
+  defaults are 'java.lang.Enum,java.lang.Class') lets PMD accept the '=='
+  that is the only sound comparison, and since the rule matches by subtype
+  it also covers 'java.util.concurrent.CompletableFuture' and the rest of
+  the Future family. The broader interfaces in ErrorProne's
+  TypesWithUndefinedEquality list (CharSequence, Collection, Iterable, ...)
+  are deliberately left out: the rule matches subtypes, so listing them
+  would also stop flagging '==' on a 'String', a 'List' or a 'Set', where
+  reference comparison usually is a bug.
+  Downstream: https://github.com/yegor256/qulice/issues/1717
+  -->
+  <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals">
+    <properties>
+      <property name="typesThatCompareByReference" value="java.lang.Enum,java.lang.Class,java.util.concurrent.Future"/>
+    </properties>
   </rule>
   <!--
   Recognise io.github.artsok annotations (@RepeatedIfExceptionsTest,

--- a/src/test/java/com/qulice/pmd/PmdCompareObjectsWithEqualsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdCompareObjectsWithEqualsTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link PmdValidator}'s handling of the
+ * {@code CompareObjectsWithEquals} rule.
+ * @since 1.0
+ */
+final class PmdCompareObjectsWithEqualsTest {
+
+    @Test
+    void allowsComparingFuturesByReference() throws Exception {
+        new PmdAssert(
+            "CompareFuturesWithEquals.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("(CompareObjectsWithEquals)")
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void forbidsComparingPlainObjectsByReference() throws Exception {
+        new PmdAssert(
+            "CompareObjectsByReference.java",
+            Matchers.is(false),
+            Matchers.containsString("(CompareObjectsWithEquals)")
+        ).assertOk();
+    }
+}

--- a/src/test/resources/com/qulice/pmd/CompareFuturesWithEquals.java
+++ b/src/test/resources/com/qulice/pmd/CompareFuturesWithEquals.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public final class CompareFuturesWithEquals {
+
+    private final Map<Integer, Future<?>> futures;
+
+    public CompareFuturesWithEquals(final Map<Integer, Future<?>> map) {
+        this.futures = map;
+    }
+
+    public int threadOf(final Future<?> future) {
+        int thread = -1;
+        for (final Map.Entry<Integer, Future<?>> entry : this.futures.entrySet()) {
+            if (entry.getValue() == future) {
+                thread = entry.getKey();
+                break;
+            }
+        }
+        return thread;
+    }
+}

--- a/src/test/resources/com/qulice/pmd/CompareObjectsByReference.java
+++ b/src/test/resources/com/qulice/pmd/CompareObjectsByReference.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class CompareObjectsByReference {
+
+    public boolean same(final Object left, final Object right) {
+        return left == right;
+    }
+}


### PR DESCRIPTION
Closes #1717.

## Problem

Comparing two `java.util.concurrent.Future` references cannot satisfy PMD and ErrorProne at the same time:

- `entry.getValue() == future` → PMD's `CompareObjectsWithEquals` fires ("Use equals() to compare object references").
- `entry.getValue().equals(future)` → ErrorProne's `UndefinedEquals` fires ("Future does not have well-defined equality semantics").
- Keying a `Map` by the `Future` and using `Map#get` → ErrorProne's `CollectionUndefinedEquality` fires.

A `Future` genuinely has no meaningful `equals()` contract, so reference identity (`==`) is the only sound way to recognise "the same future".

## Fix

In `src/main/resources/com/qulice/pmd/ruleset.xml`, `CompareObjectsWithEquals` is now excluded from the bulk `errorprone` import and re-enabled with an extended `typesThatCompareByReference` property:

```
java.lang.Enum,java.lang.Class,java.util.concurrent.Future
```

The first two are PMD's defaults, kept intact. The rule matches by subtype (`pmd-java:typeIs`), so adding `java.util.concurrent.Future` also covers `java.util.concurrent.CompletableFuture` and the rest of the `Future` family.

The broader interfaces from ErrorProne's `TypesWithUndefinedEquality` list (`CharSequence`, `Collection`, `Iterable`, ...) are **deliberately left out**: because matching is by subtype, listing them would also stop flagging `==` on a `String`, a `List` or a `Set`, where reference comparison is usually a real bug. This mirrors how 0.30.4 disabled `OperatorPrecedence` for the analogous Checkstyle/ErrorProne contradiction (#1705).

## Tests

`PmdCompareObjectsWithEqualsTest` adds two cases:

- `allowsComparingFuturesByReference` — the `Future ==` idiom from the issue is no longer flagged.
- `forbidsComparingPlainObjectsByReference` — a plain `Object ==` comparison is still flagged, proving the rule remains active.

All 136 tests in the `com.qulice.pmd` package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EioVxaC45zLwQLfH4bwRoA)_