### PR TITLE
fix(errorprone): #1716 pin forked javac to project's source level

### DIFF
--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -194,6 +194,7 @@ public final class ErrorProneValidator implements ResourceValidator {
         args.add("-XDaddTypeAnnotationsToSymbol=true");
         args.add("--should-stop=ifError=FLOW");
         args.add("-proc:none");
+        args.addAll(this.release());
         args.add(ErrorProneValidator.PLUGIN);
         args.add("-processorpath");
         args.add(ErrorProneValidator.pluginClasspath());
@@ -241,6 +242,79 @@ public final class ErrorProneValidator implements ResourceValidator {
             }
         }
         return violations;
+    }
+
+    /**
+     * The {@code javac} flags that pin the forked compiler to the project's
+     * own Java source level.
+     *
+     * <p>Without them the forked {@code javac} runs at the host JDK's default
+     * language level (e.g. 21 on a JDK 21 host), so ErrorProne fires
+     * syntax-modernising checks such as {@code PatternMatchingInstanceof}
+     * even on projects that compile at {@code -source 8}, producing
+     * suggestions whose rewrite does not compile under the project's real
+     * source level. The level is derived exactly as
+     * {@code CheckstyleValidator} derives it: {@code maven.compiler.release}
+     * first, then {@code maven.compiler.source}, accepting both the modern
+     * ({@code "8"}, {@code "17"}) and legacy ({@code "1.8"}) forms. When the
+     * project pins a {@code release}, {@code --release} is forwarded;
+     * otherwise {@code -source}/{@code -target} are, which gates the language
+     * features while leaving the API surface untouched so that projects using
+     * newer library APIs under a plain {@code -source} build do not gain
+     * spurious "cannot find symbol" errors. When neither property is set the
+     * level is unknown and nothing is added, leaving the host default in
+     * place. See
+     * <a href="https://github.com/yegor256/qulice/issues/1716">#1716</a>.</p>
+     *
+     * @return Source-level flags, possibly empty
+     */
+    private List<String> release() {
+        final List<String> flags = new ArrayList<>(4);
+        final int rel = ErrorProneValidator.parse(
+            this.env.param("maven.compiler.release", "")
+        );
+        if (rel >= 0) {
+            flags.add("--release");
+            flags.add(String.valueOf(rel));
+        } else {
+            final int source = ErrorProneValidator.parse(
+                this.env.param("maven.compiler.source", "")
+            );
+            if (source >= 0) {
+                int target = ErrorProneValidator.parse(
+                    this.env.param("maven.compiler.target", "")
+                );
+                if (target < 0) {
+                    target = source;
+                }
+                flags.add("-source");
+                flags.add(String.valueOf(source));
+                flags.add("-target");
+                flags.add(String.valueOf(target));
+            }
+        }
+        return flags;
+    }
+
+    /**
+     * Parse a Java version string into its major number.
+     * @param value Version, e.g. {@code "8"}, {@code "1.8"} or {@code "17"}
+     * @return The major version, or {@code -1} if it cannot be parsed
+     */
+    private static int parse(final String value) {
+        int result = -1;
+        if (value != null) {
+            String txt = value.trim();
+            if (txt.startsWith("1.")) {
+                txt = txt.substring(2);
+            }
+            try {
+                result = Integer.parseInt(txt);
+            } catch (final NumberFormatException ex) {
+                result = -1;
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -270,30 +270,43 @@ public final class ErrorProneValidator implements ResourceValidator {
      */
     private List<String> release() {
         final List<String> flags = new ArrayList<>(4);
-        final int rel = ErrorProneValidator.parse(
+        final int rel = ErrorProneValidator.major(
             this.env.param("maven.compiler.release", "")
+        );
+        final int source = ErrorProneValidator.major(
+            this.env.param("maven.compiler.source", "")
         );
         if (rel >= 0) {
             flags.add("--release");
             flags.add(String.valueOf(rel));
-        } else {
-            final int source = ErrorProneValidator.parse(
-                this.env.param("maven.compiler.source", "")
-            );
-            if (source >= 0) {
-                int target = ErrorProneValidator.parse(
-                    this.env.param("maven.compiler.target", "")
-                );
-                if (target < 0) {
-                    target = source;
-                }
-                flags.add("-source");
-                flags.add(String.valueOf(source));
-                flags.add("-target");
-                flags.add(String.valueOf(target));
-            }
+        } else if (source >= 0) {
+            flags.add("-source");
+            flags.add(String.valueOf(source));
+            flags.add("-target");
+            flags.add(String.valueOf(this.target(source)));
         }
         return flags;
+    }
+
+    /**
+     * The {@code -target} level to forward alongside {@code -source}.
+     *
+     * <p>Reads {@code maven.compiler.target}, falling back to the given
+     * source level when the project does not pin a target of its own, so
+     * that {@code javac}'s requirement of {@code target >= source} is
+     * always met.</p>
+     *
+     * @param fallback The source level to use when no target is pinned
+     * @return The target level
+     */
+    private int target(final int fallback) {
+        int level = ErrorProneValidator.major(
+            this.env.param("maven.compiler.target", "")
+        );
+        if (level < 0) {
+            level = fallback;
+        }
+        return level;
     }
 
     /**
@@ -301,7 +314,7 @@ public final class ErrorProneValidator implements ResourceValidator {
      * @param value Version, e.g. {@code "8"}, {@code "1.8"} or {@code "17"}
      * @return The major version, or {@code -1} if it cannot be parsed
      */
-    private static int parse(final String value) {
+    private static int major(final String value) {
         int result = -1;
         if (value != null) {
             String txt = value.trim();

--- a/src/test/java/com/qulice/errorprone/ErrorPronePatternMatchingInstanceofTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorPronePatternMatchingInstanceofTest.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.errorprone;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ErrorProneValidator}'s source-level awareness of the
+ * stock {@code PatternMatchingInstanceof} check. The check suggests
+ * pattern-matching {@code instanceof}, a Java 16+ feature, so it must not fire
+ * when the project compiles at an older source level (issue #1716).
+ * @since 1.0
+ */
+final class ErrorPronePatternMatchingInstanceofTest {
+
+    /**
+     * Name of the ErrorProne check under test.
+     */
+    private static final String CHECK = "PatternMatchingInstanceof";
+
+    /**
+     * Path of the sample file, relative to the base directory.
+     */
+    private static final String FILE = "src/main/java/foo/Sample.java";
+
+    /**
+     * A class whose {@code instanceof} followed by a cast to the same type is
+     * exactly what {@code PatternMatchingInstanceof} suggests rewriting.
+     */
+    private static final String SOURCE = String.join(
+        System.lineSeparator(),
+        "package foo;",
+        "/**",
+        " * Sample.",
+        " * @since 1.0",
+        " */",
+        "public final class Sample {",
+        "    /**",
+        "     * Compare with another object.",
+        "     * @param other The other object",
+        "     * @return TRUE if the same",
+        "     */",
+        "    public boolean same(final Object other) {",
+        "        return other instanceof Sample",
+        "            && ((Sample) other).hashCode() == this.hashCode();",
+        "    }",
+        "}"
+    );
+
+    @Test
+    void skipsPatternMatchingInstanceofOnSourceEight() throws Exception {
+        MatcherAssert.assertThat(
+            "PatternMatchingInstanceof must not fire when source is 8",
+            this.checks("8"),
+            Matchers.not(Matchers.hasItem(ErrorPronePatternMatchingInstanceofTest.CHECK))
+        );
+    }
+
+    @Test
+    void skipsPatternMatchingInstanceofOnLegacySourceEight() throws Exception {
+        MatcherAssert.assertThat(
+            "PatternMatchingInstanceof must not fire when source is 1.8",
+            this.checks("1.8"),
+            Matchers.not(Matchers.hasItem(ErrorPronePatternMatchingInstanceofTest.CHECK))
+        );
+    }
+
+    @Test
+    void reportsPatternMatchingInstanceofOnModernSource() throws Exception {
+        MatcherAssert.assertThat(
+            "PatternMatchingInstanceof must fire when source is 17",
+            this.checks("17"),
+            Matchers.hasItem(ErrorPronePatternMatchingInstanceofTest.CHECK)
+        );
+    }
+
+    /**
+     * Run the validator over the sample file with the given source level and
+     * return the names of the checks that produced violations.
+     * @param source Value for {@code maven.compiler.source}, or {@code null}
+     * @return Names of the checks that fired
+     * @throws IOException If some IO problem
+     */
+    private Collection<String> checks(final String source) throws IOException {
+        final Environment.Mock mock = new Environment.Mock();
+        if (source != null) {
+            mock.withParam("maven.compiler.source", source);
+        }
+        final Environment env = mock.withFile(
+            ErrorPronePatternMatchingInstanceofTest.FILE,
+            ErrorPronePatternMatchingInstanceofTest.SOURCE
+        );
+        final Collection<Violation> violations = new ErrorProneValidator(env).validate(
+            Collections.singletonList(
+                new File(env.basedir(), ErrorPronePatternMatchingInstanceofTest.FILE)
+            )
+        );
+        final Collection<String> names = new ArrayList<>(violations.size());
+        for (final Violation violation : violations) {
+            names.add(violation.name());
+        }
+        return names;
+    }
+}


### PR DESCRIPTION
Closes #1716.

## Problem

`ErrorProneValidator` forks `javac` with ErrorProne wired in, but the argfile built in `command()` never passed `-source`/`-target`/`--release`. The forked `javac` therefore ran at whatever language level the active JDK defaults to (e.g. 21/25 on a modern host), independent of the consuming project's real `maven.compiler.source`/`release`.

As a result, syntax-modernising checks tied to newer language features — notably `PatternMatchingInstanceof` (a Java 16+ feature) — fired unconditionally. On projects that compile at `-source 8` (as most `yegor256` libraries do, inherited from `com.jcabi:parent`), applying the suggested rewrite fails to compile:

```
error: pattern matching in instanceof is not supported in -source 8
```

This is the same category of bug as #1690 / #1694, but in the ErrorProne validator rather than PMD/Checkstyle.

## Fix

`ErrorProneValidator.command()` now derives the project's source level exactly the way `CheckstyleValidator.level()` does — reading `maven.compiler.release` first, then falling back to `maven.compiler.source` (accepting both `"8"` and legacy `"1.8"` forms) — and forwards it to the forked `javac`:

- when the project pins a `release`, `--release <n>` is passed;
- otherwise `-source <n> -target <n>` is passed, which gates the language features while leaving the API surface untouched, so projects using newer library APIs under a plain `-source` build don't gain spurious "cannot find symbol" errors;
- when neither property is known, nothing is added and the host default is left in place (avoids silently over-restricting modern projects that don't declare a level).

With the source level pinned, ErrorProne only suggests language features the project is actually allowed to use, so `PatternMatchingInstanceof` no longer fires under `-source 8`.

## Tests

Added `ErrorPronePatternMatchingInstanceofTest`, which runs the validator over a class whose `instanceof`-plus-cast is exactly what `PatternMatchingInstanceof` rewrites:

- `maven.compiler.source=8` → check does **not** fire;
- `maven.compiler.source=1.8` → check does **not** fire;
- `maven.compiler.source=17` → check **does** fire (unchanged behaviour on modern projects).

All ErrorProne module tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HQ6i1KvVJEpNi2aXi7poX

---
_Generated by [Claude Code](https://claude.ai/code/session_016HQ6i1KvVJEpNi2aXi7poX)_