### PR TITLE
fix(pmd): #1698 recognize cactoos-matchers Assertion#affirm() as an assert

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/UnitTestShouldIncludeAssertRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UnitTestShouldIncludeAssertRule.java
@@ -5,10 +5,12 @@
 package com.qulice.pmd.rules;
 
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
+import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 
 /**
  * Rule to check that JUnit/TestNG test methods contain at least one
@@ -16,6 +18,14 @@ import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
  * {@code UnitTestShouldIncludeAssert} rule (PMD #4272), this
  * implementation descends into lambda bodies, so an assertion placed
  * inside a lambda passed to another method is still recognised.
+ *
+ * <p>It also treats the cactoos-matchers convention as an assertion: a
+ * no-argument {@code affirm()} call on an {@code Assertion} object, as in
+ * {@code new Assertion<>(...).affirm()}. PMD's own
+ * {@link TestFrameworksUtil#isProbableAssertCall(ASTMethodCall)} knows only
+ * about JUnit, TestNG, Hamcrest and AssertJ, so without this addition such
+ * tests are wrongly reported as missing an assertion (issue #1698).</p>
+ *
  * @since 0.26.0
  */
 public final class UnitTestShouldIncludeAssertRule
@@ -36,9 +46,47 @@ public final class UnitTestShouldIncludeAssertRule
             && !TestFrameworksUtil.isExpectAnnotated(method)
             && body.descendants(ASTMethodCall.class)
                 .crossFindBoundaries(true)
-                .none(TestFrameworksUtil::isProbableAssertCall)) {
+                .none(UnitTestShouldIncludeAssertRule::isAssertion)) {
             asCtx(data).addViolation(method);
         }
         return data;
+    }
+
+    /**
+     * Does this call look like a test assertion?
+     * @param call The method call to inspect
+     * @return True if it is a recognised assertion
+     */
+    private static boolean isAssertion(final ASTMethodCall call) {
+        return TestFrameworksUtil.isProbableAssertCall(call)
+            || UnitTestShouldIncludeAssertRule.isAffirmCall(call);
+    }
+
+    /**
+     * Is this a no-argument {@code affirm()} call on an {@code Assertion}
+     * object, as used by cactoos-matchers?
+     * @param call The method call to inspect
+     * @return True if it is a cactoos-matchers assertion
+     */
+    private static boolean isAffirmCall(final ASTMethodCall call) {
+        final ASTExpression qualifier = call.getQualifier();
+        return "affirm".equals(call.getMethodName())
+            && call.getArguments().isEmpty()
+            && qualifier != null
+            && UnitTestShouldIncludeAssertRule.isAssertion(qualifier);
+    }
+
+    /**
+     * Is the given expression of a type named {@code Assertion}? The
+     * comparison is by simple name so that it still holds when
+     * cactoos-matchers is absent from the classpath and the type therefore
+     * cannot be fully resolved.
+     * @param expr The expression to inspect
+     * @return True if its type's simple name is {@code Assertion}
+     */
+    private static boolean isAssertion(final ASTExpression expr) {
+        final JTypeDeclSymbol symbol = expr.getTypeMirror().getSymbol();
+        return symbol != null
+            && "Assertion".equals(symbol.getSimpleName());
     }
 }

--- a/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
@@ -223,6 +223,24 @@ final class PmdAssertionsTest {
     }
 
     /**
+     * PmdValidator recognises the cactoos-matchers convention of a
+     * no-argument {@code affirm()} call on an {@code Assertion} object as a
+     * valid assertion and does not report UnitTestShouldIncludeAssert.
+     * Regression test for https://github.com/yegor256/qulice/issues/1698
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    void findsAssertionInAffirmCall() throws Exception {
+        new PmdAssert(
+            "AssertionAffirm.java",
+            Matchers.is(true),
+            Matchers.not(
+                Matchers.containsString("UnitTestShouldIncludeAssert")
+            )
+        ).assertOk();
+    }
+
+    /**
      * PmdValidator does not flag classes that use non-JUnit test conventions
      * like g4s8/oot, where a class ends with {@code *Test} but uses a
      * {@code public static void test()} entry point instead of

--- a/src/test/resources/com/qulice/pmd/AssertionAffirm.java
+++ b/src/test/resources/com/qulice/pmd/AssertionAffirm.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+
+final class AssertionAffirmTest {
+
+    @Test
+    void checksSomethingWithAffirm() throws Exception {
+        new Assertion<>(
+            "Must be equal to the expected value",
+            "hello",
+            Matchers.equalTo("hello")
+        ).affirm();
+    }
+}


### PR DESCRIPTION
Fixes #1698.

## Problem

`UnitTestShouldIncludeAssertRule` produced false positives on tests that assert via the cactoos-matchers convention:

```java
@Test
void rendersAllPage() throws IOException {
    new Assertion<>(
        "Must print body",
        XhtmlMatchers.xhtml(...),
        XhtmlMatchers.hasXPath("//xhtml:body")
    ).affirm();
}
```

PMD's `TestFrameworksUtil.isProbableAssertCall` only recognizes JUnit, TestNG, Hamcrest and AssertJ assertion patterns, so a `.affirm()` call was not counted as an assertion and the test was wrongly reported as `UnitTestShouldIncludeAssert`.

## Fix

The rule now also treats a **no-argument `affirm()` call on a type named `Assertion`** as a valid assertion, in addition to PMD's built-in detection. The type is matched by its simple name (`Assertion`) so the check still holds when cactoos-matchers is absent from the classpath and the type cannot be fully resolved — which is the common case when Qulice runs PMD without an auxiliary classpath.

## Tests

- Added `AssertionAffirm.java` test resource: a test class whose only assertion is `new Assertion<>(...).affirm()`.
- Added `findsAssertionInAffirmCall` to `PmdAssertionsTest`, asserting the file passes validation and no `UnitTestShouldIncludeAssert` violation is reported.
- Full `Pmd*` test suite (105 tests) passes, and the project's own Qulice self-check (`mvn verify -Pqulice`) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5bnF2AUKib5udXXkQ3sEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5bnF2AUKib5udXXkQ3sEN)_