### PR TITLE
fix(pmd): #1699 cover constructor-call initializers in interveningCall

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
@@ -93,13 +93,13 @@ final class UnnecessaryLocalSkips {
     /**
      * A statement intervenes between the local's declaration and its single
      * use, so the local is pinning evaluation order and must stay. When the
-     * initialiser is a method call, any intervening statement is enough - the
-     * call's result cannot be read out of order without reordering side
-     * effects. When the initialiser is a field access (e.g. {@code
-     * System.out}), only an intervening call on the <em>same</em> qualifier
-     * (e.g. {@code System.setOut(...)}) counts, since such a call may reassign
-     * the field before it is read; an unrelated statement leaves the read
-     * inlinable. See issues #1607 and #1710.
+     * initialiser is a method call or a constructor call, any intervening
+     * statement is enough - the call's result cannot be read out of order
+     * without reordering side effects. When the initialiser is a field access
+     * (e.g. {@code System.out}), only an intervening call on the <em>same</em>
+     * qualifier (e.g. {@code System.setOut(...)}) counts, since such a call may
+     * reassign the field before it is read; an unrelated statement leaves the
+     * read inlinable. See issues #1607, #1699 and #1710.
      * @param variable The variable declarator
      * @param use The single use of the variable
      * @return True if a statement intervenes between init and its use
@@ -110,7 +110,8 @@ final class UnnecessaryLocalSkips {
     ) {
         final ASTExpression init = variable.getInitializer();
         final boolean found;
-        if (init instanceof ASTMethodCall) {
+        if (init instanceof ASTMethodCall
+            || init instanceof ASTConstructorCall) {
             final Node decl = UnnecessaryLocalSkips.blockLevel(variable);
             final Node consumer = UnnecessaryLocalSkips.blockLevel(use);
             found = UnnecessaryLocalSkips.sameBlock(decl, consumer)

--- a/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
@@ -104,6 +104,15 @@ final class UnnecessaryLocalRuleTest {
     }
 
     @Test
+    void doesNotFireWhenConstructorCapturedBeforeCall() throws Exception {
+        MatcherAssert.assertThat(
+            "UnnecessaryLocalRule should not fire when a constructor-call local pins evaluation order before an intervening call",
+            this.violations("UnnecessaryLocalConstructorBeforeCall.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
+        );
+    }
+
+    @Test
     void doesNotFireOnTryWithResourcesResource() throws Exception {
         MatcherAssert.assertThat(
             "UnnecessaryLocalRule should not fire on a try-with-resources resource variable",

--- a/src/test/resources/com/qulice/pmd/UnnecessaryLocalConstructorBeforeCall.java
+++ b/src/test/resources/com/qulice/pmd/UnnecessaryLocalConstructorBeforeCall.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class UnnecessaryLocalConstructorBeforeCall {
+
+    public int apply(final Map<String, String> sample) {
+        final Map<String, String> params = new HashMap<>(sample);
+        final Report data = new Report(params);
+        params.clear();
+        return data.size();
+    }
+
+    public static final class Report {
+
+        private final Map<String, String> params;
+
+        public Report(final Map<String, String> args) {
+            this.params = new HashMap<>(args);
+        }
+
+        public int size() {
+            return this.params.size();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1699.

## Problem

`UnnecessaryLocalSkips#interveningCall` (added for #1607) only vetoed an `UnnecessaryLocalRule` report when the local's initializer was an `ASTMethodCall`. A local whose initializer is an `ASTConstructorCall` (a plain `new Foo(...)`) got no such protection — even when a statement genuinely intervenes between the declaration and its single use and inlining would change behaviour.

The issue's example (from jpeek's `ReportDataTest`):

```java
final Map params = new HashMap<>(sample);
final ReportData data = new ReportData("metric", params);
params.clear();
new Assertion<>("Must be immutable", data.params().entrySet().size(), ...).affirm();
```

Here `data`'s only use is inside the `Assertion` constructor's argument list, so `hasReturnOrArguments` is true; because its initializer is `new ReportData(...)` rather than a method call, `interveningCall` never inspected it and the rule fired. Inlining would construct `data` *after* `params.clear()`, silently changing what the test verifies.

## Fix

Broaden `interveningCall`'s initial `instanceof` check to also accept `ASTConstructorCall`, mirroring the existing `ASTMethodCall` handling (the veto logic — any intervening statement in the same block is enough — is identical for both).

## Tests

Added `UnnecessaryLocalConstructorBeforeCall.java` fixture (a constructor-call local with an intervening destructive statement before its single use) and a corresponding test in `UnnecessaryLocalRuleTest`. Verified the new test fails against the unpatched rule and passes with the fix; all 10 tests in the class pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NjLCMZm14qmRHricBjhJP

---
_Generated by [Claude Code](https://claude.ai/code/session_012NjLCMZm14qmRHricBjhJP)_