### PR TITLE
fix(pmd): #1700 detect intervening side effects across nested blocks

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
@@ -111,10 +111,7 @@ final class UnnecessaryLocalSkips {
         final ASTExpression init = variable.getInitializer();
         final boolean found;
         if (init instanceof ASTMethodCall) {
-            final Node decl = UnnecessaryLocalSkips.blockLevel(variable);
-            final Node consumer = UnnecessaryLocalSkips.blockLevel(use);
-            found = UnnecessaryLocalSkips.sameBlock(decl, consumer)
-                && consumer.getIndexInParent() > decl.getIndexInParent() + 1;
+            found = UnnecessaryLocalSkips.intervenes(variable, use);
         } else if (init instanceof ASTFieldAccess access) {
             found = UnnecessaryLocalSkips.callsQualifier(variable, use, access);
         } else {
@@ -123,10 +120,30 @@ final class UnnecessaryLocalSkips {
         return found;
     }
 
-    private static boolean sameBlock(final Node first, final Node second) {
-        return first != null && second != null
-            && first.getParent() instanceof ASTBlock
-            && first.getParent().equals(second.getParent());
+    /**
+     * A statement sits between the declaration and its use inside the block
+     * that encloses the declaration. The use is measured through its nearest
+     * ancestor statement in that common block, so a use buried in an {@code
+     * if} or loop body (whose immediate block differs from the declaration's)
+     * is still compared against the intervening statements rather than being
+     * treated as adjacent. See issue #1700.
+     * @param variable The variable declarator
+     * @param use The single use of the variable
+     * @return True if a statement intervenes between init and its use
+     */
+    private static boolean intervenes(
+        final ASTVariableDeclarator variable,
+        final ASTVariableAccess use
+    ) {
+        boolean found = false;
+        final ASTBlock block = variable.ancestors(ASTBlock.class).first();
+        if (block != null) {
+            final Node decl = UnnecessaryLocalSkips.childOf(block, variable);
+            final Node consumer = UnnecessaryLocalSkips.childOf(block, use);
+            found = decl != null && consumer != null
+                && consumer.getIndexInParent() > decl.getIndexInParent() + 1;
+        }
+        return found;
     }
 
     private static boolean callsQualifier(
@@ -185,14 +202,6 @@ final class UnnecessaryLocalSkips {
             fresh = known || clock;
         }
         return fresh;
-    }
-
-    private static Node blockLevel(final Node node) {
-        Node current = node;
-        while (current != null && !(current.getParent() instanceof ASTBlock)) {
-            current = current.getParent();
-        }
-        return current;
     }
 
     private static String qualifierImage(final ASTExpression expr) {

--- a/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
@@ -104,6 +104,15 @@ final class UnnecessaryLocalRuleTest {
     }
 
     @Test
+    void doesNotFireWhenInterveningCallSitsBeforeNestedUse() throws Exception {
+        MatcherAssert.assertThat(
+            "UnnecessaryLocalRule should not fire when a side-effecting statement intervenes before a use nested in an if block",
+            this.violations("UnnecessaryLocalInterveningNestedBlock.java"),
+            Matchers.not(Matchers.hasItem(UnnecessaryLocalRuleTest.RULE))
+        );
+    }
+
+    @Test
     void doesNotFireOnTryWithResourcesResource() throws Exception {
         MatcherAssert.assertThat(
             "UnnecessaryLocalRule should not fire on a try-with-resources resource variable",

--- a/src/test/resources/com/qulice/pmd/UnnecessaryLocalInterveningNestedBlock.java
+++ b/src/test/resources/com/qulice/pmd/UnnecessaryLocalInterveningNestedBlock.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class UnnecessaryLocalInterveningNestedBlock {
+
+    private final boolean quiet;
+
+    public UnnecessaryLocalInterveningNestedBlock(final boolean flag) {
+        this.quiet = flag;
+    }
+
+    public void analyze(final Sink sink) {
+        final String console = this.build(sink);
+        sink.run();
+        if (!this.quiet) {
+            sink.remove(console);
+        }
+    }
+
+    private String build(final Sink sink) {
+        sink.add("console");
+        return "console";
+    }
+
+    public interface Sink {
+        void add(String name);
+
+        void run();
+
+        void remove(String name);
+    }
+}


### PR DESCRIPTION
Fixes #1700.

## Problem

`UnnecessaryLocalSkips#interveningCall` only recognised an intervening statement when the declaration and its single use shared the **exact same** immediate `ASTBlock` (via the old `sameBlock` check). When the use sat inside a nested block (e.g. an `if` body) while the declaration lived in the enclosing method body, `sameBlock` returned `false`, so the intervening side effect between them was never detected and the rule wrongly reported the local as unnecessary.

Example from the issue (jpeek's `Main`): `console` is built by a side-effecting call, `new App(...).analyze()` runs in between, and `console`'s only use is `removeAppender(console)` inside an `if` block — inlining would change when the appender is attached, yet qulice flagged it.

## Fix

In `interveningCall`, the method-call branch now walks up to the block that **encloses the declaration** (which is always the common ancestor of the declaration and any use, since a use must be within the declared variable's scope) and measures the use through its nearest ancestor statement in that common block. A use buried in an `if`/loop body is therefore compared against the intervening statements instead of being treated as adjacent.

The now-unused `blockLevel` and `sameBlock` helpers were removed; the existing `childOf` helper is reused.

## Tests

- New fixture `UnnecessaryLocalInterveningNestedBlock.java` reproduces the issue: a method-call-initialised local, a side-effecting statement in between, and the single use nested inside an `if` block.
- New test `doesNotFireWhenInterveningCallSitsBeforeNestedUse` asserts the rule no longer fires.
- All existing `UnnecessaryLocalRuleTest` cases still pass (10 run, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hrve2r8e5c5eDseL8DgCh7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hrve2r8e5c5eDseL8DgCh7)_