### PR TITLE
fix: Allow deprecation Javadoc on overridden methods

### DIFF
--- a/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
@@ -10,6 +10,8 @@ import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 /**
  * Checks that there is no Javadoc for inherited methods.
@@ -19,6 +21,13 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  * @since 0.16
  */
 public final class NoJavadocForOverriddenMethodsCheck extends AbstractCheck {
+
+    /**
+     * Javadoc deprecation block tag.
+     */
+    private static final Pattern DEPRECATED = Pattern.compile(
+        "^\\s*(?:\\*|/\\*\\*)?\\s*@deprecated(?:\\s|\\*/|$)"
+    );
 
     /**
      * Default constructor.
@@ -52,7 +61,12 @@ public final class NoJavadocForOverriddenMethodsCheck extends AbstractCheck {
             final TextBlock javadoc = contents.getJavadocBefore(
                 ast.getLineNo()
             );
-            if (javadoc != null) {
+            if (
+                javadoc != null
+                    && Arrays.stream(javadoc.getText()).noneMatch(
+                        line -> DEPRECATED.matcher(line).find()
+                    )
+            ) {
                 log(ast, "Overridden methods should not have Javadoc");
             }
         }

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForOverriddenMethodsCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForOverriddenMethodsCheck/Valid.java
@@ -20,6 +20,14 @@ public final class Valid {
     }
 
     /**
+     * @deprecated Use {@link #note()} instead.
+     */
+    @Deprecated
+    @Override
+    public void deprecated() {
+    }
+
+    /**
      * Javadoc.
      */
     public void doc() {


### PR DESCRIPTION
## Summary

Refine `NoJavadocForOverriddenMethodsCheck` so it preserves the existing prohibition for ordinary descriptive or `{@inheritDoc}` Javadoc while accepting an overridden method whose Javadoc contains a real `@deprecated` block tag. Inspect the `TextBlock` as structured Javadoc lines and recognize the tag at block-tag position, avoiding a broad substring exception that could mistake prose or inline code for deprecation metadata. Add a representative `@Override` plus `@Deprecated` method to the check's valid fixture; the existing invalid fixture continues to prove that unrelated Javadoc and `{@inheritDoc}` remain violations.

## Why

`NoJavadocForOverriddenMethodsCheck` currently reports every Javadoc comment attached to a method annotated with `@Override`. Java deprecation conventions require an overridden method marked `@Deprecated` to document that status with an `@deprecated` block tag, so the unconditional rule prevents consumers from expressing the deprecation correctly. The check is already registered in the shipped Checkstyle configuration and is exercised through the resource-driven `ChecksTest` harness. The issue has no assignee, prior closed pull request, or open competing pull request in the supplied evidence.

## Tests

- An overridden method annotated with `@Deprecated` and documented with a genuine `@deprecated` block tag produces no `NoJavadocForOverriddenMethodsCheck` violation.
- Existing overridden methods without Javadoc remain valid.
- Existing overridden methods with ordinary descriptive Javadoc or `{@inheritDoc}` continue to report `Overridden methods should not have Javadoc`.
- Non-overridden methods with Javadoc remain unaffected by the exception.

Fixes #744
