### PR TITLE
Ignore parameter count of private methods

### DIFF
--- a/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -169,7 +169,6 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
      * @param index Line number that contains the javadoc tag
      * @param line Javadoc tag line number in file
      * @return Javadoc tags with arguments
-     * @checkstyle ParameterNumberCheck (30 lines)
      */
     private static List<JavadocTag> getMultilineArgTags(
         final Matcher matcher, final int column, final String[] lines,

--- a/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -151,7 +151,6 @@ public final class JavadocTagsCheck extends AbstractCheck {
      * @param cstart Line number where comment starts
      * @param cend Line number where comment ends
      * @param tag Name of the tag
-     * @checkstyle ParameterNumber (3 lines)
      */
     private void findProhibited(
         final String[] lines,
@@ -178,7 +177,6 @@ public final class JavadocTagsCheck extends AbstractCheck {
      * @param end Ending line number
      * @param tag Name of the tag to look for
      * @return Line number with found tag or -1 otherwise
-     * @checkstyle ParameterNumber (3 lines)
      */
     private List<Integer> findTagLineNum(
         final String[] lines,

--- a/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
@@ -8,7 +8,8 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
- * Number of parameters, tolerant to constructors that only take attributes.
+ * Number of parameters, tolerant to constructors that only take attributes
+ * and to private methods.
  *
  * <p>The stock {@code ParameterNumber} check treats a constructor as it
  * treats a method, while a constructor has no choice: it must accept a
@@ -17,6 +18,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * has to be blamed, not its constructor. That's why a constructor with no
  * more parameters than the number of attributes of its class passes here,
  * no matter how big the limit is.
+ *
+ * <p>A private method passes too. It is invisible outside its class, its
+ * parameters belong to no contract anybody else can see, and wrapping them
+ * into a new type only to satisfy the limit buys nothing.
  *
  * @since 1.0
  */
@@ -32,10 +37,31 @@ public final class ParameterNumberCheck
 
     @Override
     public void visitToken(final DetailAST ast) {
-        if (ast.getType() != TokenTypes.CTOR_DEF
-            || ParameterNumberCheck.parameters(ast) > ParameterNumberCheck.attributes(ast)) {
+        if (!ParameterNumberCheck.tolerated(ast)) {
             super.visitToken(ast);
         }
+    }
+
+    /**
+     * May this node keep its long list of parameters?
+     *
+     * <p>A constructor may, when it takes no more parameters than the
+     * number of attributes of its class. A method may, when it is
+     * private.</p>
+     *
+     * @param ast The CTOR_DEF or METHOD_DEF node
+     * @return TRUE if the check has to stay silent about it
+     */
+    private static boolean tolerated(final DetailAST ast) {
+        final boolean answer;
+        if (ast.getType() == TokenTypes.CTOR_DEF) {
+            answer = ParameterNumberCheck.parameters(ast)
+                <= ParameterNumberCheck.attributes(ast);
+        } else {
+            answer = ast.findFirstToken(TokenTypes.MODIFIERS)
+                .findFirstToken(TokenTypes.LITERAL_PRIVATE) != null;
+        }
+        return answer;
     }
 
     /**

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -373,8 +373,10 @@
     <module name="MethodLength"/>
     <!--
     Same as the stock ParameterNumber, but silent about a constructor that
-    takes no more parameters than the number of attributes of its class.
+    takes no more parameters than the number of attributes of its class,
+    and about a private method.
     See https://github.com/yegor256/qulice/issues/1677
+    See https://github.com/yegor256/qulice/issues/1727
     -->
     <module name="com.qulice.checkstyle.ParameterNumberCheck">
       <property name="max" value="3"/>

--- a/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
@@ -34,6 +34,15 @@ final class CheckstyleParameterNumberTest {
     }
 
     @Test
+    void acceptsPrivateMethodWithManyParameters() throws Exception {
+        MatcherAssert.assertThat(
+            "Private method with four parameters cannot fail",
+            this.runValidation("PrivateFourParameters.java", true),
+            Matchers.empty()
+        );
+    }
+
+    @Test
     void rejectsMethodWithTooManyParameters() throws Exception {
         final String file = "FourParameters.java";
         MatcherAssert.assertThat(

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ParameterNumberCheck/Valid.java
@@ -52,6 +52,15 @@ class Overriding {
     }
 }
 
+class PrivateMethods {
+    private int mix(final int one, final int two, final int three, final int four) {
+        return one + two + three + four;
+    }
+    private static int blend(final int one, final int two, final int three, final int four) {
+        return one * two * three * four;
+    }
+}
+
 class StaticsAndAttributes {
     private static final int LIMIT = 10;
     private final int alpha;

--- a/src/test/resources/com/qulice/checkstyle/PrivateFourParameters.java
+++ b/src/test/resources/com/qulice/checkstyle/PrivateFourParameters.java
@@ -1,0 +1,44 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Class with a private method of four parameters.
+ * @since 1.0
+ */
+public final class PrivateFourParameters {
+
+    /**
+     * The base.
+     */
+    private final int base;
+
+    /**
+     * Ctor.
+     * @param num The base
+     */
+    public PrivateFourParameters(final int num) {
+        this.base = num;
+    }
+
+    /**
+     * Sum of a few numbers.
+     * @return The sum
+     */
+    public int total() {
+        return this.sum(1, 2, 3, 4);
+    }
+
+    /**
+     * Sum of all numbers and the base.
+     * @param one First number
+     * @param two Second number
+     * @param three Third number
+     * @param four Fourth number
+     * @return The sum
+     */
+    private int sum(final int one, final int two, final int three, final int four) {
+        return this.base + one + two + three + four;
+    }
+}


### PR DESCRIPTION
`ParameterNumberCheck` now stays quiet about a private method, no matter how many parameters it takes. The condition in `visitToken()` moved into a `tolerated()` predicate that covers both cases: a constructor taking no more parameters than the attributes of its class, and any private method.

A private method is invisible outside its class, so its parameter list is part of no contract anybody else can see. Bundling those arguments into a new type only to get under the limit adds a class and buys nothing.

Private constructors stay under the old rule — they are still judged against the number of attributes. Closes #1727