### PR TITLE
Report elapsed time when the check completes

### DIFF
--- a/src/it/log-check/verify.groovy
+++ b/src/it/log-check/verify.groovy
@@ -6,4 +6,4 @@
 
 def log = new File(basedir, 'build.log')
 assert log.text.contains('Checking compile classpath')
-assert log.text.contains('Qulice quality check completed')
+assert log.text =~ /Qulice quality check completed in \d+(ms|s|min|hr)/

--- a/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -134,6 +134,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     @Override
     public final void execute() throws MojoFailureException {
+        final long start = System.currentTimeMillis();
         StaticLoggerBinder.getSingleton().setMavenLog(this.getLog());
         if (this.skip) {
             this.getLog().info("Execution skipped");
@@ -147,7 +148,11 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
         this.environment.setAssertion(this.asserts);
         this.environment.setEncoding(this.charset);
         this.doExecute();
-        Logger.info(this, "Qulice quality check completed");
+        Logger.info(
+            this,
+            "Qulice quality check completed in %[ms]s",
+            System.currentTimeMillis() - start
+        );
     }
 
     /**


### PR DESCRIPTION
The last line Qulice logs is now `Qulice quality check completed in 218ms` instead of a bare `Qulice quality check completed`. The elapsed time comes from a `System.currentTimeMillis()` stamp taken at the top of `execute()`, rendered through jcabi-log's `%[ms]s` decor, so short runs print milliseconds and long ones print seconds or minutes.

On a big project the check takes minutes and the log gave no clue about it, which makes it hard to tell whether Qulice or something else owns the slow part of the build. The mojo already had everything needed for this, so it was one format specifier away.

The `log-check` integration test now matches the timed line with a regex rather than a plain substring. Worth noting: the decor is registered under the name `ms`, not `msec` — `%[msec]s` would blow up at runtime.

Closes #1730