### PR TITLE
Report every javac warning and error, not just ErrorProne findings

### DIFF
--- a/src/it/javac-warnings/LICENSE.txt
+++ b/src/it/javac-warnings/LICENSE.txt
@@ -1,0 +1,28 @@
+Copyright (c) 2011-2026 Yegor Bugayenko
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met: 1) Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer. 2) Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution. 3) Neither the name of the Qulice.com nor
+the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/it/javac-warnings/invoker.properties
+++ b/src/it/javac-warnings/invoker.properties
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+invoker.goals = clean verify
+invoker.buildResult = failure

--- a/src/it/javac-warnings/pom.xml
+++ b/src/it/javac-warnings/pom.xml
@@ -16,9 +16,11 @@
   <packaging>jar</packaging>
   <name>javac-warnings</name>
   <properties>
-    <!-- source/target rather than release, on purpose: this is the
-         configuration that made Qulice complain about its own command
-         line, see #1732 -->
+    <!--
+    source/target rather than release, on purpose: this is the
+    configuration that made Qulice complain about its own command
+    line, see #1732
+    -->
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>
@@ -33,8 +35,10 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <!-- the parent turns warnings into compile errors; here the
-               warning must survive the compiler and reach Qulice -->
+          <!--
+          the parent turns warnings into compile errors; here the
+          warning must survive the compiler and reach Qulice
+          -->
           <failOnWarning>false</failOnWarning>
         </configuration>
       </plugin>

--- a/src/it/javac-warnings/pom.xml
+++ b/src/it/javac-warnings/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.jcabi</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.73.4</version>
+  </parent>
+  <groupId>com.qulice.plugin</groupId>
+  <artifactId>javac-warnings</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>javac-warnings</name>
+  <properties>
+    <!-- source/target rather than release, on purpose: this is the
+         configuration that made Qulice complain about its own command
+         line, see #1732 -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>false</failIfNoTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- the parent turns warnings into compile errors; here the
+               warning must survive the compiler and reach Qulice -->
+          <failOnWarning>false</failOnWarning>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.qulice</groupId>
+        <artifactId>qulice-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <license>file:${basedir}/LICENSE.txt</license>
+          <excludes>
+            <exclude>checkstyle:.*</exclude>
+            <exclude>pmd:.*</exclude>
+            <exclude>duplicatefinder:.*</exclude>
+            <exclude>dependencies:.*</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/javac-warnings/src/main/java/com/qulice/foo/Caller.java
+++ b/src/it/javac-warnings/src/main/java/com/qulice/foo/Caller.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.foo;
+
+/**
+ * Sample class whose only defect is a plain {@code javac} warning, with no
+ * ErrorProne bug pattern anywhere in sight.
+ * @since 1.0
+ */
+public final class Caller {
+
+    /**
+     * Call the stale method and earn the {@code [removal]} warning.
+     * @return Whatever {@link Stale#old()} returns
+     */
+    public int call() {
+        return Stale.old();
+    }
+}

--- a/src/it/javac-warnings/src/main/java/com/qulice/foo/Stale.java
+++ b/src/it/javac-warnings/src/main/java/com/qulice/foo/Stale.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.foo;
+
+/**
+ * Sample class holding a method nobody should call any more.
+ * @since 1.0
+ */
+public final class Stale {
+
+    /**
+     * Method scheduled for removal.
+     * @return Always one
+     */
+    @Deprecated(forRemoval = true)
+    public static int old() {
+        return 1;
+    }
+}

--- a/src/it/javac-warnings/src/main/java/com/qulice/foo/package-info.java
+++ b/src/it/javac-warnings/src/main/java/com/qulice/foo/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Sample package containing a plain compiler warning.
+ * @since 1.0
+ */
+package com.qulice.foo;

--- a/src/it/javac-warnings/verify.groovy
+++ b/src/it/javac-warnings/verify.groovy
@@ -1,0 +1,10 @@
+/**
+ *
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+def log = new File(basedir, 'build.log')
+assert log.text.contains('ErrorProne:')
+assert log.text.contains('[removal]')
+assert !log.text.contains('[options]')

--- a/src/main/java/com/qulice/errorprone/Diagnostics.java
+++ b/src/main/java/com/qulice/errorprone/Diagnostics.java
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.errorprone;
+
+import com.qulice.spi.Violation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * What a forked {@code javac} printed, read as violations.
+ *
+ * <p>Every diagnostic counts, not just the ones ErrorProne labels with
+ * its {@code [CheckName]} prefix: a plain {@code cannot find symbol} is
+ * the loudest signal of all, because {@code javac} stops before the
+ * analysis phase once it sees an error and ErrorProne then reports
+ * nothing at all. Lines that carry no source position, such as
+ * {@code error: warnings found and -Werror specified}, are blamed on the
+ * project itself.</p>
+ *
+ * @since 1.0
+ */
+final class Diagnostics {
+
+    /**
+     * Standard {@code javac} diagnostic format,
+     * {@code path:line: warning|error: body}, where the body optionally
+     * opens with the {@code [Name]} prefix that ErrorProne puts on its
+     * findings and {@code javac} puts on its lint categories.
+     */
+    private static final Pattern POSITIONED = Pattern.compile(
+        "^(.+?):(\\d+): (?:warning|error): (?:\\[([A-Za-z][A-Za-z0-9_]*)] )?(.+)$"
+    );
+
+    /**
+     * A {@code javac} diagnostic that names no source position.
+     */
+    private static final Pattern GLOBAL = Pattern.compile(
+        "^(?:warning|error): (?:\\[([A-Za-z][A-Za-z0-9_]*)] )?(.+)$"
+    );
+
+    /**
+     * Check name for a diagnostic that carries no bracketed name of its own.
+     */
+    private static final String JAVAC = "javac";
+
+    /**
+     * Name of the validator to attribute the violations to.
+     */
+    private final String validator;
+
+    /**
+     * File to blame for the diagnostics that name no source position.
+     */
+    private final String fallback;
+
+    /**
+     * Constructor.
+     * @param validator Name of the validator reporting these diagnostics
+     * @param fallback File to blame when a diagnostic names no position
+     */
+    Diagnostics(final String validator, final String fallback) {
+        this.validator = validator;
+        this.fallback = fallback;
+    }
+
+    /**
+     * Read the diagnostics out of the compiler's output.
+     * @param output Combined stdout/stderr of the forked process
+     * @return Violations, one per diagnostic line
+     */
+    Collection<Violation> violations(final List<String> output) {
+        final Collection<Violation> violations = new ArrayList<>(0);
+        for (final String line : output) {
+            final Matcher positioned = Diagnostics.POSITIONED.matcher(line);
+            final Matcher global = Diagnostics.GLOBAL.matcher(line);
+            if (positioned.matches()) {
+                violations.add(
+                    this.violation(
+                        positioned.group(1),
+                        positioned.group(2),
+                        Diagnostics.check(positioned.group(3)),
+                        positioned.group(4)
+                    )
+                );
+            } else if (global.matches()) {
+                violations.add(
+                    this.violation(
+                        this.fallback,
+                        "0",
+                        Diagnostics.check(global.group(1)),
+                        global.group(2)
+                    )
+                );
+            }
+        }
+        return violations;
+    }
+
+    /**
+     * Turn one parsed diagnostic into a violation.
+     * @param file Source file the compiler pointed at
+     * @param lines Line number inside that file
+     * @param check Name of the check or lint category
+     * @param message Diagnostic body, without the bracketed name
+     * @return The violation
+     */
+    private Violation violation(final String file, final String lines,
+        final String check, final String message) {
+        return new Violation.Default(
+            this.validator,
+            check,
+            file,
+            lines,
+            String.format("[%s] %s", check, message)
+        );
+    }
+
+    /**
+     * Name of the check a diagnostic belongs to, falling back to
+     * {@code javac} for the diagnostics the compiler leaves unlabelled.
+     * @param name Bracketed name the diagnostic carried, or {@code null}
+     * @return Name to report the violation under
+     */
+    private static String check(final String name) {
+        return Optional.ofNullable(name).orElse(Diagnostics.JAVAC);
+    }
+}

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -17,10 +17,11 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -35,14 +36,11 @@ import java.util.regex.Pattern;
  * JVM hosting Maven and Qulice is unaffected, so consumers do not have to
  * touch their own {@code .mvn/jvm.config} to use this validator.</p>
  *
- * <p>Diagnostics from the forked {@code javac} are parsed from the
- * combined stdout/stderr stream. Only lines that match the standard
- * compiler diagnostic format and whose message starts with the
- * {@code [CheckName]} prefix ErrorProne always emits are converted into
- * {@link Violation}s — plain compile errors caused by the project not
- * being built yet are ignored. {@code -proc:none} is passed to keep
- * regular annotation processors (Lombok, Hibernate-Validator, etc.) out
- * of the ErrorProne pass.</p>
+ * <p>The combined stdout/stderr stream is handed to {@link Diagnostics},
+ * which turns every line of it into a {@link Violation} — ErrorProne
+ * findings, {@code javac} lint warnings and plain compile errors alike.
+ * {@code -proc:none} is passed to keep regular annotation processors
+ * (Lombok, Hibernate-Validator, etc.) out of the ErrorProne pass.</p>
  *
  * @since 1.0
  */
@@ -95,13 +93,9 @@ public final class ErrorProneValidator implements ResourceValidator {
     );
 
     /**
-     * Standard {@code javac} diagnostic format with an ErrorProne
-     * {@code [CheckName]} prefix on the message:
-     * {@code path:line: warning|error: [Name] body}.
+     * Path fragment that tells Maven's test source root from its main one.
      */
-    private static final Pattern DIAGNOSTIC = Pattern.compile(
-        "^(.+?):(\\d+): (?:warning|error): \\[([A-Za-z][A-Za-z0-9_]*)] (.+)$"
-    );
+    private static final String TESTS = "/src/test/";
 
     /**
      * Splits a multi-line stdout block into individual lines, on any
@@ -134,7 +128,17 @@ public final class ErrorProneValidator implements ResourceValidator {
             );
         } else {
             Logger.debug(this, "ErrorProne processing %d files", sources.size());
-            violations.addAll(this.parse(this.run(sources)));
+            final Diagnostics diagnostics = new Diagnostics(
+                this.name(), this.env.basedir().getAbsolutePath()
+            );
+            for (final Map.Entry<String, List<File>> batch
+                : ErrorProneValidator.batches(sources).entrySet()) {
+                violations.addAll(
+                    diagnostics.violations(
+                        this.run(batch.getKey(), batch.getValue())
+                    )
+                );
+            }
             Logger.debug(this, "ErrorProne processed %d files", sources.size());
         }
         return violations;
@@ -146,12 +150,51 @@ public final class ErrorProneValidator implements ResourceValidator {
     }
 
     /**
+     * Split the sources the way Maven compiles them: main sources in one
+     * batch, test sources in another.
+     *
+     * <p>A single {@code javac} pass over both would manufacture
+     * diagnostics no project could ever silence, because Maven's two
+     * source roots are allowed to hold twins of the same file. The
+     * clearest case is {@code package-info.java}, which Qulice's own
+     * {@code JavadocPackage} check demands in every package: with one
+     * pass, a package that has both main and test code earns
+     * {@code a package-info.java file has already been seen} and, once
+     * the file carries an annotation, {@code has already been
+     * annotated}.</p>
+     *
+     * @param sources Java source files to split
+     * @return Batches by name, in compilation order, none of them empty
+     */
+    private static Map<String, List<File>> batches(final List<File> sources) {
+        final List<File> main = new ArrayList<>(sources.size());
+        final List<File> tests = new ArrayList<>(sources.size());
+        for (final File source : sources) {
+            if (source.getPath().replace(File.separatorChar, '/')
+                .contains(ErrorProneValidator.TESTS)) {
+                tests.add(source);
+            } else {
+                main.add(source);
+            }
+        }
+        final Map<String, List<File>> batches = new LinkedHashMap<>(2);
+        if (!main.isEmpty()) {
+            batches.put("main", main);
+        }
+        if (!tests.isEmpty()) {
+            batches.put("test", tests);
+        }
+        return batches;
+    }
+
+    /**
      * Run the forked {@code javac} process with ErrorProne enabled.
+     * @param batch Name of the batch being compiled
      * @param sources Java source files to feed
      * @return Combined stdout/stderr of the process, line by line
      */
-    private List<String> run(final List<File> sources) {
-        final Result result = new Jaxec(this.command(sources))
+    private List<String> run(final String batch, final List<File> sources) {
+        final Result result = new Jaxec(this.command(batch, sources))
             .withRedirect(true)
             .withCheck(false)
             .exec();
@@ -172,10 +215,20 @@ public final class ErrorProneValidator implements ResourceValidator {
      * argument other than the launcher itself and the {@code -J}
      * flags (which {@code javac} forbids inside argfiles) is written
      * to a temporary argfile and passed as {@code @argfile}.
+     *
+     * <p>{@code -Xlint:-options} turns off the one lint category that
+     * would report Qulice to the project instead of the project to the
+     * user: {@code options} complains about the {@code -source}/
+     * {@code -target} pair this class deliberately builds in place of
+     * {@code --release} (see
+     * <a href="https://github.com/yegor256/qulice/issues/1716">#1716</a>),
+     * and no change to the project could ever silence it.</p>
+     *
+     * @param batch Name of the batch being compiled
      * @param sources Java source files to feed
      * @return Argv
      */
-    private List<String> command(final List<File> sources) {
+    private List<String> command(final String batch, final List<File> sources) {
         final List<String> command = new ArrayList<>(
             ErrorProneValidator.JVM_FLAGS.size() + 2
         );
@@ -183,17 +236,20 @@ public final class ErrorProneValidator implements ResourceValidator {
         for (final String flag : ErrorProneValidator.JVM_FLAGS) {
             command.add("-J".concat(flag));
         }
-        final File outdir = new File(this.env.tempdir(), "errorprone-classes");
+        final File outdir = new File(
+            this.env.tempdir(), String.format("errorprone-classes-%s", batch)
+        );
         if (!outdir.exists() && !outdir.mkdirs()) {
             throw new IllegalStateException(
                 String.format("Unable to create %s", outdir)
             );
         }
-        final List<String> args = new ArrayList<>(sources.size() + 11);
+        final List<String> args = new ArrayList<>(sources.size() + 12);
         args.add("-XDcompilePolicy=simple");
         args.add("-XDaddTypeAnnotationsToSymbol=true");
         args.add("--should-stop=ifError=FLOW");
         args.add("-proc:none");
+        args.add("-Xlint:-options");
         args.addAll(this.release());
         args.add(ErrorProneValidator.PLUGIN);
         args.add("-processorpath");
@@ -211,37 +267,15 @@ public final class ErrorProneValidator implements ResourceValidator {
         command.add(
             "@".concat(
                 new Argfile(
-                    new File(this.env.tempdir(), "errorprone-args.txt"), args
+                    new File(
+                        this.env.tempdir(),
+                        String.format("errorprone-args-%s.txt", batch)
+                    ),
+                    args
                 ).save().getAbsolutePath()
             )
         );
         return command;
-    }
-
-    /**
-     * Translate diagnostic lines into Qulice violations, keeping only
-     * those messages prefixed by an ErrorProne bug-pattern name.
-     * @param output Combined stdout/stderr of the forked process
-     * @return Violations
-     */
-    private Collection<Violation> parse(final List<String> output) {
-        final Collection<Violation> violations = new ArrayList<>(0);
-        for (final String line : output) {
-            final Matcher matcher = ErrorProneValidator.DIAGNOSTIC.matcher(line);
-            if (matcher.matches()) {
-                final String check = matcher.group(3);
-                violations.add(
-                    new Violation.Default(
-                        this.name(),
-                        check,
-                        matcher.group(1),
-                        matcher.group(2),
-                        String.format("[%s] %s", check, matcher.group(4))
-                    )
-                );
-            }
-        }
-        return violations;
     }
 
     /**

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -37,10 +37,12 @@ import java.util.regex.Pattern;
  * touch their own {@code .mvn/jvm.config} to use this validator.</p>
  *
  * <p>The combined stdout/stderr stream is handed to {@link Diagnostics},
- * which turns every line of it into a {@link Violation} — ErrorProne
- * findings, {@code javac} lint warnings and plain compile errors alike.
- * {@code -proc:none} is passed to keep regular annotation processors
- * (Lombok, Hibernate-Validator, etc.) out of the ErrorProne pass.</p>
+ * which turns every diagnostic it finds there into a {@link Violation} —
+ * ErrorProne findings, {@code javac} lint warnings and plain compile
+ * errors alike — and passes over the carets, symbol hints and counters
+ * the compiler prints around them. {@code -proc:none} is passed to keep
+ * regular annotation processors (Lombok, Hibernate-Validator, etc.) out
+ * of the ErrorProne pass.</p>
  *
  * @since 1.0
  */

--- a/src/test/java/com/qulice/errorprone/DiagnosticsTest.java
+++ b/src/test/java/com/qulice/errorprone/DiagnosticsTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.errorprone;
+
+import com.qulice.spi.Violation;
+import java.util.Collection;
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Diagnostics}.
+ * @since 1.0
+ */
+final class DiagnosticsTest {
+
+    @Test
+    void namesTheErrorProneCheck() {
+        MatcherAssert.assertThat(
+            "bracketed check name must survive into the violation",
+            new Diagnostics("ErrorProne", "/prj").violations(
+                List.of("/prj/Foo.java:42: warning: [SelfAssignment] assigned to itself")
+            ).iterator().next().name(),
+            Matchers.equalTo("SelfAssignment")
+        );
+    }
+
+    @Test
+    void namesThePlainCompilerAsCheck() {
+        MatcherAssert.assertThat(
+            "an unlabelled diagnostic cannot be left nameless",
+            new Diagnostics("ErrorProne", "/prj").violations(
+                List.of("/prj/Foo.java:7: error: cannot find symbol")
+            ).iterator().next().name(),
+            Matchers.equalTo("javac")
+        );
+    }
+
+    @Test
+    void keepsTheSourcePosition() {
+        MatcherAssert.assertThat(
+            "line number of the diagnostic must not be lost",
+            new Diagnostics("ErrorProne", "/prj").violations(
+                List.of("/prj/Foo.java:19: warning: [removal] old() is deprecated")
+            ).iterator().next().lines(),
+            Matchers.equalTo("19")
+        );
+    }
+
+    @Test
+    void blamesProjectForPositionlessDiagnostic() {
+        MatcherAssert.assertThat(
+            "a diagnostic with no source position must still land somewhere",
+            new Diagnostics("ErrorProne", "/prj").violations(
+                List.of("error: warnings found and -Werror specified")
+            ).iterator().next().file(),
+            Matchers.equalTo("/prj")
+        );
+    }
+
+    @Test
+    void dontReportCompilerChatter() {
+        final Collection<Violation> violations =
+            new Diagnostics("ErrorProne", "/prj").violations(
+                List.of(
+                    "    int count() { return Missing.value(); }",
+                    "                         ^",
+                    "  symbol:   variable Missing",
+                    "  location: class Broken",
+                    "Note: Some input files use unchecked operations.",
+                    "1 error",
+                    "5 warnings"
+                )
+            );
+        MatcherAssert.assertThat(
+            String.format("carets and counters are not violations: %s", violations),
+            violations,
+            Matchers.<Violation>empty()
+        );
+    }
+}

--- a/src/test/java/com/qulice/errorprone/DiagnosticsTest.java
+++ b/src/test/java/com/qulice/errorprone/DiagnosticsTest.java
@@ -51,6 +51,17 @@ final class DiagnosticsTest {
     }
 
     @Test
+    void readsWindowsDriveLetterPath() {
+        MatcherAssert.assertThat(
+            "a drive letter cannot be mistaken for the line separator",
+            new Diagnostics("ErrorProne", "C:\\prj").violations(
+                List.of("C:\\prj\\Foo.java:7: error: cannot find symbol")
+            ).iterator().next().file(),
+            Matchers.equalTo("C:\\prj\\Foo.java")
+        );
+    }
+
+    @Test
     void blamesProjectForPositionlessDiagnostic() {
         MatcherAssert.assertThat(
             "a diagnostic with no source position must still land somewhere",

--- a/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
@@ -117,4 +117,122 @@ final class ErrorProneValidatorTest {
             Matchers.<Violation>empty()
         );
     }
+
+    @Test
+    void doesNotBlameProjectForTwinPackageInfo() throws Exception {
+        final String main = "src/main/java/com/qulice/package-info.java";
+        final String test = "src/test/java/com/qulice/package-info.java";
+        final String body = String.join(
+            System.lineSeparator(),
+            "/**",
+            " * Sample.",
+            " * @since 1.0",
+            " */",
+            "package com.qulice;"
+        );
+        final Environment env = new Environment.Mock()
+            .withFile(main, body).withFile(test, body);
+        final java.util.Collection<Violation> violations =
+            new ErrorProneValidator(env).validate(
+                java.util.Arrays.asList(
+                    new File(env.basedir(), main), new File(env.basedir(), test)
+                )
+            );
+        MatcherAssert.assertThat(
+            String.format(
+                "twin package-info files are legal in Maven and must pass: %s",
+                violations
+            ),
+            violations,
+            Matchers.<Violation>empty()
+        );
+    }
+
+    @Test
+    void reportsPlainCompilerError() throws Exception {
+        final String file = "src/main/java/com/qulice/Broken.java";
+        final Environment env = new Environment.Mock().withFile(
+            file,
+            String.join(
+                System.lineSeparator(),
+                "package com.qulice;",
+                "/**",
+                " * Sample.",
+                " * @since 1.0",
+                " */",
+                "final class Broken {",
+                "    int count() { return Missing.value(); }",
+                "}"
+            )
+        );
+        MatcherAssert.assertThat(
+            "cannot find symbol must not slip through as a green build",
+            new ErrorProneValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            ).stream().map(Violation::message).toList(),
+            Matchers.hasItem(Matchers.containsString("cannot find symbol"))
+        );
+    }
+
+    @Test
+    void reportsPlainCompilerWarning() throws Exception {
+        final String file = "src/main/java/com/qulice/Removal.java";
+        final Environment env = new Environment.Mock().withFile(
+            file,
+            String.join(
+                System.lineSeparator(),
+                "package com.qulice;",
+                "/**",
+                " * Sample.",
+                " * @since 1.0",
+                " */",
+                "final class Removal {",
+                "    @Deprecated(forRemoval = true)",
+                "    static int old() { return 1; }",
+                "}",
+                "final class Caller {",
+                "    int call() { return Removal.old(); }",
+                "}"
+            )
+        );
+        MatcherAssert.assertThat(
+            "deprecated-for-removal warning must not slip through as a green build",
+            new ErrorProneValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            ).stream().map(Violation::message).toList(),
+            Matchers.hasItem(Matchers.containsString("marked for removal"))
+        );
+    }
+
+    @Test
+    void doesNotBlameProjectForOwnCompilerOptions() throws Exception {
+        final String file = "src/main/java/com/qulice/Pinned.java";
+        final Environment env = new Environment.Mock()
+            .withParam("maven.compiler.source", "21").withFile(
+                file,
+                String.join(
+                    System.lineSeparator(),
+                    "package com.qulice;",
+                    "/**",
+                    " * Sample.",
+                    " * @since 1.0",
+                    " */",
+                    "final class Pinned {",
+                    "    int square(final int num) { return num * num; }",
+                    "}"
+                )
+            );
+        final java.util.Collection<Violation> violations =
+            new ErrorProneValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            );
+        MatcherAssert.assertThat(
+            String.format(
+                "Qulice must not blame the project for its own -source flag: %s",
+                violations
+            ),
+            violations,
+            Matchers.<Violation>empty()
+        );
+    }
 }


### PR DESCRIPTION
The `ErrorProneValidator` used to keep only the diagnostics whose message opened with the `[CheckName]` prefix that ErrorProne puts on its own findings. Everything else `javac` printed — `cannot find symbol`, duplicate `package-info`, lint categories — went to the log with Jaxec's `>>` prefix and never became a violation, so the build finished green while the compiler was counting errors right there in the output. Now every diagnostic line turns into a violation, named after the bracketed check when there is one and `javac` otherwise, and the position-less `warning:`/`error:` lines get blamed on the project directory.

Errors are the ones that hurt most. `--should-stop=ifError=FLOW` makes ErrorProne give up before the analysis phase as soon as `javac` reports one, so the old code handed back a clean pass in exactly the runs where it had checked the least.

Two of the diagnostics in that stream turned out to be Qulice's own fault, and blaming the project for them would have been unfair, so they are fixed at the source instead. `-Xlint:-options` silences the complaint about the `-source`/`-target` pair this validator builds on purpose instead of `--release` (#1716) — nothing a project does could quiet that one. And main and test sources now go through two separate `javac` passes, the way Maven compiles them, which ends the `a package-info.java file has already been seen` warning and the `has already been annotated` error that a package with both main and test code used to earn — a layout Qulice's own `JavadocPackage` check asks for. The `multi-module` integration test was hitting exactly that.

Parsing moved into a new `Diagnostics` class, otherwise `ErrorProneValidator` crossed the God Class threshold. Reviewers may want to know that projects which currently pass may start failing on real compiler output they never saw reported before — that is the point of the change, but it is worth a release note.

Closes #1732
