### PR TITLE
Report checked files and applied rules when a check completes

### DIFF
--- a/src/it/hibernate-validator-check/verify.groovy
+++ b/src/it/hibernate-validator-check/verify.groovy
@@ -6,3 +6,4 @@
 
 def log = new File(basedir, 'build.log')
 assert !log.text.contains('JSR-303 validator failed to initialize')
+assert log.text =~ /Qulice checked 2 \.java files against \d+ rules \(\d+ Checkstyle, \d+ PMD\) in \d+(ms|s|min|hr)/

--- a/src/it/log-check/verify.groovy
+++ b/src/it/log-check/verify.groovy
@@ -6,4 +6,4 @@
 
 def log = new File(basedir, 'build.log')
 assert log.text.contains('Checking compile classpath')
-assert log.text =~ /Qulice checked \d+ \.java files? against \d+ rules \(\d+ Checkstyle, \d+ PMD\) in \d+(ms|s|min|hr)/
+assert log.text =~ /Qulice checked 0 \.java files against 0 rules in \d+(ms|s|min|hr)/

--- a/src/it/log-check/verify.groovy
+++ b/src/it/log-check/verify.groovy
@@ -6,4 +6,4 @@
 
 def log = new File(basedir, 'build.log')
 assert log.text.contains('Checking compile classpath')
-assert log.text =~ /Qulice quality check completed in \d+(ms|s|min|hr)/
+assert log.text =~ /Qulice checked \d+ \.java files? against \d+ rules \(\d+ Checkstyle, \d+ PMD\) in \d+(ms|s|min|hr)/

--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -133,6 +133,11 @@ public final class CheckstyleValidator implements ResourceValidator {
         return "Checkstyle";
     }
 
+    @Override
+    public int rules() {
+        return CheckstyleValidator.count(this.configuration());
+    }
+
     /**
      * Filters out excluded files from further validation.
      * @param files Files to validate
@@ -255,6 +260,30 @@ public final class CheckstyleValidator implements ResourceValidator {
             }
         }
         return result;
+    }
+
+    /**
+     * Count the checks in a configuration tree.
+     *
+     * <p>A module without children is one check, while a module that holds
+     * others — {@code Checker} and {@code TreeWalker} — only carries them
+     * and is not a check itself. Suppression filters and holders are left
+     * out too, since they silence violations instead of finding them.</p>
+     *
+     * @param config Configuration to count in
+     * @return The number of checks configured
+     */
+    private static int count(final Configuration config) {
+        int total = 0;
+        for (final Configuration child : config.getChildren()) {
+            final String name = child.getName();
+            if (child.getChildren().length > 0) {
+                total += CheckstyleValidator.count(child);
+            } else if (!name.endsWith("Filter") && !name.endsWith("Holder")) {
+                total += 1;
+            }
+        }
+        return total;
     }
 
     /**

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -49,6 +49,14 @@ import java.util.regex.Pattern;
  * {@code qulice.errorprone} parameter.</p>
  *
  * @since 1.0
+ * @todo #1736:60min Count the bug patterns this validator applies, so that
+ *  {@code rules()} stops returning zero and ErrorProne joins the summary
+ *  Qulice prints when a check completes. The number starts at
+ *  {@code BuiltInCheckerSuppliers.defaultChecks()}, minus the patterns
+ *  {@link Xplugin} switches off and plus the ones the project switches back
+ *  on. That class lives in {@code error_prone_core}, a runtime dependency of
+ *  this plugin, so counting them means either promoting the jar to compile
+ *  scope or asking the forked {@code javac} for the number.
  */
 public final class ErrorProneValidator implements ResourceValidator {
 
@@ -133,6 +141,11 @@ public final class ErrorProneValidator implements ResourceValidator {
     @Override
     public String name() {
         return "ErrorProne";
+    }
+
+    @Override
+    public int rules() {
+        return 0;
     }
 
     /**

--- a/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -180,10 +180,10 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
                 String.join(" ", this.errorprone)
             );
         }
-        this.doExecute();
         Logger.info(
             this,
-            "Qulice quality check completed in %[ms]s",
+            "Qulice %s in %[ms]s",
+            this.doExecute(),
             System.currentTimeMillis() - start
         );
     }
@@ -198,9 +198,11 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Do the real execution.
+     * @return What was done, as the middle of the final log line, e.g.
+     *  {@code "checked 42 .java files against 385 rules"}
      * @throws MojoFailureException If some failure inside
      */
-    protected abstract void doExecute() throws MojoFailureException;
+    protected abstract String doExecute() throws MojoFailureException;
 
     /**
      * Get the environment.

--- a/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/src/main/java/com/qulice/maven/CheckMojo.java
@@ -77,9 +77,9 @@ public final class CheckMojo extends AbstractQuliceMojo {
     }
 
     @Override
-    public void doExecute() throws MojoFailureException {
+    public String doExecute() throws MojoFailureException {
         try {
-            this.run();
+            return this.run();
         } catch (final ValidationException ex) {
             Logger.info(
                 this,
@@ -107,17 +107,19 @@ public final class CheckMojo extends AbstractQuliceMojo {
 
     /**
      * Run them all.
+     * @return What was checked, for the final log line
      * @throws ValidationException If any of them fail
      */
     @SuppressWarnings("PMD.CognitiveComplexity")
-    private void run() throws ValidationException {
+    private String run() throws ValidationException {
         final List<Violation> results = new ArrayList<>(0);
         final MavenEnvironment env = this.env();
         final ValidatorsProvider prov = this.validators(env);
+        final Collection<ResourceValidator> resources = prov.externalResource();
         final Collection<File> files = env.files("*.*");
         if (!files.isEmpty()) {
             final Collection<Future<Collection<Violation>>> futures =
-                this.submit(env, files, prov.externalResource());
+                this.submit(env, files, resources);
             for (final Future<Collection<Violation>> future : futures) {
                 try {
                     if ("forever".equalsIgnoreCase(this.timeout)) {
@@ -171,6 +173,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
         for (final MavenValidator validator : prov.internal()) {
             validator.validate(env);
         }
+        return new Summary(files, resources).toString();
     }
 
     /**

--- a/src/main/java/com/qulice/maven/Summary.java
+++ b/src/main/java/com/qulice/maven/Summary.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import com.qulice.spi.ResourceValidator;
+import java.io.File;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The scope of a finished check, as one line of text.
+ *
+ * <p>Tells the reader what the run has just covered: how many Java files
+ * went through the validators and how many rules judged them, validator
+ * by validator. A validator that cannot count its rules stays out of the
+ * breakdown, instead of claiming zero.</p>
+ *
+ * @since 1.0
+ */
+final class Summary {
+
+    /**
+     * Files handed to the validators.
+     */
+    private final Collection<File> files;
+
+    /**
+     * Validators that read them.
+     */
+    private final Collection<ResourceValidator> validators;
+
+    /**
+     * Constructor.
+     * @param files Files handed to the validators
+     * @param validators Validators that read them
+     */
+    Summary(final Collection<File> files,
+        final Collection<ResourceValidator> validators) {
+        this.files = files;
+        this.validators = validators;
+    }
+
+    @Override
+    public String toString() {
+        final Map<String, Integer> counts = this.counts();
+        return String.format(
+            "checked %s against %d rules%s",
+            this.javas(),
+            counts.values().stream().mapToInt(Integer::intValue).sum(),
+            Summary.breakdown(counts)
+        );
+    }
+
+    /**
+     * How many rules each validator applies, by validator name, leaving
+     * out the ones that count none.
+     * @return Rule counts, in the order the validators ran
+     */
+    private Map<String, Integer> counts() {
+        final Map<String, Integer> counts =
+            new LinkedHashMap<>(this.validators.size());
+        for (final ResourceValidator validator : this.validators) {
+            final int rules = validator.rules();
+            if (rules > 0) {
+                counts.put(validator.name(), rules);
+            }
+        }
+        return counts;
+    }
+
+    /**
+     * The Java files among them, counted and named.
+     * @return Text, e.g. {@code "42 .java files"}
+     */
+    private String javas() {
+        final long count = this.files.stream().filter(
+            file -> file.getName().toLowerCase(Locale.ROOT).endsWith(".java")
+        ).count();
+        final String text;
+        if (count == 1L) {
+            text = "1 .java file";
+        } else {
+            text = String.format("%d .java files", count);
+        }
+        return text;
+    }
+
+    /**
+     * Spell the rule counts out, validator by validator.
+     * @param counts Rule counts by validator name
+     * @return Text in brackets, e.g. {@code " (253 Checkstyle, 132 PMD)"},
+     *  or empty when nobody counted anything
+     */
+    private static String breakdown(final Map<String, Integer> counts) {
+        final String text;
+        if (counts.isEmpty()) {
+            text = "";
+        } else {
+            text = counts.entrySet().stream().map(
+                entry -> String.format("%d %s", entry.getValue(), entry.getKey())
+            ).collect(Collectors.joining(", ", " (", ")"));
+        }
+        return text;
+    }
+}

--- a/src/main/java/com/qulice/maven/Summary.java
+++ b/src/main/java/com/qulice/maven/Summary.java
@@ -18,7 +18,8 @@ import java.util.stream.Collectors;
  * <p>Tells the reader what the run has just covered: how many Java files
  * went through the validators and how many rules judged them, validator
  * by validator. A validator that cannot count its rules stays out of the
- * breakdown, instead of claiming zero.</p>
+ * breakdown, instead of claiming zero, and a module that had no file to
+ * give them counts no rules at all.</p>
  *
  * @since 1.0
  */
@@ -59,15 +60,23 @@ final class Summary {
     /**
      * How many rules each validator applies, by validator name, leaving
      * out the ones that count none.
+     *
+     * <p>A module without a single file to read runs no validator at all,
+     * so nobody is asked to count: the counting itself is expensive, since
+     * it makes Checkstyle load its configuration and PMD resolve its
+     * ruleset.</p>
+     *
      * @return Rule counts, in the order the validators ran
      */
     private Map<String, Integer> counts() {
         final Map<String, Integer> counts =
             new LinkedHashMap<>(this.validators.size());
-        for (final ResourceValidator validator : this.validators) {
-            final int rules = validator.rules();
-            if (rules > 0) {
-                counts.put(validator.name(), rules);
+        if (!this.files.isEmpty()) {
+            for (final ResourceValidator validator : this.validators) {
+                final int rules = validator.rules();
+                if (rules > 0) {
+                    counts.put(validator.name(), rules);
+                }
             }
         }
         return counts;

--- a/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -68,6 +68,11 @@ public final class PmdValidator implements ResourceValidator {
         return "PMD";
     }
 
+    @Override
+    public int rules() {
+        return new SourceValidator(this.env.encoding()).rules();
+    }
+
     /**
      * Filters out excluded files from further validation.
      * @param files Files to validate

--- a/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -16,6 +16,7 @@ import java.util.List;
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.PmdAnalysis;
 import net.sourceforge.pmd.lang.rule.RulePriority;
+import net.sourceforge.pmd.lang.rule.RuleSet;
 import net.sourceforge.pmd.reporting.Report;
 import net.sourceforge.pmd.reporting.RuleViolation;
 import org.cactoos.list.ListOf;
@@ -53,14 +54,8 @@ final class SourceValidator {
      */
     Collection<PmdError> validate(
         final Collection<File> sources, final String path) {
-        this.config.setRuleSets(new ListOf<>("com/qulice/pmd/ruleset.xml"));
-        this.config.setThreads(0);
-        this.config.setMinimumPriority(RulePriority.LOW);
-        this.config.setIgnoreIncrementalAnalysis(true);
-        this.config.setShowSuppressedViolations(true);
-        this.config.setSourceEncoding(this.encoding);
         final List<PmdError> errors = new ArrayList<>(0);
-        try (PmdAnalysis analysis = PmdAnalysis.create(this.config)) {
+        try (PmdAnalysis analysis = PmdAnalysis.create(this.configured())) {
             for (final File source : sources) {
                 Logger.debug(
                     this,
@@ -81,6 +76,35 @@ final class SourceValidator {
                 .forEach(errors::add);
         }
         return errors;
+    }
+
+    /**
+     * How many rules the ruleset holds, once PMD has resolved the
+     * categories it refers to and taken the exclusions out.
+     * @return The number of rules
+     */
+    int rules() {
+        int total = 0;
+        try (PmdAnalysis analysis = PmdAnalysis.create(this.configured())) {
+            for (final RuleSet set : analysis.getRulesets()) {
+                total += set.size();
+            }
+        }
+        return total;
+    }
+
+    /**
+     * The PMD configuration, with the Qulice ruleset in it.
+     * @return Configuration to run PMD with
+     */
+    private PMDConfiguration configured() {
+        this.config.setRuleSets(new ListOf<>("com/qulice/pmd/ruleset.xml"));
+        this.config.setThreads(0);
+        this.config.setMinimumPriority(RulePriority.LOW);
+        this.config.setIgnoreIncrementalAnalysis(true);
+        this.config.setShowSuppressedViolations(true);
+        this.config.setSourceEncoding(this.encoding);
+        return this.config;
     }
 
     /**

--- a/src/main/java/com/qulice/spi/ResourceValidator.java
+++ b/src/main/java/com/qulice/spi/ResourceValidator.java
@@ -25,4 +25,10 @@ public interface ResourceValidator {
      * @return Name of this validator
      */
     String name();
+
+    /**
+     * How many rules this validator applies to every file it reads.
+     * @return Number of rules, or zero when the validator cannot tell
+     */
+    int rules();
 }

--- a/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -82,6 +82,15 @@ final class CheckstyleValidatorTest {
     }
 
     @Test
+    void countsRulesItApplies() throws Exception {
+        MatcherAssert.assertThat(
+            "Checkstyle cannot stay silent about how many rules it applies",
+            new CheckstyleValidator(new Environment.Mock()).rules(),
+            Matchers.greaterThan(100)
+        );
+    }
+
+    @Test
     void failsClearlyWhenCacheParentIsNotWritable() throws Exception {
         final Environment.Mock mock = new Environment.Mock();
         final File parent = new File(mock.tempdir(), "checkstyle");

--- a/src/test/java/com/qulice/maven/BlockedValidator.java
+++ b/src/test/java/com/qulice/maven/BlockedValidator.java
@@ -58,6 +58,11 @@ final class BlockedValidator implements ResourceValidator {
         return "blocked forever";
     }
 
+    @Override
+    public int rules() {
+        return 0;
+    }
+
     int count() {
         return this.cnt.get();
     }

--- a/src/test/java/com/qulice/maven/FakeResourceValidator.java
+++ b/src/test/java/com/qulice/maven/FakeResourceValidator.java
@@ -13,9 +13,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A test fake {@link ResourceValidator} that records how many times
- * {@code validate} was invoked and reports a configurable name through
- * {@link #name()}. The validate call always returns an empty
- * collection, so {@code CheckMojo} treats the run as clean.
+ * {@code validate} was invoked and reports a configurable name and
+ * rule count through {@link #name()} and {@link #rules()}. The validate
+ * call always returns an empty collection, so {@code CheckMojo} treats
+ * the run as clean.
  * @since 0.27.0
  */
 final class FakeResourceValidator implements ResourceValidator {
@@ -26,12 +27,22 @@ final class FakeResourceValidator implements ResourceValidator {
     private final String label;
 
     /**
+     * How many rules this validator pretends to apply.
+     */
+    private final int total;
+
+    /**
      * Method calls counter.
      */
     private final AtomicInteger cnt;
 
     FakeResourceValidator(final String name) {
+        this(name, 0);
+    }
+
+    FakeResourceValidator(final String name, final int rules) {
         this.label = name;
+        this.total = rules;
         this.cnt = new AtomicInteger(0);
     }
 
@@ -44,6 +55,11 @@ final class FakeResourceValidator implements ResourceValidator {
     @Override
     public String name() {
         return this.label;
+    }
+
+    @Override
+    public int rules() {
+        return this.total;
     }
 
     int count() {

--- a/src/test/java/com/qulice/maven/SummaryTest.java
+++ b/src/test/java/com/qulice/maven/SummaryTest.java
@@ -58,8 +58,20 @@ final class SummaryTest {
         MatcherAssert.assertThat(
             "Summary without rules cannot carry an empty pair of brackets",
             new Summary(
-                Collections.emptyList(),
+                Collections.singleton(new File("pom.xml")),
                 Collections.singleton(new FakeResourceValidator("Zeta", 0))
+            ).toString(),
+            Matchers.equalTo("checked 0 .java files against 0 rules")
+        );
+    }
+
+    @Test
+    void countsNoRulesWhenNothingReachedValidators() {
+        MatcherAssert.assertThat(
+            "Rules cannot be counted when no file went to the validators",
+            new Summary(
+                Collections.emptyList(),
+                Collections.singleton(new FakeResourceValidator("Eta", 12))
             ).toString(),
             Matchers.equalTo("checked 0 .java files against 0 rules")
         );

--- a/src/test/java/com/qulice/maven/SummaryTest.java
+++ b/src/test/java/com/qulice/maven/SummaryTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Summary} class.
+ * @since 1.0
+ */
+final class SummaryTest {
+
+    @Test
+    void countsJavaFilesAndRulesOfEveryValidator() {
+        MatcherAssert.assertThat(
+            "Summary must count the Java files checked and the rules applied",
+            new Summary(
+                Arrays.asList(
+                    new File("Broken.java"),
+                    new File("pom.xml"),
+                    new File("Fixed.JAVA")
+                ),
+                Arrays.asList(
+                    new FakeResourceValidator("Alpha", 41),
+                    new FakeResourceValidator("Beta", 7)
+                )
+            ).toString(),
+            Matchers.equalTo(
+                "checked 2 .java files against 48 rules (41 Alpha, 7 Beta)"
+            )
+        );
+    }
+
+    @Test
+    void skipsValidatorThatCountsNoRules() {
+        MatcherAssert.assertThat(
+            "Validator without rules cannot show up in the summary",
+            new Summary(
+                Collections.singleton(new File("Main.java")),
+                Arrays.asList(
+                    new FakeResourceValidator("Gamma", 3),
+                    new FakeResourceValidator("Delta", 0)
+                )
+            ).toString(),
+            Matchers.equalTo("checked 1 .java file against 3 rules (3 Gamma)")
+        );
+    }
+
+    @Test
+    void mentionsNoRulesWhenNobodyCounts() {
+        MatcherAssert.assertThat(
+            "Summary without rules cannot carry an empty pair of brackets",
+            new Summary(
+                Collections.emptyList(),
+                Collections.singleton(new FakeResourceValidator("Zeta", 0))
+            ).toString(),
+            Matchers.equalTo("checked 0 .java files against 0 rules")
+        );
+    }
+}

--- a/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -35,6 +35,15 @@ final class PmdValidatorTest {
     }
 
     @Test
+    void countsRulesItApplies() throws Exception {
+        MatcherAssert.assertThat(
+            "PMD cannot stay silent about how many rules it applies",
+            new PmdValidator(new Environment.Mock()).rules(),
+            Matchers.greaterThan(100)
+        );
+    }
+
+    @Test
     void acceptsJavaFilesWithUppercaseExtension() throws Exception {
         final String file = "src/main/java/Main.JAVA";
         final Environment env = new Environment.Mock()


### PR DESCRIPTION
The line Qulice prints at the end of a check now says what the run covered, not just how long it took:

```
[INFO] Qulice checked 533 .java files against 520 rules (237 Checkstyle, 283 PMD) in 9s
```

Every `ResourceValidator` now answers for its own rules through a new `rules()` method, so nobody counts on somebody else's behalf: Checkstyle counts the modules of the configuration it loads (filters and holders left out, since they silence violations instead of finding them), and PMD counts the rules it resolves out of `ruleset.xml`, which is the only honest number there — the file refers to whole categories minus exclusions. `CheckMojo` counts the `.java` files among those it hands to the validators, and `Summary` puts the line together.

Seven seconds means one thing for a module with three classes and another for a module with three hundred, and the old line let no one tell which had just happened.

ErrorProne stays out of the breakdown for now, since it cannot count its bug patterns without reaching into `error_prone_core`, a runtime-scoped jar; a puzzle in its Javadoc says so. The `log-check` integration test asserts the new shape of the line.

Closes #1736