### PR TITLE
Count the ErrorProne bug patterns that fire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,9 +307,19 @@
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_check_api</artifactId>
+      <version>2.49.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>
       <version>2.49.0</version>
-      <scope>runtime</scope>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.gson</groupId>

--- a/src/it/hibernate-validator-check/verify.groovy
+++ b/src/it/hibernate-validator-check/verify.groovy
@@ -6,4 +6,4 @@
 
 def log = new File(basedir, 'build.log')
 assert !log.text.contains('JSR-303 validator failed to initialize')
-assert log.text =~ /Qulice checked 2 \.java files against \d+ rules \(\d+ Checkstyle, \d+ PMD\) in \d+(ms|s|min|hr)/
+assert log.text =~ /Qulice checked 2 \.java files against \d+ rules \(\d+ Checkstyle, \d+ PMD, \d+ ErrorProne\) in \d+(ms|s|min|hr)/

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -49,14 +49,6 @@ import java.util.regex.Pattern;
  * {@code qulice.errorprone} parameter.</p>
  *
  * @since 1.0
- * @todo #1736:60min Count the bug patterns this validator applies, so that
- *  {@code rules()} stops returning zero and ErrorProne joins the summary
- *  Qulice prints when a check completes. The number starts at
- *  {@code BuiltInCheckerSuppliers.defaultChecks()}, minus the patterns
- *  {@link Xplugin} switches off and plus the ones the project switches back
- *  on. That class lives in {@code error_prone_core}, a runtime dependency of
- *  this plugin, so counting them means either promoting the jar to compile
- *  scope or asking the forked {@code javac} for the number.
  */
 public final class ErrorProneValidator implements ResourceValidator {
 
@@ -145,7 +137,9 @@ public final class ErrorProneValidator implements ResourceValidator {
 
     @Override
     public int rules() {
-        return 0;
+        return new Xplugin(
+            this.env.param(ErrorProneValidator.PARAM, "")
+        ).patterns();
     }
 
     /**

--- a/src/main/java/com/qulice/errorprone/Xplugin.java
+++ b/src/main/java/com/qulice/errorprone/Xplugin.java
@@ -4,6 +4,8 @@
  */
 package com.qulice.errorprone;
 
+import com.google.errorprone.ErrorProneOptions;
+import com.google.errorprone.scanner.BuiltInCheckerSuppliers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -86,13 +88,41 @@ public final class Xplugin {
      * @return The whole {@code -Xplugin:ErrorProne ...} argument
      */
     public String argument() {
+        return String.format(
+            "-Xplugin:ErrorProne %s", String.join(" ", this.flags())
+        );
+    }
+
+    /**
+     * How many bug patterns fire with these flags.
+     *
+     * <p>ErrorProne answers this itself: the count starts at the patterns
+     * it enables by default and then the very flags the forked
+     * {@code javac} receives are applied to it, so a pattern Qulice
+     * switches off leaves the count and one the project switches back on
+     * rejoins it.</p>
+     *
+     * @return The number of bug patterns that judge every file
+     */
+    public int patterns() {
+        return BuiltInCheckerSuppliers.defaultChecks()
+            .applyOverrides(ErrorProneOptions.processArgs(this.flags()))
+            .getEnabledChecks()
+            .size();
+    }
+
+    /**
+     * The {@code -Xep} flags, Qulice's own first and the project's after
+     * them.
+     * @return Flags, in the order ErrorProne reads them
+     */
+    private List<String> flags() {
         final List<String> flags = new ArrayList<>(
             Xplugin.DISABLED.size() + 4
         );
-        flags.add("-Xplugin:ErrorProne");
         flags.addAll(Xplugin.DISABLED);
         flags.addAll(this.extras());
-        return String.join(" ", flags);
+        return flags;
     }
 
     /**

--- a/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
@@ -19,6 +19,15 @@ import org.junit.jupiter.api.Test;
 final class ErrorProneValidatorTest {
 
     @Test
+    void countsRulesItApplies() throws Exception {
+        MatcherAssert.assertThat(
+            "ErrorProne must tell how many bug patterns it applies",
+            new ErrorProneValidator(new Environment.Mock()).rules(),
+            Matchers.greaterThan(100)
+        );
+    }
+
+    @Test
     void findsViolationInBadJavaFile() throws Exception {
         final String file = "src/main/java/Bad.java";
         final Environment env = new Environment.Mock().withFile(

--- a/src/test/java/com/qulice/errorprone/XpluginTest.java
+++ b/src/test/java/com/qulice/errorprone/XpluginTest.java
@@ -56,6 +56,33 @@ final class XpluginTest {
     }
 
     @Test
+    void countsPatternsThatFire() {
+        MatcherAssert.assertThat(
+            "ErrorProne cannot stay silent about how many patterns it applies",
+            new Xplugin("").patterns(),
+            Matchers.greaterThan(100)
+        );
+    }
+
+    @Test
+    void countsOnePatternFewerWhenProjectSwitchesOneOff() {
+        MatcherAssert.assertThat(
+            "a pattern the project switches off must leave the count",
+            new Xplugin("-Xep:UnusedVariable:OFF").patterns(),
+            Matchers.equalTo(new Xplugin("").patterns() - 1)
+        );
+    }
+
+    @Test
+    void countsOnePatternMoreWhenProjectSwitchesOneBackOn() {
+        MatcherAssert.assertThat(
+            "a pattern the project switches back on must join the count",
+            new Xplugin("-Xep:OperatorPrecedence:ERROR").patterns(),
+            Matchers.equalTo(new Xplugin("").patterns() + 1)
+        );
+    }
+
+    @Test
     void refusesFlagErrorProneWouldNotUnderstand() {
         MatcherAssert.assertThat(
             "the flag that cannot work must be named in the failure",


### PR DESCRIPTION
ErrorProne now says how many bug patterns judge the code, so it joins the other two in the line printed when a check completes:

```
[INFO] Qulice checked 533 .java files against 1006 rules (237 Checkstyle, 283 PMD, 486 ErrorProne) in 8s
```

`Xplugin` already builds the `-Xep` flags for the forked `javac`, so it now hands those same flags to ErrorProne's own `ScannerSupplier.applyOverrides` and counts what stays enabled. No flag parsing of our own: a pattern Qulice switches off leaves the count, one the project switches back on rejoins it, and two tests pin exactly that. Before this, `rules()` returned a hard-coded zero and `Summary` dropped ErrorProne from the tally, which made 520 look like the whole story when it was half of it.

This needs `error_prone_core` and `error_prone_check_api` at compile scope instead of runtime — the only cost of the change, and the reason the puzzle in `ErrorProneValidator` was left open rather than solved in place. That puzzle is gone now.

Closes #1738