### PR TITLE
fix(maven): #1741 give tempdir() a directory of its own

### DIFF
--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -105,7 +105,15 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     @Override
     public File tempdir() {
-        return new File(this.iproject.getBuild().getOutputDirectory());
+        final File dir = new File(
+            this.iproject.getBuild().getDirectory(), "tempdir"
+        );
+        if (!dir.mkdirs() && !dir.isDirectory()) {
+            throw new IllegalStateException(
+                String.format("Cannot create tempdir at %s", dir)
+            );
+        }
+        return dir;
     }
 
     @Override

--- a/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -391,4 +391,55 @@ final class DefaultMavenEnvironmentTest {
             )
         );
     }
+
+    /**
+     * DefaultMavenEnvironment.tempdir() must not point at the directory
+     * with compiled classes, otherwise validators drop their scratch files
+     * into {@code target/classes} and they end up in the JAR and confuse
+     * {@code jacoco:report}
+     * (see <a href="https://github.com/yegor256/qulice/issues/1741">
+     * issue #1741</a>).
+     * @param basedir Temporary base directory
+     */
+    @Test
+    void keepsTempdirOutsideOutdir(@TempDir final Path basedir) {
+        final Path target = basedir.resolve("target");
+        final Build build = new Build();
+        build.setDirectory(target.toAbsolutePath().toString());
+        build.setOutputDirectory(
+            target.resolve("classes").toAbsolutePath().toString()
+        );
+        final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
+        env.setProject(
+            new MavenProjectStub() {
+                @Override
+                public File getBasedir() {
+                    return basedir.toFile();
+                }
+
+                @Override
+                public Build getBuild() {
+                    return build;
+                }
+            }
+        );
+        final File temp = env.tempdir();
+        MatcherAssert.assertThat(
+            "Temporary directory must be ready to use",
+            temp.isDirectory(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "Temporary directory must not be inside the output directory",
+            temp.toPath().toAbsolutePath()
+                .startsWith(env.outdir().toPath().toAbsolutePath()),
+            Matchers.is(false)
+        );
+        MatcherAssert.assertThat(
+            "Temporary directory must be inside the build directory",
+            temp.toPath().toAbsolutePath()
+                .startsWith(target.toAbsolutePath()),
+            Matchers.is(true)
+        );
+    }
 }

--- a/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -423,22 +423,12 @@ final class DefaultMavenEnvironmentTest {
                 }
             }
         );
-        final File temp = env.tempdir();
+        final Path temp = env.tempdir().toPath().toAbsolutePath();
         MatcherAssert.assertThat(
-            "Temporary directory must be ready to use",
-            temp.isDirectory(),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            "Temporary directory must not be inside the output directory",
-            temp.toPath().toAbsolutePath()
-                .startsWith(env.outdir().toPath().toAbsolutePath()),
-            Matchers.is(false)
-        );
-        MatcherAssert.assertThat(
-            "Temporary directory must be inside the build directory",
-            temp.toPath().toAbsolutePath()
-                .startsWith(target.toAbsolutePath()),
+            "Scratch dir must be usable, under target/ and away from classes",
+            env.tempdir().isDirectory()
+                && temp.startsWith(target.toAbsolutePath())
+                && !temp.startsWith(env.outdir().toPath().toAbsolutePath()),
             Matchers.is(true)
         );
     }


### PR DESCRIPTION
Closes #1741.

`DefaultMavenEnvironment.tempdir()` returned `getBuild().getOutputDirectory()` — the very same value `outdir()` returns two lines below it. Every validator that asked for scratch space therefore wrote into `target/classes`: `ErrorProneValidator` created `errorprone-classes-main`/`errorprone-classes-test` and its `errorprone-args-*.txt` files there, `CheckstyleValidator` put `checkstyle/checkstyle.cache` there, and `UnusedSuppressions` its own cache files. Every compiled class then existed twice under the output directory, so `jacoco:report` died with `Can't add different class with same name: ...` and a build without `clean` packaged the scratch directories into the artifact.

Changes:

* `DefaultMavenEnvironment.tempdir()` now returns `new File(getBuild().getDirectory(), "tempdir")` — the same layout `Environment.Mock.tempdir()` has always used — and creates it, since callers such as `Argfile` write straight into it without creating parents themselves.
* New test `keepsTempdirOutsideOutdir` in `DefaultMavenEnvironmentTest` asserts the temporary directory exists, sits under the build directory, and is not inside `outdir()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKqdpfkdxqrJsYQHTe7mzz)_