### PR TITLE
fix(errorprone): #1745 give every source root a batch of its own

### DIFF
--- a/src/main/java/com/qulice/errorprone/Batches.java
+++ b/src/main/java/com/qulice/errorprone/Batches.java
@@ -1,0 +1,183 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.errorprone;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Relative;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.apache.commons.io.FilenameUtils;
+
+/**
+ * Java sources split the way Maven compiles them: one batch per source
+ * root, never two roots in one batch.
+ *
+ * <p>A single {@code javac} pass over two roots would manufacture
+ * diagnostics no project could ever silence, because Maven lets every
+ * source root hold a twin of the same file. The clearest case is
+ * {@code package-info.java}, which Qulice's own {@code JavadocPackage}
+ * check demands in every package: with one pass, a package present in two
+ * roots earns {@code a package-info.java file has already been seen} and,
+ * once the file carries an annotation, {@code has already been
+ * annotated}.</p>
+ *
+ * <p>The roots a file may sit under are the ones the project declares,
+ * which is what {@link Environment#testdirs()} reports. Matching the
+ * {@code /src/test/} path fragment instead would miss every further root a
+ * project registers through
+ * {@code build-helper-maven-plugin:add-test-source} — {@code src/mock/java}
+ * in the jcabi parent POM (see
+ * <a href="https://github.com/yegor256/qulice/issues/1742">#1742</a>).
+ * Folding all of those roots into one {@code test} batch does not help
+ * either: {@code src/test/java} and {@code src/mock/java} are as free to
+ * hold twins as {@code src/main/java} and {@code src/test/java} are, so
+ * each root earns a batch of its own (see
+ * <a href="https://github.com/yegor256/qulice/issues/1745">#1745</a>). A
+ * file under none of them belongs to the main batch. Cross-batch
+ * references still resolve, since the project's own compiled classes are
+ * on the {@code -classpath} of every pass.</p>
+ *
+ * @since 1.0
+ */
+public final class Batches {
+
+    /**
+     * Runs of characters that have no place in a file name, in the path of
+     * a source root that {@link #label(File, int)} turns into a batch name.
+     */
+    private static final Pattern SEPARATOR = Pattern.compile("[^A-Za-z0-9]+");
+
+    /**
+     * The dashes {@link #SEPARATOR} leaves at either end of a batch name.
+     */
+    private static final Pattern EDGES = Pattern.compile("^-+|-+$");
+
+    /**
+     * Name of the batch of the sources that sit under no declared test
+     * source root.
+     */
+    private static final String MAIN = "main";
+
+    /**
+     * Environment that knows the source roots.
+     */
+    private final Environment env;
+
+    /**
+     * Java source files to split.
+     */
+    private final List<File> sources;
+
+    /**
+     * Constructor.
+     * @param env Environment that knows the source roots
+     * @param sources Java source files to split
+     */
+    public Batches(final Environment env, final List<File> sources) {
+        this.env = env;
+        this.sources = sources;
+    }
+
+    /**
+     * Split the sources, one batch per source root.
+     * @return Batches by name, in compilation order, none of them empty
+     */
+    public Map<String, List<File>> split() {
+        final Map<String, String> roots = new LinkedHashMap<>(0);
+        int index = 0;
+        for (final File dir : this.env.testdirs()) {
+            index += 1;
+            roots.putIfAbsent(
+                Batches.slashed(dir).concat("/"), this.label(dir, index)
+            );
+        }
+        final Map<String, List<File>> batches = new LinkedHashMap<>(0);
+        batches.put(Batches.MAIN, new ArrayList<>(0));
+        for (final String name : roots.values()) {
+            batches.put(name, new ArrayList<>(0));
+        }
+        for (final File source : this.sources) {
+            batches.get(
+                Batches.owner(Batches.slashed(source), roots)
+            ).add(source);
+        }
+        batches.values().removeIf(List::isEmpty);
+        return batches;
+    }
+
+    /**
+     * The name of the batch of the given source root.
+     *
+     * <p>Batch names end up inside file names, so the path of the root is
+     * reduced to letters and digits. The position of the root among the
+     * ones the project declares is prepended, because that reduction is not
+     * injective — {@code src/mock-java} and {@code src/mock/java} share a
+     * shape — and two roots sharing a name would land in one batch, which
+     * is the very thing this split prevents.</p>
+     *
+     * @param root The source root
+     * @param index Its position among the roots, one-based
+     * @return Name of the batch, safe to use in a file name
+     */
+    private String label(final File root, final int index) {
+        return String.format(
+            "test-%d-%s",
+            index,
+            Batches.EDGES.matcher(
+                Batches.SEPARATOR.matcher(
+                    new Relative(this.env.basedir(), root).path()
+                ).replaceAll("-")
+            ).replaceAll("")
+        );
+    }
+
+    /**
+     * The batch a source file belongs to: the root it sits under, or the
+     * main batch when it sits under none of them.
+     *
+     * <p>The longest matching root wins, so that a root nested inside
+     * another one — {@code src/test} and {@code src/test/java} both
+     * declared, say — claims its own files instead of leaving them to the
+     * root above.</p>
+     *
+     * @param path Normalized absolute path of the file
+     * @param roots Batch name by root path, each ending with a slash
+     * @return Name of the batch
+     */
+    private static String owner(final String path,
+        final Map<String, String> roots) {
+        String name = Batches.MAIN;
+        int longest = 0;
+        for (final Map.Entry<String, String> root : roots.entrySet()) {
+            final String dir = root.getKey();
+            if (dir.length() > longest && path.startsWith(dir)) {
+                longest = dir.length();
+                name = root.getValue();
+            }
+        }
+        return name;
+    }
+
+    /**
+     * The absolute path of a file, in one shape: forward slashes, no
+     * {@code .} or {@code ..} steps. Source roots arrive from the POM
+     * while sources arrive from walking the disk, so only a normalized
+     * form makes the two comparable as text.
+     * @param file File to render
+     * @return Its absolute path
+     */
+    private static String slashed(final File file) {
+        final String absolute = file.getAbsolutePath();
+        String path = FilenameUtils.normalize(absolute, true);
+        if (path == null) {
+            path = absolute.replace(File.separatorChar, '/');
+        }
+        return path;
+    }
+}

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -17,13 +17,11 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.apache.commons.io.FilenameUtils;
 
 /**
  * Validates source code with Google ErrorProne.
@@ -48,6 +46,11 @@ import org.apache.commons.io.FilenameUtils;
  * <p>Which bug patterns fire is up to {@link Xplugin}, which also takes
  * in the {@code -Xep} flags of the project, read from the
  * {@code qulice.errorprone} parameter.</p>
+ *
+ * <p>The sources are not fed to one {@code javac} pass but to as many as
+ * the project has source roots, which is what {@link Batches} works out;
+ * the name of each batch tells the passes apart on disk, both in the
+ * argfile they read and in the directory they write classes to.</p>
  *
  * @since 1.0
  */
@@ -114,7 +117,7 @@ public final class ErrorProneValidator implements ResourceValidator {
                 this.name(), this.env.basedir().getAbsolutePath()
             );
             for (final Map.Entry<String, List<File>> batch
-                : this.batches(sources).entrySet()) {
+                : new Batches(this.env, sources).split().entrySet()) {
                 violations.addAll(
                     diagnostics.violations(
                         this.run(batch.getKey(), batch.getValue())
@@ -136,74 +139,6 @@ public final class ErrorProneValidator implements ResourceValidator {
         return new Xplugin(
             this.env.param(ErrorProneValidator.PARAM, "")
         ).patterns();
-    }
-
-    /**
-     * Split the sources the way Maven compiles them: main sources in one
-     * batch, test sources in another.
-     *
-     * <p>A single {@code javac} pass over both would manufacture
-     * diagnostics no project could ever silence, because Maven's two
-     * source roots are allowed to hold twins of the same file. The
-     * clearest case is {@code package-info.java}, which Qulice's own
-     * {@code JavadocPackage} check demands in every package: with one
-     * pass, a package that has both main and test code earns
-     * {@code a package-info.java file has already been seen} and, once
-     * the file carries an annotation, {@code has already been
-     * annotated}.</p>
-     *
-     * <p>A file counts as a test when it lives under one of the test source
-     * roots the project declares, which is what {@link Environment#testdirs()}
-     * reports. Matching the {@code /src/test/} path fragment instead would
-     * miss every further root a project registers through
-     * {@code build-helper-maven-plugin:add-test-source} — {@code src/mock/java}
-     * in the jcabi parent POM — and the files there would join the main batch,
-     * earning exactly the diagnostic this split exists to prevent (see
-     * <a href="https://github.com/yegor256/qulice/issues/1742">#1742</a>).</p>
-     *
-     * @param sources Java source files to split
-     * @return Batches by name, in compilation order, none of them empty
-     */
-    private Map<String, List<File>> batches(final List<File> sources) {
-        final Collection<String> roots = new ArrayList<>(0);
-        for (final File dir : this.env.testdirs()) {
-            roots.add(ErrorProneValidator.slashed(dir).concat("/"));
-        }
-        final List<File> main = new ArrayList<>(sources.size());
-        final List<File> tests = new ArrayList<>(sources.size());
-        for (final File source : sources) {
-            final String path = ErrorProneValidator.slashed(source);
-            if (roots.stream().anyMatch(path::startsWith)) {
-                tests.add(source);
-            } else {
-                main.add(source);
-            }
-        }
-        final Map<String, List<File>> batches = new LinkedHashMap<>(2);
-        if (!main.isEmpty()) {
-            batches.put("main", main);
-        }
-        if (!tests.isEmpty()) {
-            batches.put("test", tests);
-        }
-        return batches;
-    }
-
-    /**
-     * The absolute path of a file, in one shape: forward slashes, no
-     * {@code .} or {@code ..} steps. Source roots arrive from the POM
-     * while sources arrive from walking the disk, so only a normalized
-     * form makes the two comparable as text.
-     * @param file File to render
-     * @return Its absolute path
-     */
-    private static String slashed(final File file) {
-        final String absolute = file.getAbsolutePath();
-        String path = FilenameUtils.normalize(absolute, true);
-        if (path == null) {
-            path = absolute.replace(File.separatorChar, '/');
-        }
-        return path;
     }
 
     /**

--- a/src/test/java/com/qulice/errorprone/BatchesTest.java
+++ b/src/test/java/com/qulice/errorprone/BatchesTest.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.errorprone;
+
+import com.qulice.spi.Environment;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Batches}.
+ * @since 1.0
+ */
+final class BatchesTest {
+
+    @Test
+    void keepsEveryTestRootApart() {
+        final Environment env = new Environment.Mock()
+            .withTestdir("src/mock/java");
+        final Map<String, List<File>> batches = new Batches(
+            env,
+            Arrays.asList(
+                new File(env.basedir(), "src/main/java/com/qulice/Foo.java"),
+                new File(env.basedir(), "src/test/java/com/qulice/Foo.java"),
+                new File(env.basedir(), "src/mock/java/com/qulice/Foo.java")
+            )
+        ).split();
+        MatcherAssert.assertThat(
+            String.format(
+                "each source root must compile on its own: %s", batches
+            ),
+            batches.keySet(),
+            Matchers.contains("main", "test-1-src-mock-java", "test-2-src-test")
+        );
+    }
+
+    @Test
+    void namesBatchesAfterTheirRoots() {
+        final Environment env = new Environment.Mock()
+            .withTestdir("src/mock/java");
+        final Map<String, List<File>> batches = new Batches(
+            env,
+            Collections.singletonList(
+                new File(env.basedir(), "src/mock/java/com/qulice/Foo.java")
+            )
+        ).split();
+        MatcherAssert.assertThat(
+            String.format(
+                "the batch of a root must be named after it: %s", batches
+            ),
+            batches.keySet(),
+            Matchers.contains("test-1-src-mock-java")
+        );
+    }
+
+    @Test
+    void skipsEmptyBatches() {
+        final Environment env = new Environment.Mock()
+            .withTestdir("src/mock/java");
+        final Map<String, List<File>> batches = new Batches(
+            env,
+            Collections.singletonList(
+                new File(env.basedir(), "src/main/java/com/qulice/Foo.java")
+            )
+        ).split();
+        MatcherAssert.assertThat(
+            String.format("a root without sources needs no pass: %s", batches),
+            batches.keySet(),
+            Matchers.contains("main")
+        );
+    }
+
+    @Test
+    void givesNestedRootItsOwnBatch() {
+        final Environment env = new Environment.Mock()
+            .withTestdir("src/test/java/it");
+        final File outer = new File(
+            env.basedir(), "src/test/java/com/qulice/Foo.java"
+        );
+        final File inner = new File(
+            env.basedir(), "src/test/java/it/com/qulice/Foo.java"
+        );
+        final Map<String, List<File>> batches = new Batches(
+            env, Arrays.asList(outer, inner)
+        ).split();
+        MatcherAssert.assertThat(
+            String.format(
+                "a root nested in another must claim its files: %s", batches
+            ),
+            batches.get("test-1-src-test-java-it"),
+            Matchers.contains(inner)
+        );
+    }
+}

--- a/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
@@ -189,6 +189,37 @@ final class ErrorProneValidatorTest {
     }
 
     @Test
+    void doesNotBlameProjectForTwinPackageInfoInTestRoots() throws Exception {
+        final String test = "src/test/java/com/qulice/package-info.java";
+        final String mock = "src/mock/java/com/qulice/package-info.java";
+        final String body = String.join(
+            System.lineSeparator(),
+            "/**",
+            " * Sample.",
+            " * @since 1.0",
+            " */",
+            "package com.qulice;"
+        );
+        final Environment env = new Environment.Mock()
+            .withTestdir("src/mock/java")
+            .withFile(test, body).withFile(mock, body);
+        final java.util.Collection<Violation> violations =
+            new ErrorProneValidator(env).validate(
+                java.util.Arrays.asList(
+                    new File(env.basedir(), test), new File(env.basedir(), mock)
+                )
+            );
+        MatcherAssert.assertThat(
+            String.format(
+                "two test source roots must compile apart from each other: %s",
+                violations
+            ),
+            violations,
+            Matchers.<Violation>empty()
+        );
+    }
+
+    @Test
     void reportsPlainCompilerError() throws Exception {
         final String file = "src/main/java/com/qulice/Broken.java";
         final Environment env = new Environment.Mock().withFile(


### PR DESCRIPTION
Closes #1745.

## The bug

The fix for #1742 taught `batches()` to tell a test file from a main one by the roots `Environment.testdirs()` reports, but folded every one of those roots into a single `test` batch. A project with two test roots — `src/test/java` plus the `src/mock/java` that the jcabi parent POM registers through `build-helper-maven-plugin:add-test-source` — therefore handed one `javac` pass two `package-info.java` files for the same package:

```
src/mock/java/com/qulice/package-info.java:5: warning: a package-info.java file has already been seen for package com.qulice
```

The collision had moved rather than gone. `src/test/java` and `src/mock/java` are as free to hold twins as `src/main/java` and `src/test/java` are, and deleting the twin is no escape, because Checkstyle's `JavadocPackageCheck` then demands it back — the deadlock of #572, this time made by Qulice's own batching.

## The fix

The splitting moves out of `ErrorProneValidator` into a new `Batches` class (the validator was already at PMD's `GodClass` limit), which keys a batch by the root its files sit under instead of merging all roots under one key:

- one batch per declared source root, so no `javac` pass ever sees two `package-info.java` files for one package;
- the longest matching root wins, so a root nested inside another claims its own files;
- files under no declared root belong to the `main` batch, as before;
- cross-batch references still resolve, since the project's compiled classes stay on the `-classpath` of every pass.

Batch names end up in file names — the argfile a pass reads and the directory it writes classes to — so the path of a root is reduced to letters and digits (`/src/mock/java` → `test-1-src-mock-java`). Its position among the declared roots is prefixed because that reduction is not injective, and two roots sharing a name would land in one batch, which is the very thing the split prevents.

## Tests

- `BatchesTest` — four cases: every root gets its own batch, batches are named after their roots, a root without sources yields no pass, and a nested root claims its own files.
- `ErrorProneValidatorTest.doesNotBlameProjectForTwinPackageInfoInTestRoots` — end-to-end reproduction: `package-info.java` in both `src/test/java` and `src/mock/java` for one package. It fails on `master` with the exact diagnostic from the issue and passes with this change.

`mvn -Pqulice install` is green, including Qulice's check of its own sources.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J3KCvVmr2Q9oqb4TiLW3vT)_