### PR TITLE
fix(errorprone): #1746 compile the test batch at its own source level

### DIFF
--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -238,7 +238,7 @@ public final class ErrorProneValidator implements ResourceValidator {
      * <p>{@code -Xlint:-options} turns off the one lint category that
      * would report Qulice to the project instead of the project to the
      * user: {@code options} complains about the {@code -source}/
-     * {@code -target} pair this class deliberately builds in place of
+     * {@code -target} pair {@link Release} deliberately builds in place of
      * {@code --release} (see
      * <a href="https://github.com/yegor256/qulice/issues/1716">#1716</a>),
      * and no change to the project could ever silence it.</p>
@@ -277,7 +277,7 @@ public final class ErrorProneValidator implements ResourceValidator {
         args.add("-Xlint:-options");
         args.add("-encoding");
         args.add(this.env.encoding().name());
-        args.addAll(this.release());
+        args.addAll(new Release(this.env, batch).flags());
         args.add(
             new Xplugin(
                 this.env.param(ErrorProneValidator.PARAM, "")
@@ -307,92 +307,6 @@ public final class ErrorProneValidator implements ResourceValidator {
             )
         );
         return command;
-    }
-
-    /**
-     * The {@code javac} flags that pin the forked compiler to the project's
-     * own Java source level.
-     *
-     * <p>Without them the forked {@code javac} runs at the host JDK's default
-     * language level (e.g. 21 on a JDK 21 host), so ErrorProne fires
-     * syntax-modernising checks such as {@code PatternMatchingInstanceof}
-     * even on projects that compile at {@code -source 8}, producing
-     * suggestions whose rewrite does not compile under the project's real
-     * source level. The level is derived exactly as
-     * {@code CheckstyleValidator} derives it: {@code maven.compiler.release}
-     * first, then {@code maven.compiler.source}, accepting both the modern
-     * ({@code "8"}, {@code "17"}) and legacy ({@code "1.8"}) forms. When the
-     * project pins a {@code release}, {@code --release} is forwarded;
-     * otherwise {@code -source}/{@code -target} are, which gates the language
-     * features while leaving the API surface untouched so that projects using
-     * newer library APIs under a plain {@code -source} build do not gain
-     * spurious "cannot find symbol" errors. When neither property is set the
-     * level is unknown and nothing is added, leaving the host default in
-     * place. See
-     * <a href="https://github.com/yegor256/qulice/issues/1716">#1716</a>.</p>
-     *
-     * @return Source-level flags, possibly empty
-     */
-    private List<String> release() {
-        final List<String> flags = new ArrayList<>(4);
-        final int rel = ErrorProneValidator.major(
-            this.env.param("maven.compiler.release", "")
-        );
-        final int source = ErrorProneValidator.major(
-            this.env.param("maven.compiler.source", "")
-        );
-        if (rel >= 0) {
-            flags.add("--release");
-            flags.add(String.valueOf(rel));
-        } else if (source >= 0) {
-            flags.add("-source");
-            flags.add(String.valueOf(source));
-            flags.add("-target");
-            flags.add(String.valueOf(this.target(source)));
-        }
-        return flags;
-    }
-
-    /**
-     * The {@code -target} level to forward alongside {@code -source}.
-     *
-     * <p>Reads {@code maven.compiler.target}, falling back to the given
-     * source level when the project does not pin a target of its own, so
-     * that {@code javac}'s requirement of {@code target >= source} is
-     * always met.</p>
-     *
-     * @param fallback The source level to use when no target is pinned
-     * @return The target level
-     */
-    private int target(final int fallback) {
-        int level = ErrorProneValidator.major(
-            this.env.param("maven.compiler.target", "")
-        );
-        if (level < 0) {
-            level = fallback;
-        }
-        return level;
-    }
-
-    /**
-     * Parse a Java version string into its major number.
-     * @param value Version, e.g. {@code "8"}, {@code "1.8"} or {@code "17"}
-     * @return The major version, or {@code -1} if it cannot be parsed
-     */
-    private static int major(final String value) {
-        int result = -1;
-        if (value != null) {
-            String txt = value.trim();
-            if (txt.startsWith("1.")) {
-                txt = txt.substring(2);
-            }
-            try {
-                result = Integer.parseInt(txt);
-            } catch (final NumberFormatException ex) {
-                result = -1;
-            }
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/com/qulice/errorprone/Release.java
+++ b/src/main/java/com/qulice/errorprone/Release.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.errorprone;
+
+import com.qulice.spi.Environment;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The {@code javac} flags that pin the forked compiler to the Java source
+ * level of one batch of the project's sources.
+ *
+ * <p>Without them the forked {@code javac} runs at the host JDK's default
+ * language level (e.g. 21 on a JDK 21 host), so ErrorProne fires
+ * syntax-modernising checks such as {@code PatternMatchingInstanceof} even on
+ * projects that compile at {@code -source 8}, producing suggestions whose
+ * rewrite does not compile under the project's real source level. The level is
+ * derived exactly as {@code CheckstyleValidator} derives it:
+ * {@code maven.compiler.release} first, then {@code maven.compiler.source},
+ * accepting both the modern ({@code "8"}, {@code "17"}) and legacy
+ * ({@code "1.8"}) forms. When the project pins a {@code release},
+ * {@code --release} is forwarded; otherwise {@code -source}/{@code -target}
+ * are, which gates the language features while leaving the API surface
+ * untouched so that projects using newer library APIs under a plain
+ * {@code -source} build do not gain spurious "cannot find symbol" errors. When
+ * neither property is set the level is unknown and nothing is added, leaving
+ * the host default in place. See
+ * <a href="https://github.com/yegor256/qulice/issues/1716">#1716</a>.</p>
+ *
+ * <p>Maven does not oblige the main sources and the test sources to share a
+ * level: the {@code testCompile} goal reads {@code maven.compiler.testRelease},
+ * {@code maven.compiler.testSource} and {@code maven.compiler.testTarget}, so a
+ * project may compile its tests higher than its main code — as
+ * {@code hone-maven-plugin} does, staying usable from Java 8 while its own
+ * tests are written in Java 17. The test batch therefore derives its level from
+ * those properties first, and only when the project pins none of them does it
+ * fall back to the main ones, which keeps the fallback whole: a project that
+ * sets nothing test-specific is compiled exactly as before. See
+ * <a href="https://github.com/yegor256/qulice/issues/1746">#1746</a>.</p>
+ *
+ * @since 1.0
+ */
+final class Release {
+
+    /**
+     * Name of the batch that holds the test sources, as
+     * {@code ErrorProneValidator} names it.
+     */
+    private static final String TESTS = "test";
+
+    /**
+     * Environment to read the Maven properties from.
+     */
+    private final Environment env;
+
+    /**
+     * Name of the batch being compiled.
+     */
+    private final String batch;
+
+    /**
+     * Constructor.
+     * @param env Environment to read the Maven properties from
+     * @param batch Name of the batch being compiled
+     */
+    Release(final Environment env, final String batch) {
+        this.env = env;
+        this.batch = batch;
+    }
+
+    /**
+     * The source-level flags to append to the {@code javac} command line.
+     * @return Source-level flags, possibly empty
+     */
+    List<String> flags() {
+        List<String> flags = new ArrayList<>(0);
+        if (Release.TESTS.equals(this.batch)) {
+            flags = this.pinned(
+                "maven.compiler.testRelease",
+                "maven.compiler.testSource",
+                "maven.compiler.testTarget"
+            );
+        }
+        if (flags.isEmpty()) {
+            flags = this.pinned(
+                "maven.compiler.release",
+                "maven.compiler.source",
+                "maven.compiler.target"
+            );
+        }
+        return flags;
+    }
+
+    /**
+     * The flags a given trio of Maven properties asks for.
+     * @param release Name of the property holding the release level
+     * @param source Name of the property holding the source level
+     * @param target Name of the property holding the target level
+     * @return Source-level flags, empty when neither release nor source is set
+     */
+    private List<String> pinned(
+        final String release, final String source, final String target
+    ) {
+        final List<String> flags = new ArrayList<>(4);
+        final int rel = Release.major(this.env.param(release, ""));
+        final int level = Release.major(this.env.param(source, ""));
+        if (rel >= 0) {
+            flags.add("--release");
+            flags.add(String.valueOf(rel));
+        } else if (level >= 0) {
+            flags.add("-source");
+            flags.add(String.valueOf(level));
+            flags.add("-target");
+            flags.add(String.valueOf(this.target(target, level)));
+        }
+        return flags;
+    }
+
+    /**
+     * The {@code -target} level to forward alongside {@code -source}.
+     *
+     * <p>Reads the given property, falling back to the given source level when
+     * the project does not pin a target of its own, so that {@code javac}'s
+     * requirement of {@code target >= source} is always met.</p>
+     *
+     * @param property Name of the property holding the target level
+     * @param fallback The source level to use when no target is pinned
+     * @return The target level
+     */
+    private int target(final String property, final int fallback) {
+        int level = Release.major(this.env.param(property, ""));
+        if (level < 0) {
+            level = fallback;
+        }
+        return level;
+    }
+
+    /**
+     * Parse a Java version string into its major number.
+     * @param value Version, e.g. {@code "8"}, {@code "1.8"} or {@code "17"}
+     * @return The major version, or {@code -1} if it cannot be parsed
+     */
+    private static int major(final String value) {
+        int result = -1;
+        if (value != null) {
+            String txt = value.trim();
+            if (txt.startsWith("1.")) {
+                txt = txt.substring(2);
+            }
+            try {
+                result = Integer.parseInt(txt);
+            } catch (final NumberFormatException ex) {
+                result = -1;
+            }
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
@@ -369,4 +369,89 @@ final class ErrorProneValidatorTest {
             Matchers.<Violation>empty()
         );
     }
+
+    @Test
+    void compilesTestsAtTheirOwnSourceLevel() throws Exception {
+        final String main = "src/main/java/com/qulice/Old.java";
+        final String test = "src/test/java/com/qulice/OldTest.java";
+        final Environment env = new Environment.Mock()
+            .withParam("maven.compiler.release", "8")
+            .withParam("maven.compiler.testRelease", "17")
+            .withFile(main, ErrorProneValidatorTest.ancient("Old"))
+            .withFile(test, ErrorProneValidatorTest.modern("OldTest"));
+        final java.util.Collection<Violation> violations =
+            new ErrorProneValidator(env).validate(
+                java.util.Arrays.asList(
+                    new File(env.basedir(), main), new File(env.basedir(), test)
+                )
+            );
+        MatcherAssert.assertThat(
+            String.format(
+                "tests pinned to a higher level must compile at it: %s",
+                violations
+            ),
+            violations,
+            Matchers.<Violation>empty()
+        );
+    }
+
+    @Test
+    void keepsMainSourcesAtTheirOwnLevel() throws Exception {
+        final String file = "src/main/java/com/qulice/Modern.java";
+        final Environment env = new Environment.Mock()
+            .withParam("maven.compiler.release", "8")
+            .withParam("maven.compiler.testRelease", "17")
+            .withFile(file, ErrorProneValidatorTest.modern("Modern"));
+        MatcherAssert.assertThat(
+            "the level of the tests must not leak into the main batch",
+            new ErrorProneValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            ).stream().map(Violation::message).toList(),
+            Matchers.hasItem(Matchers.containsString("text block"))
+        );
+    }
+
+    /**
+     * A class that every Java compiler accepts, no matter how old the
+     * source level it is pinned to.
+     * @param name Name of the class
+     * @return Its source code
+     */
+    private static String ancient(final String name) {
+        return String.join(
+            System.lineSeparator(),
+            "package com.qulice;",
+            "/**",
+            " * Sample.",
+            " * @since 1.0",
+            " */",
+            String.format("final class %s {", name),
+            "    int square(final int num) { return num * num; }",
+            "}"
+        );
+    }
+
+    /**
+     * A class that only a Java 15 or newer compiler accepts, since it
+     * holds a text block.
+     * @param name Name of the class
+     * @return Its source code
+     */
+    private static String modern(final String name) {
+        return String.join(
+            System.lineSeparator(),
+            "package com.qulice;",
+            "/**",
+            " * Sample.",
+            " * @since 1.0",
+            " */",
+            String.format("final class %s {", name),
+            "    String text() {",
+            "        return \"\"\"",
+            "            hello",
+            "            \"\"\";",
+            "    }",
+            "}"
+        );
+    }
 }

--- a/src/test/java/com/qulice/errorprone/ReleaseTest.java
+++ b/src/test/java/com/qulice/errorprone/ReleaseTest.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.errorprone;
+
+import com.qulice.spi.Environment;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Release}.
+ * @since 1.0
+ */
+final class ReleaseTest {
+
+    /**
+     * Name of the Maven property holding the release level of main sources.
+     */
+    private static final String RELEASE = "maven.compiler.release";
+
+    /**
+     * Name of the Maven property holding the release level of test sources.
+     */
+    private static final String TEST_RELEASE = "maven.compiler.testRelease";
+
+    @Test
+    void addsNothingWhenNoLevelIsPinned() {
+        MatcherAssert.assertThat(
+            "an unpinned project must keep the host default level",
+            new Release(new Environment.Mock(), "main").flags(),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void forwardsTheReleaseOfMainSources() {
+        MatcherAssert.assertThat(
+            "the release of the project must reach javac",
+            new Release(
+                new Environment.Mock().withParam(ReleaseTest.RELEASE, "8"),
+                "main"
+            ).flags(),
+            Matchers.contains("--release", "8")
+        );
+    }
+
+    @Test
+    void forwardsSourceAndTargetWhenNoReleaseIsPinned() {
+        MatcherAssert.assertThat(
+            "a project pinning only -source must keep its API surface",
+            new Release(
+                new Environment.Mock()
+                    .withParam("maven.compiler.source", "1.8"),
+                "main"
+            ).flags(),
+            Matchers.contains("-source", "8", "-target", "8")
+        );
+    }
+
+    @Test
+    void forwardsTheTestReleaseToTheTestBatch() {
+        MatcherAssert.assertThat(
+            "tests compiled higher than main code must say so",
+            new Release(
+                new Environment.Mock()
+                    .withParam(ReleaseTest.RELEASE, "8")
+                    .withParam(ReleaseTest.TEST_RELEASE, "17"),
+                "test"
+            ).flags(),
+            Matchers.contains("--release", "17")
+        );
+    }
+
+    @Test
+    void prefersTheTestSourceOverTheReleaseOfMainSources() {
+        MatcherAssert.assertThat(
+            "a test-specific -source must outrank the main --release",
+            new Release(
+                new Environment.Mock()
+                    .withParam(ReleaseTest.RELEASE, "8")
+                    .withParam("maven.compiler.testSource", "17"),
+                "test"
+            ).flags(),
+            Matchers.contains("-source", "17", "-target", "17")
+        );
+    }
+
+    @Test
+    void fallsBackToMainLevelWhenTestsPinNothing() {
+        MatcherAssert.assertThat(
+            "tests of a project pinning one level must compile at it",
+            new Release(
+                new Environment.Mock().withParam(ReleaseTest.RELEASE, "11"),
+                "test"
+            ).flags(),
+            Matchers.contains("--release", "11")
+        );
+    }
+
+    @Test
+    void keepsMainSourcesAwayFromTheTestLevel() {
+        MatcherAssert.assertThat(
+            "the level of the tests must not reach the main batch",
+            new Release(
+                new Environment.Mock()
+                    .withParam(ReleaseTest.RELEASE, "8")
+                    .withParam(ReleaseTest.TEST_RELEASE, "17"),
+                "main"
+            ).flags(),
+            Matchers.contains("--release", "8")
+        );
+    }
+
+    @Test
+    void forwardsTheTestTargetAlongsideTheTestSource() {
+        MatcherAssert.assertThat(
+            "a test-specific -target must be forwarded too",
+            new Release(
+                new Environment.Mock()
+                    .withParam("maven.compiler.testSource", "11")
+                    .withParam("maven.compiler.testTarget", "17"),
+                "test"
+            ).flags(),
+            Matchers.contains("-source", "11", "-target", "17")
+        );
+    }
+}


### PR DESCRIPTION
Closes #1746.

Since #1742 `ErrorProneValidator` compiles the project in two batches, but the source level was derived once for the whole project — from `maven.compiler.release`, then `maven.compiler.source` — and appended to both. Maven does not oblige the batches to share a level: the `testCompile` goal reads `maven.compiler.testRelease`, `maven.compiler.testSource` and `maven.compiler.testTarget`, so a project may compile its tests higher than its main code, as `hone-maven-plugin` does — `release` is 8 so the plugin stays usable from Java 8 projects, while its tests are Java 17. Such a project got `--release 8` forced onto its test batch, earning violations (`text blocks are not supported in -source 8`, `cannot find symbol` for `Files.readString`) that no change of its own could silence.

The derivation moves out of the validator into a new `Release` class, which takes the name of the batch it is compiling:

- the **test** batch reads `maven.compiler.testRelease`, then `maven.compiler.testSource`/`maven.compiler.testTarget`, and only when the project pins none of them does it fall back to the main properties, so the fallback stays whole — a project that sets nothing test-specific is compiled exactly as before;
- the **main** batch derives its level as it does today, untouched by the test properties.

Since a test-specific `-source` outranks a main `--release`, a project whose tests are pinned only through `maven.compiler.testSource` is no longer dragged down to the main release level.

The move also keeps `ErrorProneValidator` under the `GodClass` threshold that the extra branch would otherwise have pushed it past.

Tests: `ReleaseTest` covers the flag derivation for both batches (release, source/target, the test-specific overrides, the fallback and the precedence), and two new cases in `ErrorProneValidatorTest` compile a real text block through the forked `javac` — clean in the test batch at `testRelease` 17, still reported in the main batch at `release` 8. Full suite green (439 tests), and `mvn verify -Pqulice` passes on the change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeViXn4YsoRP4PTyZwZrr6)_