### PR TITLE
Ignore Maven @Parameter fields in VisibilityModifier

### DIFF
--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -201,7 +201,14 @@
     <module name="RightCurly"/>
     <module name="AvoidNestedBlocks"/>
     <!-- Checks for class design. -->
-    <module name="VisibilityModifier"/>
+    <!--
+    Fields annotated with Maven's @Parameter are injected by Maven itself
+    and may have to stay protected, when a mojo inherits them from its
+    abstract parent.
+    -->
+    <module name="VisibilityModifier">
+      <property name="ignoreAnnotationCanonicalNames" value="com.google.common.annotations.VisibleForTesting, org.junit.ClassRule, org.junit.Rule, org.apache.maven.plugins.annotations.Parameter"/>
+    </module>
     <module name="FinalClass"/>
     <module name="InterfaceIsType"/>
     <module name="HideUtilityClassConstructor"/>

--- a/src/test/java/com/qulice/checkstyle/CheckstyleVisibilityModifierTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleVisibilityModifierTest.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.IoCheckedText;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CheckstyleValidator}'s handling of the
+ * stock {@code VisibilityModifier} check.
+ * @since 0.28.0
+ */
+final class CheckstyleVisibilityModifierTest {
+
+    /**
+     * Name of the file with Maven parameters.
+     */
+    private static final String FILE = "MavenParameters.java";
+
+    /**
+     * Name of the check.
+     */
+    private static final String NAME = "VisibilityModifierCheck";
+
+    @Test
+    void acceptsProtectedMavenParameters() throws Exception {
+        MatcherAssert.assertThat(
+            "protected @Parameter fields should not be reported",
+            CheckstyleVisibilityModifierTest.violations(),
+            Matchers.not(
+                Matchers.hasItems(
+                    new ViolationMatcher(
+                        "Variable 'dir' must be private and have accessor methods.",
+                        CheckstyleVisibilityModifierTest.FILE,
+                        "18",
+                        CheckstyleVisibilityModifierTest.NAME
+                    ),
+                    new ViolationMatcher(
+                        "Variable 'charset' must be private and have accessor methods.",
+                        CheckstyleVisibilityModifierTest.FILE,
+                        "24",
+                        CheckstyleVisibilityModifierTest.NAME
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    void rejectsProtectedFieldsWithoutMavenParameter() throws Exception {
+        MatcherAssert.assertThat(
+            "protected field without @Parameter should be reported",
+            CheckstyleVisibilityModifierTest.violations(),
+            Matchers.hasItem(
+                new ViolationMatcher(
+                    "Variable 'extra' must be private and have accessor methods.",
+                    CheckstyleVisibilityModifierTest.FILE,
+                    "29",
+                    CheckstyleVisibilityModifierTest.NAME
+                )
+            )
+        );
+    }
+
+    private static Collection<Violation> violations() throws IOException {
+        final Environment.Mock mock = new Environment.Mock();
+        final Environment env = mock.withParam(
+            "license",
+            String.format(
+                "file:%s",
+                new License().savePackageInfo(
+                    new File(mock.basedir(), "src/main/java/foo")
+                ).withLines("Hello.")
+                    .withEol(String.valueOf('\n')).file()
+            )
+        ).withFile(
+            String.format(
+                "src/main/java/foo/%s",
+                CheckstyleVisibilityModifierTest.FILE
+            ),
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf(
+                        new FormattedText(
+                            "com/qulice/checkstyle/%s",
+                            CheckstyleVisibilityModifierTest.FILE
+                        )
+                    )
+                )
+            ).asString()
+        );
+        return new CheckstyleValidator(env).validate(
+            env.files(CheckstyleVisibilityModifierTest.FILE)
+        );
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/MavenParameters.java
+++ b/src/test/resources/com/qulice/checkstyle/MavenParameters.java
@@ -1,0 +1,30 @@
+/*
+ * Hello.
+ */
+package foo;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Mojo with parameters injected by Maven.
+ * @since 1.0
+ */
+public abstract class MavenParameters {
+
+    /**
+     * Directory to scan, injected by Maven.
+     */
+    @Parameter(property = "foo.dir", defaultValue = "${project.basedir}")
+    protected String dir;
+
+    /**
+     * Encoding of sources, injected by Maven.
+     */
+    @org.apache.maven.plugins.annotations.Parameter(property = "foo.charset")
+    protected String charset;
+
+    /**
+     * Just a field, not a parameter.
+     */
+    protected String extra;
+}


### PR DESCRIPTION
The `VisibilityModifier` module in `checks.xml` now lists `org.apache.maven.plugins.annotations.Parameter` in `ignoreAnnotationCanonicalNames`, next to Checkstyle's three defaults. A new test with a fixture covers both the short and the fully-qualified form of the annotation, and checks that a plain `protected` field is still reported.

An abstract mojo has to declare its shared parameters as `protected`, since `private` hides them from the subclasses and `public` is no better. Until now the only escape from the violation was a suppression.

Closes #1752