### PR TITLE
Allow short English words as method names

### DIFF
--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -359,8 +359,12 @@
     <module name="MemberName">
       <property name="format" value="^(id|[a-z]{3,12})$"/>
     </module>
+    <!--
+    Two-letter English words, like "at" or "go", are good method names,
+    even though they are shorter than the rest.
+    -->
     <module name="MethodName">
-      <property name="format" value="^(id|[a-z]{2,}[a-zA-Z]+)$"/>
+      <property name="format" value="^(as|at|by|go|id|in|is|of|on|or|to|up|[a-z]{2,}[a-zA-Z]+)$"/>
     </module>
     <module name="MethodTypeParameterName"/>
     <module name="PackageName"/>

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -364,7 +364,7 @@
     even though they are shorter than the rest.
     -->
     <module name="MethodName">
-      <property name="format" value="^(as|at|by|go|id|in|is|of|on|or|to|up|[a-z]{2,}[a-zA-Z]+)$"/>
+      <property name="format" value="^(as|at|by|go|id|in|is|it|of|on|or|to|up|[a-z]{2,}[a-zA-Z]+)$"/>
     </module>
     <module name="MethodTypeParameterName"/>
     <module name="PackageName"/>

--- a/src/test/java/com/qulice/checkstyle/CheckstyleMethodNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleMethodNameTest.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.IoCheckedText;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CheckstyleValidator}'s handling of the
+ * stock {@code MethodName} check.
+ * @since 0.28.0
+ */
+final class CheckstyleMethodNameTest {
+
+    @Test
+    void acceptsShortEnglishWords() throws Exception {
+        MatcherAssert.assertThat(
+            "short English words should be allowed as method names",
+            CheckstyleMethodNameTest.violations("ShortMethodNames.java"),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void rejectsTwoLetterGibberish() throws Exception {
+        final String file = "InvalidMethodName.java";
+        MatcherAssert.assertThat(
+            "two letters that make no word should be reported",
+            CheckstyleMethodNameTest.violations(file),
+            Matchers.hasItem(
+                new ViolationMatcher(
+                    "Name 'zz' must match pattern", file, "29", "MethodNameCheck"
+                )
+            )
+        );
+    }
+
+    private static Collection<Violation> violations(final String file)
+        throws IOException {
+        final Environment.Mock mock = new Environment.Mock();
+        final Environment env = mock.withParam(
+            "license",
+            String.format(
+                "file:%s",
+                new License().savePackageInfo(
+                    new File(mock.basedir(), "src/main/java/foo")
+                ).withLines("Hello.")
+                    .withEol(String.valueOf('\n')).file()
+            )
+        ).withFile(
+            String.format("src/main/java/foo/%s", file),
+            new IoCheckedText(
+                new TextOf(
+                    new ResourceOf(
+                        new FormattedText("com/qulice/checkstyle/%s", file)
+                    )
+                )
+            ).asString()
+        );
+        return new CheckstyleValidator(env).validate(env.files(file));
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/InvalidMethodName.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidMethodName.java
@@ -1,0 +1,32 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Rejects a two-letter name that is not an English word.
+ * @since 1.0
+ */
+public final class InvalidMethodName {
+
+    /**
+     * The text.
+     */
+    private final String text;
+
+    /**
+     * Ctor.
+     * @param txt The text
+     */
+    public InvalidMethodName(final String txt) {
+        this.text = txt;
+    }
+
+    /**
+     * The text.
+     * @return The text
+     */
+    public String zz() {
+        return this.text;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ShortMethodNames.java
+++ b/src/test/resources/com/qulice/checkstyle/ShortMethodNames.java
@@ -85,6 +85,14 @@ public final class ShortMethodNames {
     }
 
     /**
+     * The text itself.
+     * @return The text
+     */
+    public String it() {
+        return this.text;
+    }
+
+    /**
      * The text of the given length.
      * @param length The length
      * @return The text

--- a/src/test/resources/com/qulice/checkstyle/ShortMethodNames.java
+++ b/src/test/resources/com/qulice/checkstyle/ShortMethodNames.java
@@ -1,0 +1,130 @@
+/*
+ * Hello.
+ */
+package foo;
+
+import java.util.Comparator;
+import java.util.Locale;
+
+/**
+ * Allows short English words as method names.
+ * @since 1.0
+ */
+public final class ShortMethodNames {
+
+    /**
+     * The text.
+     */
+    private final String text;
+
+    /**
+     * Ctor.
+     * @param txt The text
+     */
+    public ShortMethodNames(final String txt) {
+        this.text = txt;
+    }
+
+    /**
+     * The text as a string.
+     * @return The text
+     */
+    public String as() {
+        return this.text;
+    }
+
+    /**
+     * The character at the given position.
+     * @param position The position
+     * @return The character
+     */
+    public char at(final int position) {
+        return this.text.charAt(position);
+    }
+
+    /**
+     * The text sorted by the given comparator.
+     * @param order The comparator
+     * @return The text
+     */
+    public String by(final Comparator<String> order) {
+        return this.text;
+    }
+
+    /**
+     * Move forward.
+     * @return The text
+     */
+    public String go() {
+        return this.text;
+    }
+
+    /**
+     * The identity of this object.
+     * @return The text
+     */
+    public String id() {
+        return this.text;
+    }
+
+    /**
+     * Is the text present in the given line?
+     * @param line The line
+     * @return True if present
+     */
+    public boolean in(final String line) {
+        return line.contains(this.text);
+    }
+
+    /**
+     * Is the text empty?
+     * @return True if empty
+     */
+    public boolean is() {
+        return this.text.isEmpty();
+    }
+
+    /**
+     * The text of the given length.
+     * @param length The length
+     * @return The text
+     */
+    public String of(final int length) {
+        return this.text.substring(0, length);
+    }
+
+    /**
+     * React on the given event.
+     * @param event The event
+     * @return The text
+     */
+    public String on(final String event) {
+        return this.text;
+    }
+
+    /**
+     * The text or the given alternative.
+     * @param alternative The alternative
+     * @return The text
+     */
+    public String or(final String alternative) {
+        return this.text;
+    }
+
+    /**
+     * The text converted to the given charset.
+     * @param charset The charset
+     * @return The text
+     */
+    public String to(final String charset) {
+        return this.text;
+    }
+
+    /**
+     * The text in upper case.
+     * @return The text
+     */
+    public String up() {
+        return this.text.toUpperCase(Locale.ENGLISH);
+    }
+}


### PR DESCRIPTION
The `MethodName` format in `checks.xml` gets twelve two-letter words next to `id`: as, at, by, go, in, is, of, on, or, to, up. A new test covers a fixture that uses all of them and another one where `zz()` is still reported, so the length rule keeps working for names that are not words.

Right now anything under three letters except `id` is a violation, which rules out perfectly readable names like `at()` or `go()` and pushes you towards padding them into `atPosition()`.

If some word in the list feels wrong to you, or one is missing, it is a one-line edit to the pattern.

Closes #1754