### PR TITLE
Keep TooManyMethods quiet for JNA bindings

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
@@ -7,6 +7,9 @@ package com.qulice.pmd.rules;
 import java.util.Set;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassType;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
@@ -21,7 +24,10 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * skipped too, since a supertype dictates them and the class has no say
  * in how many of them there are. Test classes are skipped altogether, since
  * one assertion per test method inflates their method count beyond any
- * useful threshold. Skipping them here instead of through a
+ * useful threshold. JNA bindings are skipped too: a type that extends
+ * {@code com.sun.jna.Library} mirrors a native library method by method,
+ * and its size is dictated by that library rather than by its author.
+ * Skipping them here instead of through a
  * {@code violationSuppressXPath} keeps a redundant
  * {@code @SuppressWarnings("PMD.TooManyMethods")} visible to
  * {@code UnnecessaryWarningSuppression}, which PMD credits to the
@@ -34,6 +40,22 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
      * The largest number of public and protected methods a class may have.
      */
     private static final int MAX = 10;
+
+    /**
+     * Package of the JNA interface that marks a type as a native binding.
+     */
+    private static final String PACKAGE = "com.sun.jna";
+
+    /**
+     * Simple name of that interface.
+     */
+    private static final String LIBRARY = "Library";
+
+    /**
+     * Canonical name of that interface.
+     */
+    private static final String QUALIFIED =
+        TooManyMethodsRule.PACKAGE + '.' + TooManyMethodsRule.LIBRARY;
 
     /**
      * Simple-name suffixes that mark a type as a test.
@@ -69,6 +91,7 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
     @Override
     public Object visit(final ASTClassDeclaration type, final Object data) {
         if (!TooManyMethodsRule.tested(type)
+            && !TooManyMethodsRule.binding(type)
             && TooManyMethodsRule.exposed(type) > TooManyMethodsRule.MAX) {
             this.asCtx(data).addViolation(type);
         }
@@ -85,6 +108,28 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
         return method.getVisibility()
             .isAtLeast(ModifierOwner.Visibility.V_PROTECTED)
             && !method.isAnnotationPresent(Override.class);
+    }
+
+    private static boolean binding(final ASTClassDeclaration type) {
+        return type.getSuperInterfaceTypeNodes().any(TooManyMethodsRule::jna);
+    }
+
+    private static boolean jna(final ASTClassType parent) {
+        return TooManyMethodsRule.LIBRARY.equals(parent.getSimpleName())
+            && (TooManyMethodsRule.PACKAGE.equals(parent.getPackageQualifier())
+                || TooManyMethodsRule.imported(parent.getRoot()));
+    }
+
+    private static boolean imported(final ASTCompilationUnit unit) {
+        return unit.children(ASTImportDeclaration.class).any(
+            TooManyMethodsRule::jna
+        );
+    }
+
+    private static boolean jna(final ASTImportDeclaration imported) {
+        return TooManyMethodsRule.QUALIFIED.equals(imported.getImportedName())
+            || imported.isImportOnDemand()
+            && TooManyMethodsRule.PACKAGE.equals(imported.getImportedName());
     }
 
     private static boolean tested(final ASTClassDeclaration type) {

--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -520,7 +520,9 @@
       private and package-private ones are implementation detail rather
       than part of the contract of the class. Test classes are not
       checked at all, because one assertion per test method inflates
-      their method count beyond any useful threshold.
+      their method count beyond any useful threshold. Types that extend
+      com.sun.jna.Library are skipped too, since they mirror a native
+      library method by method.
     </description>
     <priority>3</priority>
   </rule>

--- a/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
@@ -85,6 +85,33 @@ final class PmdTooManyMethodsTest {
         ).assertOk();
     }
 
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "JnaLibrary.java",
+            "JnaQualifiedLibrary.java",
+            "JnaDirectLibrary.java"
+        }
+    )
+    void allowsManyMethodsInJnaBinding(final String file) throws Exception {
+        new PmdAssert(
+            file,
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("TooManyMethods")
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void reportsTooManyMethodsInPlainInterface() throws Exception {
+        new PmdAssert(
+            "ManyMethodsInterface.java",
+            Matchers.is(false),
+            Matchers.containsString("TooManyMethods")
+        ).assertOk();
+    }
+
     @Test
     void reportsRedundantSuppressionInTestClass() throws Exception {
         new PmdAssert(

--- a/src/test/resources/com/qulice/pmd/JnaDirectLibrary.java
+++ b/src/test/resources/com/qulice/pmd/JnaDirectLibrary.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import com.sun.jna.Library;
+
+public final class JnaDirectLibrary implements Library {
+
+    public int firstCall() {
+        return 0;
+    }
+
+    public int secondCall() {
+        return 0;
+    }
+
+    public int thirdCall() {
+        return 0;
+    }
+
+    public int fourthCall() {
+        return 0;
+    }
+
+    public int fifthCall() {
+        return 0;
+    }
+
+    public int sixthCall() {
+        return 0;
+    }
+
+    public int seventhCall() {
+        return 0;
+    }
+
+    public int eighthCall() {
+        return 0;
+    }
+
+    public int ninthCall() {
+        return 0;
+    }
+
+    public int tenthCall() {
+        return 0;
+    }
+
+    public int eleventhCall() {
+        return 0;
+    }
+
+    public int twelfthCall() {
+        return 0;
+    }
+}

--- a/src/test/resources/com/qulice/pmd/JnaLibrary.java
+++ b/src/test/resources/com/qulice/pmd/JnaLibrary.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import com.sun.jna.Library;
+
+public interface JnaLibrary extends Library {
+
+    int firstCall();
+
+    int secondCall();
+
+    int thirdCall();
+
+    int fourthCall();
+
+    int fifthCall();
+
+    int sixthCall();
+
+    int seventhCall();
+
+    int eighthCall();
+
+    int ninthCall();
+
+    int tenthCall();
+
+    int eleventhCall();
+
+    int twelfthCall();
+}

--- a/src/test/resources/com/qulice/pmd/JnaQualifiedLibrary.java
+++ b/src/test/resources/com/qulice/pmd/JnaQualifiedLibrary.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public interface JnaQualifiedLibrary extends com.sun.jna.Library {
+
+    int firstCall();
+
+    int secondCall();
+
+    int thirdCall();
+
+    int fourthCall();
+
+    int fifthCall();
+
+    int sixthCall();
+
+    int seventhCall();
+
+    int eighthCall();
+
+    int ninthCall();
+
+    int tenthCall();
+
+    int eleventhCall();
+
+    int twelfthCall();
+}

--- a/src/test/resources/com/qulice/pmd/ManyMethodsInterface.java
+++ b/src/test/resources/com/qulice/pmd/ManyMethodsInterface.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public interface ManyMethodsInterface {
+
+    int firstCall();
+
+    int secondCall();
+
+    int thirdCall();
+
+    int fourthCall();
+
+    int fifthCall();
+
+    int sixthCall();
+
+    int seventhCall();
+
+    int eighthCall();
+
+    int ninthCall();
+
+    int tenthCall();
+
+    int eleventhCall();
+
+    int twelfthCall();
+}


### PR DESCRIPTION
`TooManyMethodsRule` now skips a type whose extends or implements clause names `com.sun.jna.Library`. Since PMD runs here without an auxiliary classpath, the supertype never resolves, so the check reads the name in the clause plus the imports of the file: both `extends Library` with the import and `extends com.sun.jna.Library` are recognised, and so is a class that implements it for direct mapping.

A JNA binding transcribes a native library function by function, so an eleventh function in the `.so` turns into a violation you cannot act on — splitting the type would break the mapping.

Tests cover the three shapes above, and a plain interface with the same number of methods is still reported, so only JNA gets the pass.

Closes #1756