### PR TITLE
Spare JNA binding methods from three more checks

### DIFF
--- a/src/main/java/com/qulice/checkstyle/JnaBinding.java
+++ b/src/main/java/com/qulice/checkstyle/JnaBinding.java
@@ -1,0 +1,148 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FullIdent;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * A method of a JNA binding.
+ *
+ * <p>A type that extends {@code com.sun.jna.Library} transcribes a native
+ * library function by function. The name of every method and the length of
+ * its parameter list come from the native side, so its author has no say in
+ * either of them and the checks that judge them have nothing to say here.
+ *
+ * <p>Qulice runs Checkstyle on one file at a time, so {@code Library} is
+ * never resolved to a class. The name in the {@code extends} or
+ * {@code implements} clause is therefore trusted only when it is fully
+ * qualified or when the file imports it from {@code com.sun.jna}.
+ *
+ * @since 1.0
+ */
+final class JnaBinding {
+
+    /**
+     * Package of the JNA interface that marks a type as a native binding.
+     */
+    private static final String PACKAGE = "com.sun.jna";
+
+    /**
+     * Simple name of that interface.
+     */
+    private static final String LIBRARY = "Library";
+
+    /**
+     * Canonical name of that interface.
+     */
+    private static final String QUALIFIED =
+        JnaBinding.PACKAGE + '.' + JnaBinding.LIBRARY;
+
+    /**
+     * The node of the method declaration.
+     */
+    private final DetailAST node;
+
+    /**
+     * Ctor.
+     * @param method The METHOD_DEF node
+     */
+    JnaBinding(final DetailAST method) {
+        this.node = method;
+    }
+
+    /**
+     * Is this method a part of a JNA binding?
+     * @return TRUE if the type that declares it maps a native library
+     */
+    boolean is() {
+        DetailAST type = this.node.getParent();
+        boolean answer = false;
+        while (type != null) {
+            if (type.getType() == TokenTypes.CLASS_DEF
+                || type.getType() == TokenTypes.INTERFACE_DEF) {
+                answer = JnaBinding.mapped(type);
+                break;
+            }
+            type = type.getParent();
+        }
+        return answer;
+    }
+
+    /**
+     * Does this type declare JNA's interface as its supertype?
+     * @param type The CLASS_DEF or INTERFACE_DEF node
+     * @return TRUE if it does
+     */
+    private static boolean mapped(final DetailAST type) {
+        return JnaBinding.declares(type, TokenTypes.EXTENDS_CLAUSE)
+            || JnaBinding.declares(type, TokenTypes.IMPLEMENTS_CLAUSE);
+    }
+
+    /**
+     * Does this clause of the type name JNA's interface?
+     * @param type The CLASS_DEF or INTERFACE_DEF node
+     * @param clause The token of the clause to look into
+     * @return TRUE if it does
+     */
+    private static boolean declares(final DetailAST type, final int clause) {
+        final DetailAST names = type.findFirstToken(clause);
+        final boolean answer;
+        if (names == null) {
+            answer = false;
+        } else {
+            answer = new ChildStream(names).children()
+                .anyMatch(JnaBinding::library);
+        }
+        return answer;
+    }
+
+    /**
+     * Is this name the one of JNA's interface?
+     * @param name The IDENT or DOT node of a supertype
+     * @return TRUE if it is
+     */
+    private static boolean library(final DetailAST name) {
+        final String text = FullIdent.createFullIdent(name).getText();
+        return JnaBinding.QUALIFIED.equals(text)
+            || JnaBinding.LIBRARY.equals(text) && JnaBinding.imported(name);
+    }
+
+    /**
+     * Does the file that holds this node import JNA's interface?
+     * @param node The node to start the walk from
+     * @return TRUE if it does
+     */
+    private static boolean imported(final DetailAST node) {
+        DetailAST root = node;
+        while (root.getParent() != null) {
+            root = root.getParent();
+        }
+        return new ChildStream(root).children().anyMatch(JnaBinding::importing);
+    }
+
+    /**
+     * Does this node import JNA's interface?
+     * @param node The node of a top-level declaration
+     * @return TRUE if it does
+     */
+    private static boolean importing(final DetailAST node) {
+        return node.getType() == TokenTypes.IMPORT
+            && JnaBinding.jna(
+                FullIdent.createFullIdentBelow(node).getText()
+            );
+    }
+
+    /**
+     * Does this imported name bring JNA's interface in?
+     * @param text The name of the import
+     * @return TRUE if it does
+     */
+    private static boolean jna(final String text) {
+        return JnaBinding.QUALIFIED.equals(text)
+            || String.format("%s.*", JnaBinding.PACKAGE).equals(text);
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/MethodNameCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodNameCheck.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+
+/**
+ * Names of methods, tolerant to the methods of a JNA binding.
+ *
+ * <p>The stock {@code MethodName} check demands the same format from every
+ * method, while a method of a type that extends {@code com.sun.jna.Library}
+ * carries the name of a native function, spelled the way the library that
+ * exports it spells it. Renaming it breaks the binding, so the check stays
+ * silent there.
+ *
+ * <p>Its messages come from the bundle of the stock check, since the two
+ * report the very same things and one wording for them is enough.
+ *
+ * @since 1.0
+ */
+public final class MethodNameCheck
+    extends com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck {
+
+    /**
+     * Default constructor.
+     */
+    public MethodNameCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        if (!new JnaBinding(ast).is()) {
+            super.visitToken(ast);
+        }
+    }
+
+    @Override
+    public String getMessageBundle() {
+        return "com.puppycrawl.tools.checkstyle.checks.naming.messages";
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
@@ -23,6 +23,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * parameters belong to no contract anybody else can see, and wrapping them
  * into a new type only to satisfy the limit buys nothing.
  *
+ * <p>So does a method of a JNA binding, whose parameter list repeats the
+ * signature of a native function and cannot be shortened without breaking
+ * the mapping.
+ *
  * @since 1.0
  */
 public final class ParameterNumberCheck
@@ -47,7 +51,7 @@ public final class ParameterNumberCheck
      *
      * <p>A constructor may, when it takes no more parameters than the
      * number of attributes of its class. A method may, when it is
-     * private.</p>
+     * private or when it belongs to a JNA binding.</p>
      *
      * @param ast The CTOR_DEF or METHOD_DEF node
      * @return TRUE if the check has to stay silent about it
@@ -59,7 +63,8 @@ public final class ParameterNumberCheck
                 <= ParameterNumberCheck.attributes(ast);
         } else {
             answer = ast.findFirstToken(TokenTypes.MODIFIERS)
-                .findFirstToken(TokenTypes.LITERAL_PRIVATE) != null;
+                .findFirstToken(TokenTypes.LITERAL_PRIVATE) != null
+                || new JnaBinding(ast).is();
         }
         return answer;
     }

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -361,9 +361,12 @@
     </module>
     <!--
     Two-letter English words, like "at" or "go", are good method names,
-    even though they are shorter than the rest.
+    even though they are shorter than the rest. Same as the stock
+    MethodName otherwise, but silent about the methods of a type that
+    extends com.sun.jna.Library, which carry the names of the native
+    functions they map.
     -->
-    <module name="MethodName">
+    <module name="com.qulice.checkstyle.MethodNameCheck">
       <property name="format" value="^(as|at|by|go|id|in|is|it|of|on|or|to|up|[a-z]{2,}[a-zA-Z]+)$"/>
     </module>
     <module name="MethodTypeParameterName"/>

--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -240,6 +240,44 @@
     Downstream: https://github.com/yegor256/qulice/issues/1685
     -->
     <exclude name="UseDiamondOperator"/>
+    <!--
+    MethodNamingConventions is re-enabled below with a
+    violationSuppressXPath that ignores the methods of a JNA binding.
+    -->
+    <exclude name="MethodNamingConventions"/>
+  </rule>
+  <!--
+  MethodNamingConventions asks every method name to start with a lower
+  case letter, while a type that extends com.sun.jna.Library names its
+  methods after the native functions they map, spelled the way the
+  library that exports them spells them. Renaming one breaks the
+  binding, so the suppression below skips them. Qulice runs PMD without
+  an auxiliary classpath, so 'Library' never resolves to a type and the
+  name in the extends or implements clause is trusted only when it is
+  fully qualified or when the file imports it from com.sun.jna.
+  -->
+  <rule ref="category/java/codestyle.xml/MethodNamingConventions">
+    <properties>
+      <property name="violationSuppressXPath">
+        <value><![CDATA[
+          .[
+            ancestor::ClassDeclaration[1]
+              /(ExtendsList | ImplementsList)
+              /ClassType[
+                @SimpleName = 'Library'
+                and (
+                  @PackageQualifier = 'com.sun.jna'
+                  or ancestor::CompilationUnit
+                    /ImportDeclaration[
+                      @ImportedName = 'com.sun.jna.Library'
+                      or @ImportedName = 'com.sun.jna'
+                    ]
+                )
+              ]
+          ]
+        ]]></value>
+      </property>
+    </properties>
   </rule>
   <!--
   UseDiamondOperator suggests replacing explicit constructor type

--- a/src/test/java/com/qulice/checkstyle/CheckstyleMethodNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleMethodNameTest.java
@@ -16,6 +16,8 @@ import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
@@ -44,6 +46,46 @@ final class CheckstyleMethodNameTest {
                     "Name 'zz' must match pattern", file, "29", "MethodNameCheck"
                 )
             )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"JnaMappedLibrary.java", "JnaDirectBinding.java"})
+    void acceptsNativeNamesInJnaBinding(final String file) throws Exception {
+        MatcherAssert.assertThat(
+            "native names in a JNA binding should not be reported",
+            CheckstyleMethodNameTest.violations(file),
+            Matchers.not(
+                Matchers.hasItem(
+                    new ViolationMatcher("", file, "", "MethodNameCheck")
+                )
+            )
+        );
+    }
+
+    @Test
+    void rejectsNativeNamesOutsideJna() throws Exception {
+        final String file = "FakeLibrary.java";
+        MatcherAssert.assertThat(
+            "a Library that is not JNA's should not be trusted",
+            CheckstyleMethodNameTest.violations(file),
+            Matchers.hasItem(
+                new ViolationMatcher(
+                    "Name 'GetLastError' must match pattern",
+                    file,
+                    "16",
+                    "MethodNameCheck"
+                )
+            )
+        );
+    }
+
+    @Test
+    void obeysSuppressionByShortName() throws Exception {
+        MatcherAssert.assertThat(
+            "suppressed name should not be reported",
+            CheckstyleMethodNameTest.violations("SuppressedMethodName.java"),
+            Matchers.empty()
         );
     }
 

--- a/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
@@ -16,6 +16,8 @@ import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
@@ -54,6 +56,20 @@ final class CheckstyleParameterNumberTest {
                     file,
                     "20",
                     "ParameterNumberCheck"
+                )
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"JnaMappedLibrary.java", "JnaDirectBinding.java"})
+    void acceptsManyParametersInJnaBinding(final String file) throws Exception {
+        MatcherAssert.assertThat(
+            "long parameter list in a JNA binding should not be reported",
+            this.runValidation(file, true),
+            Matchers.not(
+                Matchers.hasItem(
+                    new ViolationMatcher("", file, "", "ParameterNumberCheck")
                 )
             )
         );

--- a/src/test/java/com/qulice/pmd/PmdMethodNamingConventionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdMethodNamingConventionsTest.java
@@ -6,6 +6,8 @@ package com.qulice.pmd;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link PmdValidator}'s rejection of unicode
@@ -14,6 +16,27 @@ import org.junit.jupiter.api.Test;
  * @since 0.25.1
  */
 final class PmdMethodNamingConventionsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"JnaLibraryNames.java", "JnaDirectNames.java"})
+    void allowsNativeNamesInJnaBinding(final String file) throws Exception {
+        new PmdAssert(
+            file,
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("MethodNamingConventions")
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void rejectsNativeNamesOutsideJna() throws Exception {
+        new PmdAssert(
+            "FakeLibraryNames.java",
+            Matchers.is(false),
+            Matchers.containsString("MethodNamingConventions")
+        ).assertOk();
+    }
 
     @Test
     void prohibitsUnicodeCharactersInMethodNames() throws Exception {

--- a/src/test/resources/com/qulice/checkstyle/FakeLibrary.java
+++ b/src/test/resources/com/qulice/checkstyle/FakeLibrary.java
@@ -1,0 +1,17 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Extends a type named Library that comes from nowhere near JNA.
+ * @since 1.0
+ */
+public interface FakeLibrary extends Library {
+
+    /**
+     * The code of the last error.
+     * @return The code
+     */
+    int GetLastError();
+}

--- a/src/test/resources/com/qulice/checkstyle/JnaDirectBinding.java
+++ b/src/test/resources/com/qulice/checkstyle/JnaDirectBinding.java
@@ -1,0 +1,27 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Binding to a native library, mapped directly.
+ * @since 1.0
+ */
+public final class JnaDirectBinding implements com.sun.jna.Library {
+
+    /**
+     * Open a file.
+     * @param name The name of the file
+     * @param access The access mask
+     * @param mode The sharing mode
+     * @param attributes The attributes of the file
+     * @return The handle of the file
+     */
+    public native int CreateFileW(String name, int access, int mode, int attributes);
+
+    /**
+     * The code of the last error.
+     * @return The code
+     */
+    public native int GetLastError();
+}

--- a/src/test/resources/com/qulice/checkstyle/JnaMappedLibrary.java
+++ b/src/test/resources/com/qulice/checkstyle/JnaMappedLibrary.java
@@ -1,0 +1,29 @@
+/*
+ * Hello.
+ */
+package foo;
+
+import com.sun.jna.Library;
+
+/**
+ * Binding to a native library, mapped as an interface.
+ * @since 1.0
+ */
+public interface JnaMappedLibrary extends Library {
+
+    /**
+     * Open a file.
+     * @param name The name of the file
+     * @param access The access mask
+     * @param mode The sharing mode
+     * @param attributes The attributes of the file
+     * @return The handle of the file
+     */
+    int CreateFileW(String name, int access, int mode, int attributes);
+
+    /**
+     * The code of the last error.
+     * @return The code
+     */
+    int GetLastError();
+}

--- a/src/test/resources/com/qulice/checkstyle/SuppressedMethodName.java
+++ b/src/test/resources/com/qulice/checkstyle/SuppressedMethodName.java
@@ -1,0 +1,18 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Suppresses the method name check by its short name.
+ * @since 1.0
+ */
+public interface SuppressedMethodName {
+
+    /**
+     * The code of the last error.
+     * @return The code
+     * @checkstyle MethodName (2 lines)
+     */
+    int GetLastError();
+}

--- a/src/test/resources/com/qulice/pmd/FakeLibraryNames.java
+++ b/src/test/resources/com/qulice/pmd/FakeLibraryNames.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public interface FakeLibraryNames extends Library {
+
+    int GetLastError();
+}

--- a/src/test/resources/com/qulice/pmd/JnaDirectNames.java
+++ b/src/test/resources/com/qulice/pmd/JnaDirectNames.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class JnaDirectNames implements com.sun.jna.Library {
+
+    public native int CreateFileW(String name, int access);
+
+    public native int GetLastError();
+}

--- a/src/test/resources/com/qulice/pmd/JnaLibraryNames.java
+++ b/src/test/resources/com/qulice/pmd/JnaLibraryNames.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import com.sun.jna.Library;
+
+public interface JnaLibraryNames extends Library {
+
+    int CreateFileW(String name, int access);
+
+    int GetLastError();
+}


### PR DESCRIPTION
Three checks now leave the methods of a type that extends `com.sun.jna.Library` alone: `ParameterNumberCheck` gets a guard, `MethodName` gets a Qulice subclass that carries the same guard (the module in `checks.xml` points at it, keeping the format property and the stock messages), and PMD's `MethodNamingConventions` gets a `violationSuppressXPath`. The shared Checkstyle detection lives in the new `JnaBinding` class.

Those methods are named after the native functions they map and take the arguments those functions take, so `GetLastError()` and a five-argument call are the only spellings that work. Same reasoning as #1756, which did this for `TooManyMethods`.

Neither checker resolves the supertype here, so the name in the extends or implements clause is trusted only when it is fully qualified or imported from `com.sun.jna` — there are tests for a `Library` of other origin, which is still checked, and for the `@checkstyle MethodName` suppression comment, which keeps working with the renamed module. What this does not catch is a type that inherits `Library` indirectly, through an interface of your own.

Closes #1758