### PR TITLE
Recognize StdCallLibrary as a JNA binding

### DIFF
--- a/src/main/java/com/qulice/checkstyle/JnaBinding.java
+++ b/src/main/java/com/qulice/checkstyle/JnaBinding.java
@@ -7,39 +7,35 @@ package com.qulice.checkstyle;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * A method of a JNA binding.
  *
- * <p>A type that extends {@code com.sun.jna.Library} transcribes a native
+ * <p>A type that extends {@code com.sun.jna.Library}, or its Windows
+ * flavour {@code com.sun.jna.win32.StdCallLibrary}, transcribes a native
  * library function by function. The name of every method and the length of
  * its parameter list come from the native side, so its author has no say in
  * either of them and the checks that judge them have nothing to say here.
  *
- * <p>Qulice runs Checkstyle on one file at a time, so {@code Library} is
- * never resolved to a class. The name in the {@code extends} or
- * {@code implements} clause is therefore trusted only when it is fully
- * qualified or when the file imports it from {@code com.sun.jna}.
+ * <p>Qulice runs Checkstyle on one file at a time, so neither of the two
+ * interfaces is ever resolved to a class. The name in the {@code extends}
+ * or {@code implements} clause is therefore trusted only when it is fully
+ * qualified or when the file imports it from its own package.
  *
  * @since 1.0
  */
 final class JnaBinding {
 
     /**
-     * Package of the JNA interface that marks a type as a native binding.
+     * Canonical names of the JNA interfaces that mark a type as a native
+     * binding.
      */
-    private static final String PACKAGE = "com.sun.jna";
-
-    /**
-     * Simple name of that interface.
-     */
-    private static final String LIBRARY = "Library";
-
-    /**
-     * Canonical name of that interface.
-     */
-    private static final String QUALIFIED =
-        JnaBinding.PACKAGE + '.' + JnaBinding.LIBRARY;
+    private static final Collection<String> LIBRARIES = Set.of(
+        "com.sun.jna.Library",
+        "com.sun.jna.win32.StdCallLibrary"
+    );
 
     /**
      * The node of the method declaration.
@@ -101,48 +97,74 @@ final class JnaBinding {
     }
 
     /**
-     * Is this name the one of JNA's interface?
+     * Is this name the one of a JNA interface?
      * @param name The IDENT or DOT node of a supertype
      * @return TRUE if it is
      */
     private static boolean library(final DetailAST name) {
         final String text = FullIdent.createFullIdent(name).getText();
-        return JnaBinding.QUALIFIED.equals(text)
-            || JnaBinding.LIBRARY.equals(text) && JnaBinding.imported(name);
+        return JnaBinding.LIBRARIES.stream().anyMatch(
+            known -> known.equals(text)
+                || JnaBinding.simple(known).equals(text)
+                && JnaBinding.imported(name, known)
+        );
     }
 
     /**
-     * Does the file that holds this node import JNA's interface?
+     * Does the file that holds this node import this interface?
      * @param node The node to start the walk from
+     * @param known Canonical name of the interface
      * @return TRUE if it does
      */
-    private static boolean imported(final DetailAST node) {
+    private static boolean imported(final DetailAST node, final String known) {
         DetailAST root = node;
         while (root.getParent() != null) {
             root = root.getParent();
         }
-        return new ChildStream(root).children().anyMatch(JnaBinding::importing);
+        return new ChildStream(root).children().anyMatch(
+            child -> JnaBinding.importing(child, known)
+        );
     }
 
     /**
-     * Does this node import JNA's interface?
+     * Does this node import this interface?
      * @param node The node of a top-level declaration
+     * @param known Canonical name of the interface
      * @return TRUE if it does
      */
-    private static boolean importing(final DetailAST node) {
+    private static boolean importing(final DetailAST node, final String known) {
         return node.getType() == TokenTypes.IMPORT
-            && JnaBinding.jna(
-                FullIdent.createFullIdentBelow(node).getText()
+            && JnaBinding.brings(
+                FullIdent.createFullIdentBelow(node).getText(), known
             );
     }
 
     /**
-     * Does this imported name bring JNA's interface in?
+     * Does this imported name bring this interface in?
      * @param text The name of the import
+     * @param known Canonical name of the interface
      * @return TRUE if it does
      */
-    private static boolean jna(final String text) {
-        return JnaBinding.QUALIFIED.equals(text)
-            || String.format("%s.*", JnaBinding.PACKAGE).equals(text);
+    private static boolean brings(final String text, final String known) {
+        return known.equals(text)
+            || String.format("%s.*", JnaBinding.pack(known)).equals(text);
+    }
+
+    /**
+     * Simple name of this canonical name.
+     * @param known Canonical name of an interface
+     * @return The name without its package
+     */
+    private static String simple(final String known) {
+        return known.substring(known.lastIndexOf('.') + 1);
+    }
+
+    /**
+     * Package of this canonical name.
+     * @param known Canonical name of an interface
+     * @return The name without its last part
+     */
+    private static String pack(final String known) {
+        return known.substring(0, known.lastIndexOf('.'));
     }
 }

--- a/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
@@ -4,6 +4,7 @@
  */
 package com.qulice.pmd.rules;
 
+import java.util.Collection;
 import java.util.Set;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
@@ -25,8 +26,10 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * in how many of them there are. Test classes are skipped altogether, since
  * one assertion per test method inflates their method count beyond any
  * useful threshold. JNA bindings are skipped too: a type that extends
- * {@code com.sun.jna.Library} mirrors a native library method by method,
- * and its size is dictated by that library rather than by its author.
+ * {@code com.sun.jna.Library}, or its Windows flavour
+ * {@code com.sun.jna.win32.StdCallLibrary}, mirrors a native library
+ * method by method, and its size is dictated by that library rather than
+ * by its author.
  * Skipping them here instead of through a
  * {@code violationSuppressXPath} keeps a redundant
  * {@code @SuppressWarnings("PMD.TooManyMethods")} visible to
@@ -42,20 +45,13 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
     private static final int MAX = 10;
 
     /**
-     * Package of the JNA interface that marks a type as a native binding.
+     * Canonical names of the JNA interfaces that mark a type as a native
+     * binding.
      */
-    private static final String PACKAGE = "com.sun.jna";
-
-    /**
-     * Simple name of that interface.
-     */
-    private static final String LIBRARY = "Library";
-
-    /**
-     * Canonical name of that interface.
-     */
-    private static final String QUALIFIED =
-        TooManyMethodsRule.PACKAGE + '.' + TooManyMethodsRule.LIBRARY;
+    private static final Collection<String> LIBRARIES = Set.of(
+        "com.sun.jna.Library",
+        "com.sun.jna.win32.StdCallLibrary"
+    );
 
     /**
      * Simple-name suffixes that mark a type as a test.
@@ -115,21 +111,36 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
     }
 
     private static boolean jna(final ASTClassType parent) {
-        return TooManyMethodsRule.LIBRARY.equals(parent.getSimpleName())
-            && (TooManyMethodsRule.PACKAGE.equals(parent.getPackageQualifier())
-                || TooManyMethodsRule.imported(parent.getRoot()));
-    }
-
-    private static boolean imported(final ASTCompilationUnit unit) {
-        return unit.children(ASTImportDeclaration.class).any(
-            TooManyMethodsRule::jna
+        return TooManyMethodsRule.LIBRARIES.stream().anyMatch(
+            known -> TooManyMethodsRule.simple(known)
+                .equals(parent.getSimpleName())
+                && (TooManyMethodsRule.pack(known)
+                    .equals(parent.getPackageQualifier())
+                    || TooManyMethodsRule.imported(parent.getRoot(), known))
         );
     }
 
-    private static boolean jna(final ASTImportDeclaration imported) {
-        return TooManyMethodsRule.QUALIFIED.equals(imported.getImportedName())
+    private static boolean imported(
+        final ASTCompilationUnit unit, final String known) {
+        return unit.children(ASTImportDeclaration.class).any(
+            imported -> TooManyMethodsRule.brings(imported, known)
+        );
+    }
+
+    private static boolean brings(
+        final ASTImportDeclaration imported, final String known) {
+        return known.equals(imported.getImportedName())
             || imported.isImportOnDemand()
-            && TooManyMethodsRule.PACKAGE.equals(imported.getImportedName());
+            && TooManyMethodsRule.pack(known)
+                .equals(imported.getImportedName());
+    }
+
+    private static String simple(final String known) {
+        return known.substring(known.lastIndexOf('.') + 1);
+    }
+
+    private static String pack(final String known) {
+        return known.substring(0, known.lastIndexOf('.'));
     }
 
     private static boolean tested(final ASTClassDeclaration type) {

--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -248,13 +248,14 @@
   </rule>
   <!--
   MethodNamingConventions asks every method name to start with a lower
-  case letter, while a type that extends com.sun.jna.Library names its
-  methods after the native functions they map, spelled the way the
-  library that exports them spells them. Renaming one breaks the
-  binding, so the suppression below skips them. Qulice runs PMD without
-  an auxiliary classpath, so 'Library' never resolves to a type and the
-  name in the extends or implements clause is trusted only when it is
-  fully qualified or when the file imports it from com.sun.jna.
+  case letter, while a type that extends com.sun.jna.Library, or its
+  Windows flavour com.sun.jna.win32.StdCallLibrary, names its methods
+  after the native functions they map, spelled the way the library that
+  exports them spells them. Renaming one breaks the binding, so the
+  suppression below skips them. Qulice runs PMD without an auxiliary
+  classpath, so neither interface ever resolves to a type and the name
+  in the extends or implements clause is trusted only when it is fully
+  qualified or when the file imports it from its own package.
   -->
   <rule ref="category/java/codestyle.xml/MethodNamingConventions">
     <properties>
@@ -271,6 +272,15 @@
                     /ImportDeclaration[
                       @ImportedName = 'com.sun.jna.Library'
                       or @ImportedName = 'com.sun.jna'
+                    ]
+                )
+                or @SimpleName = 'StdCallLibrary'
+                and (
+                  @PackageQualifier = 'com.sun.jna.win32'
+                  or ancestor::CompilationUnit
+                    /ImportDeclaration[
+                      @ImportedName = 'com.sun.jna.win32.StdCallLibrary'
+                      or @ImportedName = 'com.sun.jna.win32'
                     ]
                 )
               ]

--- a/src/test/java/com/qulice/checkstyle/CheckstyleMethodNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleMethodNameTest.java
@@ -50,7 +50,13 @@ final class CheckstyleMethodNameTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"JnaMappedLibrary.java", "JnaDirectBinding.java"})
+    @ValueSource(
+        strings = {
+            "JnaMappedLibrary.java",
+            "JnaDirectBinding.java",
+            "JnaStdCallBinding.java"
+        }
+    )
     void acceptsNativeNamesInJnaBinding(final String file) throws Exception {
         MatcherAssert.assertThat(
             "native names in a JNA binding should not be reported",

--- a/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
@@ -62,7 +62,13 @@ final class CheckstyleParameterNumberTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"JnaMappedLibrary.java", "JnaDirectBinding.java"})
+    @ValueSource(
+        strings = {
+            "JnaMappedLibrary.java",
+            "JnaDirectBinding.java",
+            "JnaStdCallBinding.java"
+        }
+    )
     void acceptsManyParametersInJnaBinding(final String file) throws Exception {
         MatcherAssert.assertThat(
             "long parameter list in a JNA binding should not be reported",

--- a/src/test/java/com/qulice/pmd/PmdMethodNamingConventionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdMethodNamingConventionsTest.java
@@ -18,7 +18,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 final class PmdMethodNamingConventionsTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"JnaLibraryNames.java", "JnaDirectNames.java"})
+    @ValueSource(
+        strings = {
+            "JnaLibraryNames.java",
+            "JnaDirectNames.java",
+            "StdCallNames.java"
+        }
+    )
     void allowsNativeNamesInJnaBinding(final String file) throws Exception {
         new PmdAssert(
             file,

--- a/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
@@ -90,7 +90,8 @@ final class PmdTooManyMethodsTest {
         strings = {
             "JnaLibrary.java",
             "JnaQualifiedLibrary.java",
-            "JnaDirectLibrary.java"
+            "JnaDirectLibrary.java",
+            "StdCallLibraryMethods.java"
         }
     )
     void allowsManyMethodsInJnaBinding(final String file) throws Exception {

--- a/src/test/resources/com/qulice/checkstyle/JnaStdCallBinding.java
+++ b/src/test/resources/com/qulice/checkstyle/JnaStdCallBinding.java
@@ -1,0 +1,29 @@
+/*
+ * Hello.
+ */
+package foo;
+
+import com.sun.jna.win32.StdCallLibrary;
+
+/**
+ * Binding to a native library of Windows.
+ * @since 1.0
+ */
+public interface JnaStdCallBinding extends StdCallLibrary {
+
+    /**
+     * Open a file.
+     * @param name The name of the file
+     * @param access The access mask
+     * @param mode The sharing mode
+     * @param attributes The attributes of the file
+     * @return The handle of the file
+     */
+    int CreateFileW(String name, int access, int mode, int attributes);
+
+    /**
+     * The code of the last error.
+     * @return The code
+     */
+    int GetLastError();
+}

--- a/src/test/resources/com/qulice/pmd/StdCallLibraryMethods.java
+++ b/src/test/resources/com/qulice/pmd/StdCallLibraryMethods.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import com.sun.jna.win32.StdCallLibrary;
+
+public interface StdCallLibraryMethods extends StdCallLibrary {
+
+    int firstCall();
+
+    int secondCall();
+
+    int thirdCall();
+
+    int fourthCall();
+
+    int fifthCall();
+
+    int sixthCall();
+
+    int seventhCall();
+
+    int eighthCall();
+
+    int ninthCall();
+
+    int tenthCall();
+
+    int eleventhCall();
+
+    int twelfthCall();
+}

--- a/src/test/resources/com/qulice/pmd/StdCallNames.java
+++ b/src/test/resources/com/qulice/pmd/StdCallNames.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public interface StdCallNames extends com.sun.jna.win32.StdCallLibrary {
+
+    int CreateFileW(String name, int access);
+
+    int GetLastError();
+}


### PR DESCRIPTION
`com.sun.jna.win32.StdCallLibrary` now counts as a JNA binding everywhere `com.sun.jna.Library` already did: PMD's `TooManyMethods` and `MethodNamingConventions`, and Checkstyle's `MethodName` and `ParameterNumber`. Both detectors keep a set of canonical names instead of one, and each name is matched against imports of its own package, so `extends StdCallLibrary` with the import and the fully-qualified form both work.

Every stdcall binding on Windows extends `StdCallLibrary`, not `Library`. Since neither checker resolves the supertype, the fact that JNA declares one as a sub-interface of the other does not help — the exemptions from #1756 and #1758 simply never reached those bindings.

Tests add a Windows fixture to each of the four checks. Indirect inheritance is still not detected, same as before, and the `Library` of another origin stays under the checks.

Closes #1761