### PR TITLE
Do not fire ExcessiveParameterList on constructors

### DIFF
--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -394,6 +394,22 @@
     Downstream: https://github.com/yegor256/qulice/issues/1609
     -->
     <exclude name="ExceptionAsFlowControl"/>
+    <!--
+    ExcessiveParameterList is excluded from the bulk import here and
+    re-enabled below with a violationSuppressXPath that ignores
+    constructors. The rule only special-cases private constructors, so a
+    public value object with many immutable attributes gets blamed for a
+    parameter count that tracks its field count, not its complexity; the
+    rule stays active for methods, where a long parameter list is a
+    design smell worth reporting.
+    Downstream: https://github.com/yegor256/qulice/issues/1763
+    -->
+    <exclude name="ExcessiveParameterList"/>
+  </rule>
+  <rule ref="category/java/design.xml/ExcessiveParameterList">
+    <properties>
+      <property name="violationSuppressXPath" value=".[parent::ConstructorDeclaration]"/>
+    </properties>
   </rule>
   <rule ref="category/java/documentation.xml">
     <!--

--- a/src/test/java/com/qulice/pmd/PmdExcessiveParameterListTest.java
+++ b/src/test/java/com/qulice/pmd/PmdExcessiveParameterListTest.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for ExcessiveParameterList rule wiring in qulice ruleset.
+ * The rule is suppressed on constructors but stays active on methods.
+ * @since 1.0
+ */
+final class PmdExcessiveParameterListTest {
+
+    @Test
+    void doesNotFireOnConstructorWithManyParameters() throws Exception {
+        final String file = "ExcessiveParameterListInConstructor.java";
+        final Environment.Mock mock = new Environment.Mock();
+        final String name = String.format("src/main/java/foo/%s", file);
+        final Environment env = mock.withFile(
+            name,
+            new TextOf(
+                this.getClass().getResourceAsStream(file)
+            ).asString()
+        );
+        MatcherAssert.assertThat(
+            "ExcessiveParameterList must not fire on a constructor with many parameters",
+            new PmdValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), name))
+            ).stream().map(Violation::name).collect(Collectors.toList()),
+            Matchers.not(Matchers.hasItem("ExcessiveParameterList"))
+        );
+    }
+
+    @Test
+    void firesOnMethodWithManyParameters() throws Exception {
+        final String file = "ExcessiveParameterListInMethod.java";
+        final Environment.Mock mock = new Environment.Mock();
+        final String name = String.format("src/main/java/foo/%s", file);
+        final Environment env = mock.withFile(
+            name,
+            new TextOf(
+                this.getClass().getResourceAsStream(file)
+            ).asString()
+        );
+        MatcherAssert.assertThat(
+            "ExcessiveParameterList must fire on a method with many parameters",
+            new PmdValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), name))
+            ).stream().map(Violation::name).collect(Collectors.toList()),
+            Matchers.hasItem("ExcessiveParameterList")
+        );
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ExcessiveParameterListInConstructor.java
+++ b/src/test/resources/com/qulice/pmd/ExcessiveParameterListInConstructor.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class ExcessiveParameterListInConstructor {
+
+    private final int total;
+
+    public ExcessiveParameterListInConstructor(
+        final int one, final int two, final int three, final int four,
+        final int five, final int six, final int seven, final int eight,
+        final int nine, final int ten
+    ) {
+        this.total = one + two + three + four + five + six + seven
+            + eight + nine + ten;
+    }
+
+    public int total() {
+        return this.total;
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ExcessiveParameterListInMethod.java
+++ b/src/test/resources/com/qulice/pmd/ExcessiveParameterListInMethod.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class ExcessiveParameterListInMethod {
+
+    public int total(
+        final int one, final int two, final int three, final int four,
+        final int five, final int six, final int seven, final int eight,
+        final int nine, final int ten
+    ) {
+        return one + two + three + four + five + six + seven
+            + eight + nine + ten;
+    }
+}


### PR DESCRIPTION
PMD's `ExcessiveParameterList` was pulled in wholesale via `category/java/design.xml`, and its own implementation only special-cases *private* constructors — every public or package-private constructor got counted exactly like a method. This change excludes the rule from the bulk import and re-adds it on its own with a `violationSuppressXPath` of `.[parent::ConstructorDeclaration]`, so it stays silent on any constructor while still flagging methods with too many parameters.

A constructor's parameter count tracks the number of fields it initializes, not the complexity of the code it runs, so blaming it for a long list pushes towards setters or a builder that fight qulice's own Elegant-Objects style.

Added `PmdExcessiveParameterListTest` with two fixtures — a ten-parameter constructor and a ten-parameter method — to prove the rule drops the former and keeps the latter.

Closes #1763