### PR TITLE
fix(checkstyle): #1765 flag twin closing-bracket lines

### DIFF
--- a/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
@@ -18,7 +18,10 @@ import org.cactoos.text.Joined;
  * Also, if the previous non-empty line consists only of closing brackets
  * (and optional trailing semicolon or comma), the current line indentation
  * must not be greater than that of the closing bracket line, since the
- * expression has been already terminated.
+ * expression has been already terminated. Moreover, two such closing
+ * bracket lines may not follow each other at the very same indentation,
+ * since every one of them closes exactly one more nesting level and thus
+ * must be shallower than the one above it.
  * All other cases must cause a failure.
  * @since 0.3
  */
@@ -47,39 +50,65 @@ public final class CascadeIndentationCheck extends AbstractFileSetCheck {
                 || line.isEmpty()) {
                 continue;
             }
-            if (current > previous
-                && current != previous
-                + CascadeIndentationCheck.LINE_INDENT_DIFF) {
-                this.log(
-                    pos + 1,
-                    String.format(
-                        new Joined(
-                            "",
-                            "Indentation (%d) must be same or ",
-                            "less than previous line (%d), or ",
-                            "bigger by exactly 4"
-                        ).toString(),
-                        current,
-                        previous
-                    )
-                );
-            } else if (closer && current > previous) {
-                this.log(
-                    pos + 1,
-                    String.format(
-                        new Joined(
-                            "",
-                            "Indentation (%d) must not be greater ",
-                            "than the closing bracket line (%d)"
-                        ).toString(),
-                        current,
-                        previous
-                    )
-                );
+            final String message = CascadeIndentationCheck.violation(
+                line, current, previous, closer
+            );
+            if (!message.isEmpty()) {
+                this.log(pos + 1, message);
             }
             previous = current;
             closer = CascadeIndentationCheck.isClosingBracketLine(line);
         }
+    }
+
+    /**
+     * Explains what is wrong with the indentation of the given line.
+     * @param line The line to inspect
+     * @param current Indentation of the line
+     * @param previous Indentation of the previous non-empty line
+     * @param closer True if the previous line was a closing bracket line
+     * @return The message to report or an empty string if all is fine
+     */
+    private static String violation(final String line, final int current,
+        final int previous, final boolean closer) {
+        final String message;
+        if (current > previous
+            && current != previous
+            + CascadeIndentationCheck.LINE_INDENT_DIFF) {
+            message = String.format(
+                new Joined(
+                    "",
+                    "Indentation (%d) must be same or ",
+                    "less than previous line (%d), or ",
+                    "bigger by exactly 4"
+                ).toString(),
+                current,
+                previous
+            );
+        } else if (closer && current > previous) {
+            message = String.format(
+                new Joined(
+                    "",
+                    "Indentation (%d) must not be greater ",
+                    "than the closing bracket line (%d)"
+                ).toString(),
+                current,
+                previous
+            );
+        } else if (closer && current == previous
+            && CascadeIndentationCheck.isClosingBracketLine(line)) {
+            message = String.format(
+                new Joined(
+                    "",
+                    "Indentation (%d) of this closing bracket line must be ",
+                    "less than the one of the closing bracket line above it"
+                ).toString(),
+                current
+            );
+        } else {
+            message = "";
+        }
+        return message;
     }
 
     /**

--- a/src/test/java/com/qulice/checkstyle/CascadeIndentationCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/CascadeIndentationCheckTest.java
@@ -74,6 +74,27 @@ final class CascadeIndentationCheckTest {
         );
     }
 
+    @Test
+    void rejectsTwoClosingBracketsAtTheSameIndentation() throws Exception {
+        final String file = "TwinClosingBrackets.java";
+        MatcherAssert.assertThat(
+            "Two closing brackets at one indentation must be reported",
+            this.runValidation(file, false),
+            Matchers.hasItem(
+                new ViolationMatcher(
+                    "closing bracket line must be less than", file
+                )
+            )
+        );
+    }
+
+    @Test
+    void acceptsProperlyNestedClosingBrackets() throws Exception {
+        Assertions.assertDoesNotThrow(
+            () -> this.runValidation("NestedClosingBrackets.java", true)
+        );
+    }
+
     private Collection<Violation> runValidation(final String file,
         final boolean passes) throws IOException {
         final Environment.Mock mock = new Environment.Mock();

--- a/src/test/resources/com/qulice/checkstyle/NestedClosingBrackets.java
+++ b/src/test/resources/com/qulice/checkstyle/NestedClosingBrackets.java
@@ -1,0 +1,61 @@
+/*
+ * Hello.
+ */
+package foo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Simple.
+ * @since 1.0
+ */
+public final class NestedClosingBrackets {
+
+    /**
+     * The globs.
+     */
+    private final List<String> globs;
+
+    /**
+     * The files.
+     */
+    private final List<String> files;
+
+    /**
+     * Ctor.
+     * @param masks Globs
+     * @param names Files
+     */
+    public NestedClosingBrackets(final List<String> masks,
+        final List<String> names) {
+        this.globs = masks;
+        this.files = names;
+    }
+
+    /**
+     * Filter them.
+     * @return The files
+     */
+    public Collection<String> filtered() {
+        return this.files.stream().filter(
+            file -> this.globs.stream().anyMatch(
+                glob -> file.contains(glob)
+            )
+        ).collect(Collectors.toList());
+    }
+
+    /**
+     * Join them.
+     * @return The text
+     */
+    public String joined() {
+        return String.join(
+            ",",
+            this.files.stream().map(
+                file -> file.trim()
+            ).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/TwinClosingBrackets.java
+++ b/src/test/resources/com/qulice/checkstyle/TwinClosingBrackets.java
@@ -1,0 +1,49 @@
+/*
+ * Hello.
+ */
+package foo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Simple.
+ * @since 1.0
+ */
+public final class TwinClosingBrackets {
+
+    /**
+     * The globs.
+     */
+    private final List<String> globs;
+
+    /**
+     * The files.
+     */
+    private final List<String> files;
+
+    /**
+     * Ctor.
+     * @param masks Globs
+     * @param names Files
+     */
+    public TwinClosingBrackets(final List<String> masks,
+        final List<String> names) {
+        this.globs = masks;
+        this.files = names;
+    }
+
+    /**
+     * Filter them.
+     * @return The files
+     */
+    public Collection<String> filtered() {
+        return this.files.stream().filter(
+            file -> this.globs.stream().anyMatch(
+                glob -> file.contains(glob)
+            )
+            )
+            .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Closes #1765.

`CascadeIndentationCheck` never reported a line whose indentation matched the previous one, even when both lines were bare closing-bracket lines. That made it blind to the duplicated `)` case from the issue:

```java
this.stream().filter(
    file -> globs.stream().anyMatch(
        glob -> this.matches(glob, file)
    )
    )
    .collect(Collectors.toList())
```

Every well-formed nested closing sequence closes exactly one more nesting level per line, so each bare closer must sit strictly shallower than the one above it. Two of them at the identical indentation is never valid formatting.

## Changes

- `CascadeIndentationCheck.processFiltered()` now delegates the verdict to a new private `violation()` method, which returns the message to report or an empty string. This keeps the loop small while making room for the third rule.
- Added that third rule: when the previous non-empty line was a closing-bracket line and the current line is one too at the very same indentation, report it.
- Extended the class Javadoc with the new part of the contract.
- Tests: `TwinClosingBrackets.java` (the broken snippet from the issue, must be reported) and `NestedClosingBrackets.java` (the correctly reformatted version plus a second nested-closer shape, must pass), with two matching test methods.

## Verification

- `mvn test` — all suites green (`CascadeIndentationCheckTest` 7/7, no failures or errors anywhere).
- `mvn -Pqulice verify` — qulice validates its own sources cleanly under the new rule.
- Replayed the new rule over all 593 `.java` files in the repo: the only hits are the new negative fixture and `AnnotationIndentationNegative.java`, which is an intentionally malformed fixture already expected to fail validation. No false positives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wry16u6pgZ6rdogkSsHiyv)_