### PR TITLE
fix(pmd): #1767 do not fire TooManyFields on classes extending AbstractMojo

### DIFF
--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -405,10 +405,51 @@
     Downstream: https://github.com/yegor256/qulice/issues/1763
     -->
     <exclude name="ExcessiveParameterList"/>
+    <!--
+    TooManyFields is re-enabled below with a violationSuppressXPath that
+    ignores classes extending org.apache.maven.plugin.AbstractMojo.
+    Downstream: https://github.com/yegor256/qulice/issues/1767
+    -->
+    <exclude name="TooManyFields"/>
   </rule>
   <rule ref="category/java/design.xml/ExcessiveParameterList">
     <properties>
       <property name="violationSuppressXPath" value=".[parent::ConstructorDeclaration]"/>
+    </properties>
+  </rule>
+  <!--
+  TooManyFields asks a class to keep few fields, but a Maven Mojo
+  declares one field per @Parameter it exposes to users of the plugin
+  goal, since the Maven Plugin API requires each configurable parameter
+  as a directly annotated field on the Mojo. That count tracks the
+  number of options the goal accepts, not the cohesion of the class, so
+  the suppression below skips classes extending
+  org.apache.maven.plugin.AbstractMojo. Qulice runs PMD without an
+  auxiliary classpath, so the superclass never resolves to a type and
+  the name in the extends clause is trusted only when it is fully
+  qualified or when the file imports it from its own package.
+  Downstream: https://github.com/yegor256/qulice/issues/1767
+  -->
+  <rule ref="category/java/design.xml/TooManyFields">
+    <properties>
+      <property name="violationSuppressXPath">
+        <value><![CDATA[
+          .[
+            ExtendsList
+              /ClassType[
+                @SimpleName = 'AbstractMojo'
+                and (
+                  @PackageQualifier = 'org.apache.maven.plugin'
+                  or ancestor::CompilationUnit
+                    /ImportDeclaration[
+                      @ImportedName = 'org.apache.maven.plugin.AbstractMojo'
+                      or @ImportedName = 'org.apache.maven.plugin'
+                    ]
+                )
+              ]
+          ]
+        ]]></value>
+      </property>
     </properties>
   </rule>
   <rule ref="category/java/documentation.xml">

--- a/src/test/java/com/qulice/pmd/PmdTooManyFieldsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyFieldsTest.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for TooManyFields rule wiring in qulice ruleset.
+ * The rule is suppressed on classes extending AbstractMojo but stays
+ * active on plain classes.
+ * @since 1.0
+ */
+final class PmdTooManyFieldsTest {
+
+    @Test
+    void doesNotFireOnMojoWithManyFields() throws Exception {
+        final String file = "TooManyFieldsInMojo.java";
+        final Environment.Mock mock = new Environment.Mock();
+        final String name = String.format("src/main/java/foo/%s", file);
+        final Environment env = mock.withFile(
+            name,
+            new TextOf(
+                this.getClass().getResourceAsStream(file)
+            ).asString()
+        );
+        MatcherAssert.assertThat(
+            "TooManyFields must not fire on a class extending AbstractMojo",
+            new PmdValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), name))
+            ).stream().map(Violation::name).collect(Collectors.toList()),
+            Matchers.not(Matchers.hasItem("TooManyFields"))
+        );
+    }
+
+    @Test
+    void firesOnPlainClassWithManyFields() throws Exception {
+        final String file = "TooManyFieldsInPlainClass.java";
+        final Environment.Mock mock = new Environment.Mock();
+        final String name = String.format("src/main/java/foo/%s", file);
+        final Environment env = mock.withFile(
+            name,
+            new TextOf(
+                this.getClass().getResourceAsStream(file)
+            ).asString()
+        );
+        MatcherAssert.assertThat(
+            "TooManyFields must fire on a plain class with many fields",
+            new PmdValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), name))
+            ).stream().map(Violation::name).collect(Collectors.toList()),
+            Matchers.hasItem("TooManyFields")
+        );
+    }
+}

--- a/src/test/resources/com/qulice/pmd/TooManyFieldsInMojo.java
+++ b/src/test/resources/com/qulice/pmd/TooManyFieldsInMojo.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+public final class TooManyFieldsInMojo extends AbstractMojo {
+
+    private int one;
+    private int two;
+    private int three;
+    private int four;
+    private int five;
+    private int six;
+    private int seven;
+    private int eight;
+    private int nine;
+    private int ten;
+    private int eleven;
+    private int twelve;
+    private int thirteen;
+    private int fourteen;
+    private int fifteen;
+    private int sixteen;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        final int total = this.one + this.two + this.three + this.four
+            + this.five + this.six + this.seven + this.eight + this.nine
+            + this.ten + this.eleven + this.twelve + this.thirteen
+            + this.fourteen + this.fifteen + this.sixteen;
+        this.getLog().info(String.valueOf(total));
+    }
+}

--- a/src/test/resources/com/qulice/pmd/TooManyFieldsInPlainClass.java
+++ b/src/test/resources/com/qulice/pmd/TooManyFieldsInPlainClass.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class TooManyFieldsInPlainClass {
+
+    private int one;
+    private int two;
+    private int three;
+    private int four;
+    private int five;
+    private int six;
+    private int seven;
+    private int eight;
+    private int nine;
+    private int ten;
+    private int eleven;
+    private int twelve;
+    private int thirteen;
+    private int fourteen;
+    private int fifteen;
+    private int sixteen;
+
+    public int total() {
+        return this.one + this.two + this.three + this.four
+            + this.five + this.six + this.seven + this.eight + this.nine
+            + this.ten + this.eleven + this.twelve + this.thirteen
+            + this.fourteen + this.fifteen + this.sixteen;
+    }
+}


### PR DESCRIPTION
`TooManyFields` was pulled in wholesale through the bulk `category/java/design.xml` import in `ruleset.xml`, with no exclusion or override, unlike the other design rules already customized in that block (`ExcessiveParameterList`, `TooManyMethods`, etc.). It's now excluded from the bulk import and re-added on its own with a `violationSuppressXPath` that skips classes extending `org.apache.maven.plugin.AbstractMojo`, reusing the same extends-matching XPath shape already in place for `MethodNamingConventions`.

A Mojo class declares one field per `@Parameter` it exposes to plugin users, because the Maven Plugin API requires each configurable parameter as a directly annotated field — there's no way to shrink that count without fighting the API. The rule was blaming Mojos for a shape they have no choice about, while it should stay useful for ordinary classes whose field count actually reflects poor cohesion.

Added `PmdTooManyFieldsTest` with a Mojo fixture (16 fields, rule suppressed) and a plain-class fixture (same field count, rule still fires) to cover both sides of the suppression.

Closes #1767