### PR TITLE
Prohibit static nested classes outside test files

### DIFF
--- a/src/main/java/com/qulice/checkstyle/ClassDesc.java
+++ b/src/main/java/com/qulice/checkstyle/ClassDesc.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+/**
+ * Maintains information about class' ctors.
+ * @since 0.1
+ */
+final class ClassDesc {
+
+    /**
+     * Qualified class name(with package).
+     */
+    private final String qualified;
+
+    /**
+     * Is class declared as final.
+     */
+    private final boolean asfinal;
+
+    /**
+     * Is class declared as abstract.
+     */
+    private final boolean asabstract;
+
+    /**
+     * Create a new ClassDesc instance.
+     * @param qualified Qualified class name(with package)
+     * @param asfinal Indicates if the class declared as final
+     * @param asabstract Indicates if the class declared as
+     *  abstract
+     */
+    ClassDesc(final String qualified, final boolean asfinal,
+        final boolean asabstract
+    ) {
+        this.qualified = qualified;
+        this.asfinal = asfinal;
+        this.asabstract = asabstract;
+    }
+
+    /**
+     * Get qualified class name.
+     * @return Qualified class name
+     */
+    String getQualified() {
+        return this.qualified;
+    }
+
+    /**
+     * Is class declared as final.
+     * @return True if class is declared as final
+     */
+    boolean isAsfinal() {
+        return this.asfinal;
+    }
+
+    /**
+     * Is class declared as abstract.
+     * @return True if class is declared as final
+     */
+    boolean isDeclaredAsAbstract() {
+        return this.asabstract;
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/LineRanges.java
+++ b/src/main/java/com/qulice/checkstyle/LineRanges.java
@@ -4,7 +4,6 @@
  */
 package com.qulice.checkstyle;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,7 +53,7 @@ public final class LineRanges {
     public boolean inRange(final int line) {
         return !this.lines.isEmpty()
             && FluentIterable.from(this.lines)
-            .anyMatch(new LineRanges.LineWithAny(line));
+            .anyMatch(new LineWithAny(line));
     }
 
     /**
@@ -82,31 +81,5 @@ public final class LineRanges {
      */
     public void clear() {
         this.lines.clear();
-    }
-
-    /**
-     * Predicate to determine if a given line is within range of any of
-     * the line ranges.
-     * @since 0.1
-     */
-    private static final class LineWithAny implements Predicate<LineRange> {
-
-        /**
-         * The given line.
-         */
-        private final int given;
-
-        /**
-         * Default constructor.
-         * @param line The given line to check against all the line ranges
-         */
-        private LineWithAny(final int line) {
-            this.given = line;
-        }
-
-        @Override
-        public boolean apply(final LineRange range) {
-            return range != null && range.within(this.given);
-        }
     }
 }

--- a/src/main/java/com/qulice/checkstyle/LineWithAny.java
+++ b/src/main/java/com/qulice/checkstyle/LineWithAny.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.google.common.base.Predicate;
+
+/**
+ * Predicate to determine if a given line is within range of any of
+ * the line ranges.
+ * @since 0.1
+ */
+final class LineWithAny implements Predicate<LineRange> {
+
+    /**
+     * The given line.
+     */
+    private final int given;
+
+    /**
+     * Default constructor.
+     * @param line The given line to check against all the line ranges
+     */
+    LineWithAny(final int line) {
+        this.given = line;
+    }
+
+    @Override
+    public boolean apply(final LineRange range) {
+        return range != null && range.within(this.given);
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
@@ -74,7 +74,7 @@ public final class ProhibitNonFinalClassesCheck extends AbstractCheck {
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
         if (ast.getType() == TokenTypes.CLASS_DEF) {
             this.classes.push(
-                new ProhibitNonFinalClassesCheck.ClassDesc(
+                new ClassDesc(
                     this.qualifiedClassName(ast),
                     modifiers.findFirstToken(TokenTypes.FINAL) != null,
                     modifiers.findFirstToken(TokenTypes.ABSTRACT) != null
@@ -171,66 +171,5 @@ public final class ProhibitNonFinalClassesCheck extends AbstractCheck {
                 ProhibitNonFinalClassesCheck.PACKAGE_SEPARATOR
             ) + 1
         );
-    }
-
-    /**
-     * Maintains information about class' ctors.
-     * @since 0.1
-     */
-    private static final class ClassDesc {
-
-        /**
-         * Qualified class name(with package).
-         */
-        private final String qualified;
-
-        /**
-         * Is class declared as final.
-         */
-        private final boolean asfinal;
-
-        /**
-         * Is class declared as abstract.
-         */
-        private final boolean asabstract;
-
-        /**
-         * Create a new ClassDesc instance.
-         * @param qualified Qualified class name(with package)
-         * @param asfinal Indicates if the class declared as final
-         * @param asabstract Indicates if the class declared as
-         *  abstract
-         */
-        ClassDesc(final String qualified, final boolean asfinal,
-            final boolean asabstract
-        ) {
-            this.qualified = qualified;
-            this.asfinal = asfinal;
-            this.asabstract = asabstract;
-        }
-
-        /**
-         * Get qualified class name.
-         * @return Qualified class name
-         */
-        private String getQualified() {
-            return this.qualified;
-        }
-
-        /**
-         * Is class declared as final.
-         * @return True if class is declared as final
-         */
-        private boolean isAsfinal() {
-            return this.asfinal;
-        }
-
-        /**
-         * Is class declared as abstract.
-         * @return True if class is declared as final
-         */
-        private boolean isDeclaredAsAbstract() {
-            return this.asabstract;
-        }
     }
 }

--- a/src/main/java/com/qulice/checkstyle/ProhibitStaticNestedClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitStaticNestedClassesCheck.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.regex.Pattern;
+
+/**
+ * Checks that a class does not declare a static nested class, since a
+ * static nested class is a self-contained abstraction and belongs in
+ * a file of its own. Non-static (inner) nested classes are always
+ * allowed, since they keep a reference to their enclosing instance
+ * and are not self-contained.
+ *
+ * <p>Only files whose names do not match the configured pattern (by
+ * default {@code *Test.java}, {@code *IT.java}, {@code *ITCase.java})
+ * are inspected, since fake/stub helpers nested inside test classes
+ * are a normal pattern (see
+ * {@link ProhibitFieldsInTestClassesCheck}).
+ *
+ * @since 0.73.4
+ */
+public final class ProhibitStaticNestedClassesCheck extends AbstractCheck {
+
+    /**
+     * File names of test classes.
+     */
+    private static final Pattern TESTS =
+        Pattern.compile(".*(Test|IT|ITCase)\\.java$");
+
+    /**
+     * File names that this check does not apply to.
+     */
+    private Pattern exclude;
+
+    /**
+     * Default constructor.
+     */
+    public ProhibitStaticNestedClassesCheck() {
+        this.exclude = ProhibitStaticNestedClassesCheck.TESTS;
+    }
+
+    /**
+     * Do not apply this check to files matching the given pattern.
+     * @param regex Regex of file names to exclude
+     */
+    public void setExcludeFileNamePattern(final String regex) {
+        this.exclude = Pattern.compile(regex);
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {TokenTypes.CLASS_DEF};
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        if (!this.exclude.matcher(this.getFilePath()).find()
+            && ProhibitStaticNestedClassesCheck.isStaticNestedClass(ast)) {
+            final DetailAST name = ast.findFirstToken(TokenTypes.IDENT);
+            this.log(
+                name.getLineNo(),
+                String.format(
+                    "Static class \"%s\" must be moved into its own file",
+                    name.getText()
+                )
+            );
+        }
+    }
+
+    /**
+     * Is this CLASS_DEF a static class nested inside another type?
+     * @param ast Class definition node
+     * @return True if the class is nested and declared as static
+     */
+    private static boolean isStaticNestedClass(final DetailAST ast) {
+        final DetailAST parent = ast.getParent();
+        return parent != null && parent.getType() == TokenTypes.OBJBLOCK
+            && ast.findFirstToken(TokenTypes.MODIFIERS)
+                .findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+    }
+}

--- a/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/src/main/java/com/qulice/maven/CheckMojo.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -103,6 +102,31 @@ public final class CheckMojo extends AbstractQuliceMojo {
      */
     public void setTimeout(final String time) {
         this.timeout = time;
+    }
+
+    /**
+     * Filter files based on excludes.
+     * @param env Maven environment
+     * @param files Files to exclude
+     * @param validator Validator to use
+     * @return Filtered files
+     */
+    static Collection<File> filter(
+        final MavenEnvironment env,
+        final Collection<File> files, final ResourceValidator validator
+    ) {
+        final Collection<File> filtered = new ArrayList<>(files.size());
+        for (final File file : files) {
+            if (
+                !env.exclude(
+                    validator.name().toLowerCase(Locale.ENGLISH),
+                    file.toString()
+                )
+            ) {
+                filtered.add(file);
+            }
+        }
+        return filtered;
     }
 
     /**
@@ -207,7 +231,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
         for (final ResourceValidator validator : validators) {
             futures.add(
                 this.executors.submit(
-                    new CheckMojo.ValidatorCallable(validator, env, files)
+                    new ValidatorCallable(validator, env, files)
                 )
             );
         }
@@ -264,75 +288,5 @@ public final class CheckMojo extends AbstractQuliceMojo {
             .toLowerCase(Locale.ENGLISH);
         }
         return clear;
-    }
-
-    /**
-     * Filter files based on excludes.
-     * @param env Maven environment
-     * @param files Files to exclude
-     * @param validator Validator to use
-     * @return Filtered files
-     */
-    private static Collection<File> filter(
-        final MavenEnvironment env,
-        final Collection<File> files, final ResourceValidator validator
-    ) {
-        final Collection<File> filtered = new ArrayList<>(files.size());
-        for (final File file : files) {
-            if (
-                !env.exclude(
-                    validator.name().toLowerCase(Locale.ENGLISH),
-                    file.toString()
-                )
-            ) {
-                filtered.add(file);
-            }
-        }
-        return filtered;
-    }
-
-    /**
-     * Callable for validators.
-     * @since 0.1
-     */
-    private static class ValidatorCallable
-        implements Callable<Collection<Violation>> {
-
-        /**
-         * Validator to use.
-         */
-        private final ResourceValidator validator;
-
-        /**
-         * Maven environment.
-         */
-        private final MavenEnvironment env;
-
-        /**
-         * List of files to validate.
-         */
-        private final Collection<File> files;
-
-        /**
-         * Constructor.
-         * @param validator Validator to use
-         * @param env Maven environment
-         * @param files List of files to validate
-         */
-        ValidatorCallable(
-            final ResourceValidator validator,
-            final MavenEnvironment env, final Collection<File> files
-        ) {
-            this.validator = validator;
-            this.env = env;
-            this.files = files;
-        }
-
-        @Override
-        public Collection<Violation> call() {
-            return this.validator.validate(
-                CheckMojo.filter(this.env, this.files, this.validator)
-            );
-        }
     }
 }

--- a/src/main/java/com/qulice/maven/CheckerExcludes.java
+++ b/src/main/java/com/qulice/maven/CheckerExcludes.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import com.google.common.base.Function;
+import javax.annotation.Nullable;
+
+/**
+ * Converts a checker exclude into exclude param.
+ *
+ * <p>E.g. "checkstyle:.*" will become ".*".
+ *
+ * @since 0.1
+ */
+final class CheckerExcludes implements Function<String, String> {
+
+    /**
+     * All checkers.
+     */
+    private static final String ALL = "*";
+
+    /**
+     * Name of checker.
+     */
+    private final String checker;
+
+    /**
+     * Constructor.
+     * @param checker Name of checker
+     */
+    CheckerExcludes(final String checker) {
+        this.checker = checker;
+    }
+
+    @Nullable
+    @Override
+    public String apply(@Nullable final String input) {
+        String result = null;
+        if (input != null) {
+            final String[] exclude = input.split(":", 2);
+            final String check = exclude[0];
+            final boolean appropriate = CheckerExcludes.ALL.equals(check)
+                || this.checker.equals(check);
+            if (appropriate && exclude.length > 1) {
+                result = exclude[1];
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -4,8 +4,6 @@
  */
 package com.qulice.maven;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
@@ -17,7 +15,6 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -165,8 +162,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
                 throw new IllegalStateException("Failed to build URL", ex);
             }
         }
-        final URLClassLoader loader =
-            new DefaultMavenEnvironment.PrivilegedClassLoader(urls).run();
+        final URLClassLoader loader = new PrivilegedClassLoader(urls).run();
         for (final URL url : loader.getURLs()) {
             Logger.debug(this, "Classpath: %s", url);
         }
@@ -233,7 +229,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
     public boolean exclude(final String check, final String name) {
         return Iterables.any(
             this.excludes(check),
-            new DefaultMavenEnvironment.PathPredicate(name)
+            new PathPredicate(name)
         );
     }
 
@@ -242,7 +238,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         return Collections2.filter(
             Collections2.transform(
                 this.exc,
-                new DefaultMavenEnvironment.CheckerExcludes(checker)
+                new CheckerExcludes(checker)
             ),
             Predicates.notNull()
         );
@@ -445,104 +441,5 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
             resolved = new File(this.basedir(), path);
         }
         return resolved;
-    }
-
-    /**
-     * Creates URL ClassLoader in privileged block.
-     * @since 0.1
-     */
-    private static final class PrivilegedClassLoader implements
-        PrivilegedAction<URLClassLoader> {
-
-        /**
-         * URLs for class loading.
-         */
-        private final List<URL> urls;
-
-        /**
-         * Constructor.
-         * @param urls URLs for class loading
-         */
-        private PrivilegedClassLoader(final List<URL> urls) {
-            this.urls = urls;
-        }
-
-        @Override
-        public URLClassLoader run() {
-            return new URLClassLoader(
-                this.urls.toArray(new URL[0]),
-                Thread.currentThread().getContextClassLoader()
-            );
-        }
-    }
-
-    /**
-     * Checks if two paths are equal.
-     * @since 0.1
-     */
-    private static class PathPredicate implements Predicate<String> {
-
-        /**
-         * Path to match.
-         */
-        private final String name;
-
-        /**
-         * Constructor.
-         * @param name Path to match
-         */
-        PathPredicate(final String name) {
-            this.name = name;
-        }
-
-        @Override
-        public boolean apply(@Nullable final String input) {
-            return input != null
-                && FilenameUtils.normalize(this.name, true).matches(input);
-        }
-    }
-
-    /**
-     * Converts a checker exclude into exclude param.
-     *
-     * <p>E.g. "checkstyle:.*" will become ".*".
-     *
-     * @since 0.1
-     */
-    private static class CheckerExcludes implements Function<String, String> {
-
-        /**
-         * All checkers.
-         */
-        private static final String ALL = "*";
-
-        /**
-         * Name of checker.
-         */
-        private final String checker;
-
-        /**
-         * Constructor.
-         * @param checker Name of checker
-         */
-        CheckerExcludes(final String checker) {
-            this.checker = checker;
-        }
-
-        @Nullable
-        @Override
-        public String apply(@Nullable final String input) {
-            String result = null;
-            if (input != null) {
-                final String[] exclude = input.split(":", 2);
-                final String check = exclude[0];
-                final boolean appropriate = CheckerExcludes.ALL.equals(check)
-                    || this.checker.equals(check);
-                if (appropriate && exclude.length > 1) {
-                    result = exclude[1];
-                }
-            }
-            return result;
-        }
     }
 }

--- a/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -4,7 +4,6 @@
  */
 package com.qulice.maven;
 
-import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.jcabi.log.Logger;
@@ -60,7 +59,7 @@ final class DependenciesValidator implements MavenValidator {
         }
         final Collection<String> unused = Collections2.filter(
             DependenciesValidator.unused(env),
-            Predicates.not(new DependenciesValidator.ExcludePredicate(excludes))
+            Predicates.not(new ExcludePredicate(excludes))
         );
         if (!unused.isEmpty()) {
             Logger.warn(
@@ -72,7 +71,7 @@ final class DependenciesValidator implements MavenValidator {
         }
         final Collection<String> used = Collections2.filter(
             DependenciesValidator.used(env),
-            Predicates.not(new DependenciesValidator.ExcludePredicate(excludes))
+            Predicates.not(new ExcludePredicate(excludes))
         );
         if (!used.isEmpty()) {
             Logger.warn(
@@ -295,37 +294,5 @@ final class DependenciesValidator implements MavenValidator {
             match = direct || wildcard;
         }
         return match;
-    }
-
-    /**
-     * Predicate for excluded dependencies.
-     * @since 0.1
-     */
-    private static class ExcludePredicate implements Predicate<String> {
-
-        /**
-         * List of excludes.
-         */
-        private final Collection<String> excludes;
-
-        /**
-         * Constructor.
-         * @param excludes List of excludes
-         */
-        ExcludePredicate(final Collection<String> excludes) {
-            this.excludes = excludes;
-        }
-
-        @Override
-        public boolean apply(final String name) {
-            boolean ignore = false;
-            for (final String exclude : this.excludes) {
-                if (name.startsWith(exclude)) {
-                    ignore = true;
-                    break;
-                }
-            }
-            return ignore;
-        }
     }
 }

--- a/src/main/java/com/qulice/maven/ExcludePredicate.java
+++ b/src/main/java/com/qulice/maven/ExcludePredicate.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import com.google.common.base.Predicate;
+import java.util.Collection;
+
+/**
+ * Predicate for excluded dependencies.
+ * @since 0.1
+ */
+final class ExcludePredicate implements Predicate<String> {
+
+    /**
+     * List of excludes.
+     */
+    private final Collection<String> excludes;
+
+    /**
+     * Constructor.
+     * @param excludes List of excludes
+     */
+    ExcludePredicate(final Collection<String> excludes) {
+        this.excludes = excludes;
+    }
+
+    @Override
+    public boolean apply(final String name) {
+        boolean ignore = false;
+        for (final String exclude : this.excludes) {
+            if (name.startsWith(exclude)) {
+                ignore = true;
+                break;
+            }
+        }
+        return ignore;
+    }
+}

--- a/src/main/java/com/qulice/maven/PathPredicate.java
+++ b/src/main/java/com/qulice/maven/PathPredicate.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import com.google.common.base.Predicate;
+import javax.annotation.Nullable;
+import org.apache.commons.io.FilenameUtils;
+
+/**
+ * Checks if two paths are equal.
+ * @since 0.1
+ */
+final class PathPredicate implements Predicate<String> {
+
+    /**
+     * Path to match.
+     */
+    private final String name;
+
+    /**
+     * Constructor.
+     * @param name Path to match
+     */
+    PathPredicate(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean apply(@Nullable final String input) {
+        return input != null
+            && FilenameUtils.normalize(this.name, true).matches(input);
+    }
+}

--- a/src/main/java/com/qulice/maven/PrivilegedClassLoader.java
+++ b/src/main/java/com/qulice/maven/PrivilegedClassLoader.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.PrivilegedAction;
+import java.util.List;
+
+/**
+ * Creates URL ClassLoader in privileged block.
+ * @since 0.1
+ */
+final class PrivilegedClassLoader implements PrivilegedAction<URLClassLoader> {
+
+    /**
+     * URLs for class loading.
+     */
+    private final List<URL> urls;
+
+    /**
+     * Constructor.
+     * @param urls URLs for class loading
+     */
+    PrivilegedClassLoader(final List<URL> urls) {
+        this.urls = urls;
+    }
+
+    @Override
+    public URLClassLoader run() {
+        return new URLClassLoader(
+            this.urls.toArray(new URL[0]),
+            Thread.currentThread().getContextClassLoader()
+        );
+    }
+}

--- a/src/main/java/com/qulice/maven/ValidatorCallable.java
+++ b/src/main/java/com/qulice/maven/ValidatorCallable.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import com.qulice.spi.ResourceValidator;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+/**
+ * Callable for validators.
+ * @since 0.1
+ */
+final class ValidatorCallable implements Callable<Collection<Violation>> {
+
+    /**
+     * Validator to use.
+     */
+    private final ResourceValidator validator;
+
+    /**
+     * Maven environment.
+     */
+    private final MavenEnvironment env;
+
+    /**
+     * List of files to validate.
+     */
+    private final Collection<File> files;
+
+    /**
+     * Constructor.
+     * @param validator Validator to use
+     * @param env Maven environment
+     * @param files List of files to validate
+     */
+    ValidatorCallable(
+        final ResourceValidator validator,
+        final MavenEnvironment env, final Collection<File> files
+    ) {
+        this.validator = validator;
+        this.env = env;
+        this.files = files;
+    }
+
+    @Override
+    public Collection<Violation> call() {
+        return this.validator.validate(
+            CheckMojo.filter(this.env, this.files, this.validator)
+        );
+    }
+}

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -475,6 +475,7 @@
       <property name="excludeFileNamePattern" value=".*(Test|IT|ITCase)\.java"/>
     </module>
     <module name="com.qulice.checkstyle.ProhibitFieldsInTestClassesCheck"/>
+    <module name="com.qulice.checkstyle.ProhibitStaticNestedClassesCheck"/>
     <module name="com.qulice.checkstyle.ProtectedMethodInFinalClassCheck"/>
     <module name="com.qulice.checkstyle.QualifyInnerClassCheck"/>
     <module name="com.qulice.checkstyle.FinalSemicolonInTryWithResourcesCheck"/>

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -235,6 +235,7 @@ final class ChecksTest {
             "SingleSpaceSeparatorCheck",
             "SimpleStringSplitCheck",
             "ProhibitFieldsInTestClassesCheck",
+            "ProhibitStaticNestedClassesCheck",
             "ParameterNumberCheck"
         ).map(s -> String.format("ChecksTest/%s", s));
     }

--- a/src/test/java/com/qulice/maven/FakeContext.java
+++ b/src/test/java/com/qulice/maven/FakeContext.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import java.util.Collections;
+import java.util.Map;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.context.ContextException;
+
+/**
+ * FakeContext.
+ * A mock to a context.
+ * @since 0.24.1
+ */
+final class FakeContext implements Context {
+
+    /**
+     * Container.
+     */
+    private final PlexusContainer container;
+
+    FakeContext(final PlexusContainer ctainer) {
+        this.container = ctainer;
+    }
+
+    @Override
+    public boolean contains(final Object obj) {
+        return true;
+    }
+
+    @Override
+    public void put(final Object obja, final Object objb) {
+        // Intentionally left blank
+    }
+
+    @Override
+    public Object get(final Object obj) throws ContextException {
+        return this.container;
+    }
+
+    @Override
+    public Map<Object, Object> getContextData() {
+        return Collections.emptyMap();
+    }
+}

--- a/src/test/java/com/qulice/maven/FakeMavenEnvironment.java
+++ b/src/test/java/com/qulice/maven/FakeMavenEnvironment.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.context.Context;
+
+/**
+ * FakeMavenEnvironment.
+ * A mock to MavenEnvironment.
+ * @since 0.24.1
+ */
+final class FakeMavenEnvironment implements MavenEnvironment {
+
+    /**
+     * Project.
+     */
+    private final MavenProject proj;
+
+    /**
+     * Context.
+     */
+    private final Context ctx;
+
+    /**
+     * Asserts.
+     */
+    private final Collection<String> assrts;
+
+    FakeMavenEnvironment(
+        final MavenProject prj,
+        final Context ctx,
+        final Collection<String> asserts
+    ) {
+        this.proj = prj;
+        this.ctx = ctx;
+        this.assrts = asserts;
+    }
+
+    @Override
+    public MavenProject project() {
+        return this.proj;
+    }
+
+    @Override
+    public Properties properties() {
+        throw new UnsupportedOperationException("#properties()");
+    }
+
+    @Override
+    public Context context() {
+        return this.ctx;
+    }
+
+    @Override
+    public Properties config() {
+        throw new UnsupportedOperationException("#config()");
+    }
+
+    @Override
+    public MojoExecutor executor() {
+        throw new UnsupportedOperationException("#executor()");
+    }
+
+    @Override
+    public Collection<String> asserts() {
+        return this.assrts;
+    }
+
+    @Override
+    public File basedir() {
+        return this.proj.getBasedir();
+    }
+
+    @Override
+    public File tempdir() {
+        return new File("/tmp");
+    }
+
+    @Override
+    public File outdir() {
+        return this.proj.getBasedir();
+    }
+
+    @Override
+    public Collection<File> testdirs() {
+        return this.proj.getTestCompileSourceRoots().stream()
+            .map(File::new)
+            .toList();
+    }
+
+    @Override
+    public String param(final String name, final String value) {
+        return "";
+    }
+
+    @Override
+    public ClassLoader classloader() {
+        return ClassLoader.getSystemClassLoader();
+    }
+
+    @Override
+    public Collection<String> classpath() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<File> files(final String pattern) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean exclude(final String check, final String name) {
+        return true;
+    }
+
+    @Override
+    public Collection<String> excludes(final String checker) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Charset encoding() {
+        return StandardCharsets.UTF_8;
+    }
+}

--- a/src/test/java/com/qulice/maven/FakeValidatorsProvider.java
+++ b/src/test/java/com/qulice/maven/FakeValidatorsProvider.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.maven;
+
+import com.qulice.spi.ResourceValidator;
+import com.qulice.spi.Validator;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * FakeValidatorsProvides.
+ * A mock to ValidatorsProvides.
+ * @since 0.24.1
+ */
+final class FakeValidatorsProvider implements ValidatorsProvider {
+
+    /**
+     * Max validators.
+     */
+    private final Set<MavenValidator> intern;
+
+    /**
+     * External validators.
+     */
+    private final Set<Validator> extern;
+
+    /**
+     * Resources validators.
+     */
+    private final Set<ResourceValidator> rextern;
+
+    FakeValidatorsProvider(
+        final Set<MavenValidator> inter,
+        final Set<Validator> exter,
+        final Set<ResourceValidator> rexter
+    ) {
+        this.intern = inter;
+        this.extern = exter;
+        this.rextern = rexter;
+    }
+
+    @Override
+    public Set<MavenValidator> internal() {
+        return this.intern;
+    }
+
+    @Override
+    public Set<Validator> external() {
+        return this.extern;
+    }
+
+    @Override
+    public Collection<ResourceValidator> externalResource() {
+        return this.rextern;
+    }
+}

--- a/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
+++ b/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
@@ -5,22 +5,15 @@
 package com.qulice.maven;
 
 import com.qulice.spi.Environment;
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.Map;
-import java.util.Properties;
 import org.apache.maven.monitor.logging.DefaultLog;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
-import org.codehaus.plexus.context.Context;
-import org.codehaus.plexus.context.ContextException;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.slf4j.impl.StaticLoggerBinder;
 
@@ -140,168 +133,11 @@ public final class MavenEnvironmentMocker {
         this.prj.inBasedir(this.ienv.basedir());
         return new MavenEnvironment.Wrap(
             this.ienv,
-            new MavenEnvironmentMocker.FakeMavenEnvironment(
+            new FakeMavenEnvironment(
                 this.prj.mock(),
-                new MavenEnvironmentMocker.FakeContext(this.container),
+                new FakeContext(this.container),
                 this.ass
             )
         );
-    }
-
-    /**
-     * FakeContext.
-     * A mock to a context.
-     * @since 0.24.1
-     */
-    private static final class FakeContext implements Context {
-
-        /**
-         * Container.
-         */
-        private final PlexusContainer container;
-
-        FakeContext(final PlexusContainer ctainer) {
-            this.container = ctainer;
-        }
-
-        @Override
-        public boolean contains(final Object obj) {
-            return true;
-        }
-
-        @Override
-        public void put(final Object obja, final Object objb) {
-            // Intentionally left blank
-        }
-
-        @Override
-        public Object get(final Object obj) throws ContextException {
-            return this.container;
-        }
-
-        @Override
-        public Map<Object, Object> getContextData() {
-            return Collections.emptyMap();
-        }
-    }
-
-    /**
-     * FakeMavenEnvironment.
-     * A mock to MavenEnvironment.
-     * @since 0.24.1
-     */
-    private static final class FakeMavenEnvironment implements MavenEnvironment {
-
-        /**
-         * Project.
-         */
-        private final MavenProject proj;
-
-        /**
-         * Context.
-         */
-        private final Context ctx;
-
-        /**
-         * Asserts.
-         */
-        private final Collection<String> assrts;
-
-        FakeMavenEnvironment(
-            final MavenProject prj,
-            final Context ctx,
-            final Collection<String> asserts
-        ) {
-            this.proj = prj;
-            this.ctx = ctx;
-            this.assrts = asserts;
-        }
-
-        @Override
-        public MavenProject project() {
-            return this.proj;
-        }
-
-        @Override
-        public Properties properties() {
-            throw new UnsupportedOperationException("#properties()");
-        }
-
-        @Override
-        public Context context() {
-            return this.ctx;
-        }
-
-        @Override
-        public Properties config() {
-            throw new UnsupportedOperationException("#config()");
-        }
-
-        @Override
-        public MojoExecutor executor() {
-            throw new UnsupportedOperationException("#executor()");
-        }
-
-        @Override
-        public Collection<String> asserts() {
-            return this.assrts;
-        }
-
-        @Override
-        public File basedir() {
-            return this.proj.getBasedir();
-        }
-
-        @Override
-        public File tempdir() {
-            return new File("/tmp");
-        }
-
-        @Override
-        public File outdir() {
-            return this.proj.getBasedir();
-        }
-
-        @Override
-        public Collection<File> testdirs() {
-            return this.proj.getTestCompileSourceRoots().stream()
-                .map(File::new)
-                .toList();
-        }
-
-        @Override
-        public String param(final String name, final String value) {
-            return "";
-        }
-
-        @Override
-        public ClassLoader classloader() {
-            return ClassLoader.getSystemClassLoader();
-        }
-
-        @Override
-        public Collection<String> classpath() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public Collection<File> files(final String pattern) {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public boolean exclude(final String check, final String name) {
-            return true;
-        }
-
-        @Override
-        public Collection<String> excludes(final String checker) {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public Charset encoding() {
-            return StandardCharsets.UTF_8;
-        }
     }
 }

--- a/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
+++ b/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
@@ -6,7 +6,6 @@ package com.qulice.maven;
 
 import com.qulice.spi.ResourceValidator;
 import com.qulice.spi.Validator;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -66,58 +65,10 @@ final class ValidatorsProviderMocker {
      * @return The provider
      */
     ValidatorsProvider mock() {
-        return new ValidatorsProviderMocker.FakeValidatorsProvider(
+        return new FakeValidatorsProvider(
             this.internal,
             this.external,
             this.rexternal
         );
-    }
-
-    /**
-     * FakeValidatorsProvides.
-     * A mock to ValidatorsProvides.
-     * @since 0.24.1
-     */
-    private static class FakeValidatorsProvider implements ValidatorsProvider {
-
-        /**
-         * Max validators.
-         */
-        private final Set<MavenValidator> intern;
-
-        /**
-         * External validators.
-         */
-        private final Set<Validator> extern;
-
-        /**
-         * Resources validators.
-         */
-        private final Set<ResourceValidator> rextern;
-
-        FakeValidatorsProvider(
-            final Set<MavenValidator> inter,
-            final Set<Validator> exter,
-            final Set<ResourceValidator> rexter
-        ) {
-            this.intern = inter;
-            this.extern = exter;
-            this.rextern = rexter;
-        }
-
-        @Override
-        public Set<MavenValidator> internal() {
-            return this.intern;
-        }
-
-        @Override
-        public Set<Validator> external() {
-            return this.extern;
-        }
-
-        @Override
-        public Collection<ResourceValidator> externalResource() {
-            return this.rextern;
-        }
     }
 }

--- a/src/test/resources/com/qulice/checkstyle/AnnotationConstantField.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationConstantField.java
@@ -55,7 +55,7 @@ public final class AnnotationConstantField {
      * @since 1.0
      */
     @SuppressWarnings(AnnotationConstantField.TEXT4)
-    private static final class Inner {
+    private final class Inner {
 
         /**
          * Random source.

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/Invalid-Deep.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/Invalid-Deep.java
@@ -1,0 +1,11 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class InvalidDeep {
+    private final class Inner {
+        private static final class Nested {
+            private int counter;
+        }
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/Invalid.java
@@ -1,0 +1,9 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class Invalid {
+    private static class Nested {
+        private int counter;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/Valid-SampleTest.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/Valid-SampleTest.java
@@ -1,0 +1,9 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class SampleTest {
+    private static final class FakeHelper {
+        private int counter;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/Valid.java
@@ -1,0 +1,9 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class Valid {
+    private final class Inner {
+        private int counter;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.ProhibitStaticNestedClassesCheck">
+      <property name="excludeFileNamePattern" value=".*(Test|IT|ITCase)\.java$"/>
+    </module>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/violations-Deep.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/violations-Deep.txt
@@ -1,0 +1,1 @@
+7:Static class "Nested" must be moved into its own file

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ProhibitStaticNestedClassesCheck/violations.txt
@@ -1,0 +1,1 @@
+6:Static class "Nested" must be moved into its own file

--- a/src/test/resources/com/qulice/checkstyle/ValidLambdaIndentation.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidLambdaIndentation.java
@@ -49,7 +49,7 @@ public final class ValidLambdaIndentation {
      * @param <T> Type
      * @since 1.0
      */
-    private static final class Boxed<T> {
+    private final class Boxed<T> {
 
         /**
          * Inner.


### PR DESCRIPTION
Adds a new Checkstyle check, `ProhibitStaticNestedClassesCheck`, that flags a static nested class declared inside a class whose file isn't named `*Test.java`, `*IT.java`, or `*ITCase.java`. Non-static (inner) nested classes stay allowed everywhere, and static helpers nested inside test classes are still fine, since that's a normal fixture pattern already relied on elsewhere.

Neither Checkstyle nor PMD ship a rule for this, so it had to be a custom check, in the style of `ProhibitFieldsInTestClassesCheck`. Since Qulice lints itself, turning the check on also meant pulling the handful of `private static class` helpers out of Qulice's own production and test-support code (`ProhibitNonFinalClassesCheck`, `DefaultMavenEnvironment`, `CheckMojo`, `DependenciesValidator`, the two maven test mockers) into their own files, plus tweaking two Checkstyle test fixtures that happened to use a static nested class incidentally.

Closes #1770