### PR TITLE
feat(checkstyle): #1774 prohibit Javadoc on all private methods

### DIFF
--- a/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
+++ b/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
@@ -80,10 +80,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks params statement to satisfy the rule.
-     * @param node Tree node, containing method call statement
-     */
     private void checkParams(final DetailAST node) {
         final DetailAST closing = node.findFirstToken(TokenTypes.RPAREN);
         if (closing != null) {
@@ -91,12 +87,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks params statement to satisfy the rule.
-     * @param node Tree node, containing method call statement
-     * @param start First line
-     * @param end Final line
-     */
     private void checkLines(final DetailAST node, final int start,
         final int end) {
         if (start != end) {
@@ -109,14 +99,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Returns the line number of the first actual token inside the
-     * expression list. ELIST itself reports {@code lparen + 1} regardless
-     * of where the first parameter actually is, so we descend to the
-     * leftmost leaf to find the real position.
-     * @param elist Tree node, containing the expression list
-     * @return Line number of the first parameter token
-     */
     private static int firstParamLine(final DetailAST elist) {
         DetailAST leaf = elist;
         while (leaf.getFirstChild() != null) {
@@ -131,11 +113,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         return line;
     }
 
-    /**
-     * Checks expression list if closing bracket is on new line.
-     * @param elist Tree node, containing expression list
-     * @param end Final line
-     */
     private void checkExpressionList(final DetailAST elist, final int end) {
         if (elist.getChildCount() > 0) {
             DetailAST last = elist.getLastChild();
@@ -149,10 +126,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks annotation with multi-line parameter list.
-     * @param node Tree node, containing the ANNOTATION
-     */
     private void checkAnnotation(final DetailAST node) {
         final DetailAST opening = node.findFirstToken(TokenTypes.LPAREN);
         final DetailAST closing = node.findFirstToken(TokenTypes.RPAREN);
@@ -171,13 +144,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Returns the closing curly of an annotation array initializer when
-     * the annotation contains exactly one such child, otherwise null.
-     * @param first First child after the LPAREN
-     * @param last Last child before the RPAREN
-     * @return RCURLY token or null
-     */
     private static DetailAST arrayInitRcurly(final DetailAST first,
         final DetailAST last) {
         DetailAST rcurly = null;
@@ -192,13 +158,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         return rcurly;
     }
 
-    /**
-     * Logs at the first/last content of a multi-line annotation array
-     * initializer. The empty initializer {@code {}} has no content
-     * before the closing curly, so only the end is checked.
-     * @param array The ANNOTATION_ARRAY_INIT token
-     * @param rcurly The closing RCURLY of that initializer
-     */
     private void checkArrayBounds(final DetailAST array,
         final DetailAST rcurly) {
         final DetailAST inner = array.getFirstChild();
@@ -208,12 +167,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         this.checkBoundsEnd(rcurly.getPreviousSibling(), rcurly);
     }
 
-    /**
-     * Logs a violation when the first content sits on the same line as
-     * the opening bracket.
-     * @param first First content token (may be null)
-     * @param start Opening bracket token
-     */
     private void checkBoundsStart(final DetailAST first,
         final DetailAST start) {
         if (first != null && first.getLineNo() == start.getLineNo()) {
@@ -224,12 +177,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Logs a violation when the last content sits on the same line as
-     * the closing bracket.
-     * @param last Last content token (may be null)
-     * @param end Closing bracket token
-     */
     private void checkBoundsEnd(final DetailAST last, final DetailAST end) {
         DetailAST leaf = last;
         while (leaf != null && leaf.getChildCount() > 0) {
@@ -243,10 +190,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks resources of try-with-resources statement.
-     * @param node Tree node, containing the RESOURCE_SPECIFICATION
-     */
     private void checkResources(final DetailAST node) {
         final DetailAST opening = node.findFirstToken(TokenTypes.LPAREN);
         final DetailAST closing = node.findFirstToken(TokenTypes.RPAREN);
@@ -256,12 +199,6 @@ public final class BracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks RESOURCES body inside a multiline try-with-resources.
-     * @param node Tree node with the RESOURCE_SPECIFICATION
-     * @param opening The opening LPAREN token
-     * @param closing The closing RPAREN token
-     */
     private void checkResourceBody(final DetailAST node,
         final DetailAST opening, final DetailAST closing) {
         final DetailAST resources = node.findFirstToken(TokenTypes.RESOURCES);

--- a/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
@@ -61,14 +61,6 @@ public final class CascadeIndentationCheck extends AbstractFileSetCheck {
         }
     }
 
-    /**
-     * Explains what is wrong with the indentation of the given line.
-     * @param line The line to inspect
-     * @param current Indentation of the line
-     * @param previous Indentation of the previous non-empty line
-     * @param closer True if the previous line was a closing bracket line
-     * @return The message to report or an empty string if all is fine
-     */
     private static String violation(final String line, final int current,
         final int previous, final boolean closer) {
         final String message;
@@ -111,12 +103,6 @@ public final class CascadeIndentationCheck extends AbstractFileSetCheck {
         return message;
     }
 
-    /**
-     * Tells whether the line consists only of closing brackets, optionally
-     * followed by a comma or a semicolon and surrounding whitespace.
-     * @param line Input line
-     * @return True if the line is a standalone closing bracket line
-     */
     private static boolean isClosingBracketLine(final String line) {
         final String trimmed = line.trim();
         boolean result = !trimmed.isEmpty()
@@ -127,33 +113,16 @@ public final class CascadeIndentationCheck extends AbstractFileSetCheck {
         return result;
     }
 
-    /**
-     * Tells whether the character is a closing bracket.
-     * @param chr Character
-     * @return True if it is one of ')', ']', '}'
-     */
     private static boolean isClosingBracket(final char chr) {
         return chr == ')' || chr == ']' || chr == '}';
     }
 
-    /**
-     * Tells whether a character is allowed inside a standalone
-     * closing-bracket line (closing bracket, comma, semicolon or
-     * whitespace).
-     * @param chr Character
-     * @return True if the character is allowed
-     */
     private static boolean isAllowedTail(final char chr) {
         return CascadeIndentationCheck.isClosingBracket(chr)
             || chr == ';' || chr == ','
             || Character.isWhitespace(chr);
     }
 
-    /**
-     * Checks if the line belongs to a comment block.
-     * @param line Input
-     * @return True if the line belongs to a comment block
-     */
     private static boolean inCommentBlock(final String line) {
         final String trimmed = line.trim();
         return !trimmed.isEmpty()
@@ -163,11 +132,6 @@ public final class CascadeIndentationCheck extends AbstractFileSetCheck {
                 );
     }
 
-    /**
-     * Calculates indentation of a line.
-     * @param line Input line
-     * @return Indentation of the given line
-     */
     private static int indentation(final String line) {
         int result = 0;
         for (int pos = 0; pos < line.length(); pos += 1) {

--- a/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -110,15 +110,6 @@ final class CheckstyleListener implements AuditListener {
         return Collections.unmodifiableList(this.started);
     }
 
-    /**
-     * Suppress {@code JavadocPackage} on {@code src/test/java} files when the
-     * parallel {@code src/main/java} package already declares
-     * {@code package-info.java}. See <a
-     * href="https://github.com/yegor256/qulice/issues/865">#865</a>.
-     * @param event The audit event being reported
-     * @param path Project-relative path of the file under audit
-     * @return TRUE if the event should be discarded
-     */
     private boolean skipJavadocPackage(final AuditEvent event, final String path) {
         final String marker = "src/test/java/";
         final String unix = path.replace(File.separatorChar, '/');

--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -163,11 +163,6 @@ public final class CheckstyleValidator implements ResourceValidator {
         return relevant;
     }
 
-    /**
-     * Load checkstyle configuration.
-     * @return The configuration just loaded
-     * @see #validate(Collection)
-     */
     private Configuration configuration() {
         final File cache =
             new File(this.env.tempdir(), "checkstyle/checkstyle.cache");
@@ -211,18 +206,6 @@ public final class CheckstyleValidator implements ResourceValidator {
         return config;
     }
 
-    /**
-     * The effective Java source level of the project under validation.
-     *
-     * <p>Reads {@code maven.compiler.release} first and then falls back to
-     * {@code maven.compiler.source}, accepting both the modern ({@code "8"},
-     * {@code "17"}) and the legacy ({@code "1.8"}) forms. When neither is
-     * known, a value below {@link #MINIMUM} is returned, so that checks
-     * requiring newer language features are disabled by default rather than
-     * risking a suggestion that breaks the build.
-     *
-     * @return The source level, e.g. {@code 8}, {@code 17}, {@code 21}
-     */
     private int level() {
         int level = CheckstyleValidator.parse(
             this.env.param("maven.compiler.release", "")
@@ -241,11 +224,6 @@ public final class CheckstyleValidator implements ResourceValidator {
         return result;
     }
 
-    /**
-     * Parse a Java version string into its major number.
-     * @param value Version, e.g. {@code "8"}, {@code "1.8"} or {@code "17"}
-     * @return The major version, or {@code -1} if it cannot be parsed
-     */
     private static int parse(final String value) {
         int result = -1;
         if (value != null) {
@@ -262,17 +240,6 @@ public final class CheckstyleValidator implements ResourceValidator {
         return result;
     }
 
-    /**
-     * Count the checks in a configuration tree.
-     *
-     * <p>A module without children is one check, while a module that holds
-     * others — {@code Checker} and {@code TreeWalker} — only carries them
-     * and is not a check itself. Suppression filters and holders are left
-     * out too, since they silence violations instead of finding them.</p>
-     *
-     * @param config Configuration to count in
-     * @return The number of checks configured
-     */
     private static int count(final Configuration config) {
         int total = 0;
         for (final Configuration child : config.getChildren()) {
@@ -286,12 +253,6 @@ public final class CheckstyleValidator implements ResourceValidator {
         return total;
     }
 
-    /**
-     * Remove, recursively and in place, the modules with the given names
-     * from a configuration tree.
-     * @param config Configuration to strip
-     * @param names Simple names of the modules to remove
-     */
     private static void strip(final Configuration config,
         final Set<String> names) {
         for (final Configuration child : config.getChildren()) {

--- a/src/main/java/com/qulice/checkstyle/ConfiguredChecks.java
+++ b/src/main/java/com/qulice/checkstyle/ConfiguredChecks.java
@@ -49,15 +49,6 @@ final class ConfiguredChecks {
         return this.names.value().stream().anyMatch(known -> known.contains(name));
     }
 
-    /**
-     * Read the names of the enabled checks from {@code checks.xml}.
-     *
-     * <p>The cache file plays no part here, but {@code checks.xml}
-     * demands the property, hence the empty value for it.
-     *
-     * @return Names of the checks, with and without the {@code Check} suffix
-     * @throws Exception If the configuration cannot be read
-     */
     private static Collection<String> load() throws Exception {
         final Properties props = new Properties();
         props.setProperty("cache.file", "");
@@ -70,11 +61,6 @@ final class ConfiguredChecks {
         );
     }
 
-    /**
-     * Names of this module and of all modules nested in it.
-     * @param config Configuration of a module
-     * @return Names of the modules, with and without the suffix
-     */
     private static Collection<String> modules(final Configuration config) {
         final Collection<String> found = new HashSet<>(0);
         final String name = config.getName();

--- a/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
@@ -50,12 +50,6 @@ public final class ConstantUsageCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Check that constant, declared as private field of class
-     * is used more than ones.
-     * @param ast Node which contains VARIABLE_DEF
-     * @param namenode Node which contains variable name
-     */
     private void checkField(final DetailAST ast, final DetailAST namenode) {
         final String name = namenode.getText();
         final DetailAST objblock = ast.getParent();
@@ -89,13 +83,6 @@ public final class ConstantUsageCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Parses the variable definition and increments the counter
-     * if name is found.
-     * @param variable DetailAST of variable definition
-     * @param name Name of constant we search for
-     * @return Zero if not found, 1 otherwise
-     */
     private int parseVarDef(final DetailAST variable, final String name) {
         int counter = 0;
         final DetailAST modifiers =
@@ -121,12 +108,6 @@ public final class ConstantUsageCheck extends AbstractCheck {
         return counter;
     }
 
-    /**
-     * Returns text representation of the specified node, including it's
-     * children.
-     * @param node Node, containing text
-     * @return Text representation of the node
-     */
     private String getText(final DetailAST node) {
         final String ret;
         if (node == null) {
@@ -150,48 +131,20 @@ public final class ConstantUsageCheck extends AbstractCheck {
         return ret;
     }
 
-    /**
-     * Returns <code>true</code> if specified node has parent node of type
-     * <code>OBJBLOCK</code>.
-     * @param node Node to check
-     * @return True if parent node is <code>OBJBLOCK</code>, else
-     *  returns <code>false</code>
-     */
     private static boolean isField(final DetailAST node) {
         return TokenTypes.OBJBLOCK == node.getParent().getType();
     }
 
-    /**
-     * Returns true if specified node has modifiers of type <code>FINAL</code>.
-     * @param node Node to check
-     * @return True if specified node contains modifiers of type
-     *  <code>FINAL</code>, else returns <code>false</code>
-     */
     private static boolean isFinal(final DetailAST node) {
         return node.findFirstToken(TokenTypes.MODIFIERS)
             .getChildCount(TokenTypes.FINAL) > 0;
     }
 
-    /**
-     * Returns true if specified node has modifiers of type
-     * <code>PRIVATE</code>.
-     * @param node Node to check
-     * @return True if specified node contains modifiers of type
-     *  <code>PRIVATE</code>, else returns <code>false</code>
-     */
     private static boolean isPrivate(final DetailAST node) {
         return node.findFirstToken(TokenTypes.MODIFIERS)
             .getChildCount(TokenTypes.LITERAL_PRIVATE) > 0;
     }
 
-    /**
-     * Parses the body of the definition (either method or inner class) and
-     * increments counter each time when it founds constant name.
-     * @param definition Tree node, containing definition
-     * @param name Constant name to search
-     * @param type Type of definition start
-     * @return Number of found constant usages
-     */
     private int parseDef(final DetailAST definition, final String name,
         final int type) {
         int counter = 0;
@@ -215,13 +168,6 @@ public final class ConstantUsageCheck extends AbstractCheck {
         return counter;
     }
 
-    /**
-     * Parses the annotation value pair and increments the counter
-     * if name is found.
-     * @param modifiers DetailAST of variable definition
-     * @param name Name of constant we search for
-     * @return Zero if not found, 1 otherwise
-     */
     private int parseAnnotation(final DetailAST modifiers, final String name) {
         int counter = 0;
         final DetailAST variable =

--- a/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
@@ -69,17 +69,6 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Is the constructor body a single delegating
-     * {@code this(...)} or {@code super(...)} call?
-     *
-     * <p>The body's {@code SLIST} consists of the delegate call node
-     * (a {@code CTOR_CALL} or {@code SUPER_CTOR_CALL}) followed by
-     * the closing {@code RCURLY}, with nothing else in between.
-     *
-     * @param body The {@code SLIST} of the constructor body
-     * @return True if the body delegates and does nothing else
-     */
     private static boolean isOnlyDelegate(final DetailAST body) {
         final DetailAST first = body.getFirstChild();
         final boolean delegate;
@@ -92,11 +81,6 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
         return delegate;
     }
 
-    /**
-     * Is this node a {@code this(...)} or {@code super(...)} call?
-     * @param node The node to inspect, may be {@code null}
-     * @return True if the node is a constructor delegate call
-     */
     private static boolean isDelegate(final DetailAST node) {
         final boolean delegate;
         if (node == null) {
@@ -108,12 +92,6 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
         return delegate;
     }
 
-    /**
-     * Reports every method call found anywhere in the given subtree,
-     * except those nested inside lambda bodies or anonymous class bodies,
-     * and except sanctioned defensive-copy idioms.
-     * @param node Root of the subtree to scan
-     */
     private void reportCalls(final DetailAST node) {
         for (DetailAST child = node.getFirstChild();
             child != null; child = child.getNextSibling()) {
@@ -132,16 +110,6 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Is this method call a defensive array-copy idiom?
-     *
-     * <p>Recognizes {@code Arrays.copyOf(...)} (static, any qualifier
-     * ending in {@code Arrays.copyOf}) and any zero-argument
-     * {@code <expr>.clone()} call.
-     *
-     * @param call A {@code METHOD_CALL} AST node
-     * @return True if the call is a sanctioned defensive copy
-     */
     private static boolean isDefensiveCopy(final DetailAST call) {
         final DetailAST dot = call.getFirstChild();
         final boolean defensive;
@@ -159,12 +127,6 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
         return defensive;
     }
 
-    /**
-     * Is this an {@code Arrays.copyOf(...)} call?
-     * @param dot The {@code DOT} node that is first child of {@code METHOD_CALL}
-     * @param method The {@code IDENT} that is the called method's name
-     * @return True if it matches the {@code Arrays.copyOf} idiom
-     */
     private static boolean isArraysCopyOf(
         final DetailAST dot, final DetailAST method
     ) {
@@ -174,12 +136,6 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
             && ConstructorsCodeFreeCheck.endsWith(qualifier, "Arrays");
     }
 
-    /**
-     * Is this a no-argument {@code <expr>.clone()} call?
-     * @param call The {@code METHOD_CALL} AST node
-     * @param method The {@code IDENT} that is the called method's name
-     * @return True if it matches the array-clone idiom
-     */
     private static boolean isArrayClone(
         final DetailAST call, final DetailAST method
     ) {
@@ -189,17 +145,6 @@ public final class ConstructorsCodeFreeCheck extends AbstractCheck {
             && elist.getFirstChild() == null;
     }
 
-    /**
-     * Does the qualifier expression end in the given identifier?
-     *
-     * <p>Handles a bare {@code IDENT} (e.g. {@code Arrays}) and a
-     * dotted chain (e.g. {@code java.util.Arrays}), where the final
-     * segment of the chain is the identifier we look for.
-     *
-     * @param node The qualifier AST node
-     * @param name The expected last identifier
-     * @return True if the qualifier's last segment matches
-     */
     private static boolean endsWith(final DetailAST node, final String name) {
         final boolean match;
         if (node.getType() == TokenTypes.IDENT) {

--- a/src/main/java/com/qulice/checkstyle/ConstructorsOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstructorsOrderCheck.java
@@ -58,11 +58,6 @@ public final class ConstructorsOrderCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks that every secondary constructor is declared before
-     * the primary one.
-     * @param obj Object block node
-     */
     private void checkOrder(final DetailAST obj) {
         boolean primary = false;
         for (final DetailAST ctor : ConstructorsOrderCheck.constructors(obj)) {
@@ -77,12 +72,6 @@ public final class ConstructorsOrderCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Collects all constructors declared directly in the given
-     * object block, in declaration order.
-     * @param obj Object block node
-     * @return Constructors
-     */
     private static List<DetailAST> constructors(final DetailAST obj) {
         final List<DetailAST> ctors = new ArrayList<>(0);
         for (DetailAST child = obj.getFirstChild();
@@ -94,12 +83,6 @@ public final class ConstructorsOrderCheck extends AbstractCheck {
         return ctors;
     }
 
-    /**
-     * Tells whether the given constructor delegates to another
-     * constructor via {@code this(...)}.
-     * @param ctor Constructor node
-     * @return True if delegating
-     */
     private static boolean delegates(final DetailAST ctor) {
         boolean delegates = false;
         final DetailAST body = ctor.findFirstToken(TokenTypes.SLIST);

--- a/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
+++ b/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
@@ -67,10 +67,6 @@ public final class CurlyBracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks params statement to satisfy the rule.
-     * @param node Tree node, containing containing array init statement
-     */
     private void checkParams(final DetailAST node) {
         final DetailAST closing = node.findFirstToken(TokenTypes.RCURLY);
         if (closing != null) {
@@ -78,12 +74,6 @@ public final class CurlyBracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks params statement to satisfy the rule.
-     * @param node Tree node, containing array init statement
-     * @param start First line
-     * @param end Final line
-     */
     private void checkLines(final DetailAST node, final int start,
         final int end) {
         if (start != end) {
@@ -98,12 +88,6 @@ public final class CurlyBracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks that all EXPR nodes satisfy the rule.
-     * @param exprs Iterable of EXPR nodes
-     * @param start First line of ARRAY_INIT node
-     * @param end Final line ARRAY_INIT node (corresponds to RCURLY)
-     */
     private void checkExpressions(final Iterable<DetailAST> exprs,
         final int start,
         final int end
@@ -121,12 +105,6 @@ public final class CurlyBracketsStructureCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Search for all children of given type.
-     * @param base Parent node to start from
-     * @param type Node type
-     * @return Iterable
-     */
     private static Iterable<DetailAST> findAllChildren(final DetailAST base,
         final int type) {
         final List<DetailAST> children = new ArrayList<>(base.getChildCount());

--- a/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/DiamondOperatorCheck.java
@@ -94,40 +94,20 @@ public final class DiamondOperatorCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks if diamond is not required.
-     * @param node Node
-     * @return True if not array
-     */
     private static boolean validUsage(final DetailAST node) {
         return DiamondOperatorCheck.isNotObjectBlock(node)
             && DiamondOperatorCheck.isNotArray(node)
             && !DiamondOperatorCheck.isInitUsingDiamond(node);
     }
 
-    /**
-     * Checks if node is not array.
-     * @param node Node
-     * @return True if not array
-     */
     private static boolean isNotArray(final DetailAST node) {
         return node.findFirstToken(TokenTypes.ARRAY_DECLARATOR) == null;
     }
 
-    /**
-     * Checks if node is object block.
-     * @param node Node
-     * @return True if not object block
-     */
     private static boolean isNotObjectBlock(final DetailAST node) {
         return node.getLastChild().getType() != TokenTypes.OBJBLOCK;
     }
 
-    /**
-     * Checks if node has initialization with diamond operator.
-     * @param node Node
-     * @return True if not object block
-     */
     private static boolean isInitUsingDiamond(final DetailAST node) {
         final DetailAST init = node.findFirstToken(TokenTypes.ELIST);
         boolean typed = false;
@@ -143,11 +123,6 @@ public final class DiamondOperatorCheck extends AbstractCheck {
         return typed;
     }
 
-    /**
-     * Checks if node has initialization with diamond operator.
-     * @param node Node
-     * @return True if not object block
-     */
     private static DetailAST secondChild(final DetailAST node) {
         DetailAST result = null;
         if (node != null) {
@@ -159,24 +134,12 @@ public final class DiamondOperatorCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Checks if node contains empty set of type parameters and
-     * comprises angle brackets only (<>).
-     * @param node Node of type arguments
-     * @return True if node contains angle brackets only
-     */
     private static boolean isDiamondOperatorUsed(final DetailAST node) {
         return node != null && node.getChildCount() == 2
             && node.getFirstChild().getType() == TokenTypes.GENERIC_START
             && node.getLastChild().getType() == TokenTypes.GENERIC_END;
     }
 
-    /**
-     * Returns the first child node of a specified type.
-     * @param node AST subtree to process
-     * @param type Type of token
-     * @return Child node of specified type OR NULL!
-     */
     private static DetailAST findFirstChildNodeOfType(
         final DetailAST node, final int type
     ) {

--- a/src/main/java/com/qulice/checkstyle/EmptyLineBeforeFirstMemberCheck.java
+++ b/src/main/java/com/qulice/checkstyle/EmptyLineBeforeFirstMemberCheck.java
@@ -72,10 +72,6 @@ public final class EmptyLineBeforeFirstMemberCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Check the body between curly braces of the given object block.
-     * @param block OBJBLOCK node whose body must be inspected
-     */
     private void visitBlock(final DetailAST block) {
         final DetailAST left = block.findFirstToken(TokenTypes.LCURLY);
         final DetailAST right = block.findFirstToken(TokenTypes.RCURLY);

--- a/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
@@ -112,14 +112,6 @@ public final class EmptyLinesCheck extends AbstractCheck {
         super.finishTree(root);
     }
 
-    /**
-     * If this is within a valid anonymous class, make sure that is still
-     * directly inside of a method of that anonymous inner class.
-     * Note: This implementation only checks one level deep, as nesting
-     * anonymous inner classes should never been done.
-     * @param line The line to check if it is within a method or not
-     * @return True if the line is directly inside of a method
-     */
     private boolean insideMethod(final int line) {
         return EmptyLinesCheck.linesBetweenBraces(
             line, this.methods::iterator, Integer.MIN_VALUE
@@ -128,13 +120,6 @@ public final class EmptyLinesCheck extends AbstractCheck {
         );
     }
 
-    /**
-     * Find number of lines between braces that contain a given line.
-     * @param line Line to check
-     * @param iterator Iterable of line ranges
-     * @param def Default value if line is not within ranges
-     * @return Number of lines between braces
-     */
     private static int linesBetweenBraces(final int line,
         final Iterable<LineRange> iterator, final int def) {
         return StreamSupport.stream(iterator.spliterator(), false)

--- a/src/main/java/com/qulice/checkstyle/ExtraSemicolonCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ExtraSemicolonCheck.java
@@ -68,10 +68,6 @@ public final class ExtraSemicolonCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Report every {@code SEMI} token that is a direct child of the node.
-     * @param node The parent node whose children are inspected
-     */
     private void reportSemis(final DetailAST node) {
         for (DetailAST child = node.getFirstChild(); child != null;
             child = child.getNextSibling()) {

--- a/src/main/java/com/qulice/checkstyle/IfThenThrowElseCheck.java
+++ b/src/main/java/com/qulice/checkstyle/IfThenThrowElseCheck.java
@@ -73,12 +73,6 @@ public final class IfThenThrowElseCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Locates the statement or block that forms the {@code then} branch
-     * of the given {@code if}.
-     * @param ast The {@code LITERAL_IF} node
-     * @return The first statement inside the {@code then} branch
-     */
     private static DetailAST thenBranch(final DetailAST ast) {
         final DetailAST rparen = ast.findFirstToken(TokenTypes.RPAREN);
         DetailAST result = null;
@@ -88,12 +82,6 @@ public final class IfThenThrowElseCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Tells whether control flow exits the given node through an
-     * unconditional {@code throw}.
-     * @param node The node to inspect
-     * @return True when the last statement is {@code throw}
-     */
     private static boolean alwaysThrows(final DetailAST node) {
         final boolean result;
         if (node == null) {
@@ -108,12 +96,6 @@ public final class IfThenThrowElseCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Checks whether the last meaningful statement inside a
-     * {@code SLIST} is a {@code throw}.
-     * @param slist The {@code SLIST} node
-     * @return True when the last statement is {@code throw}
-     */
     private static boolean endsWithThrow(final DetailAST slist) {
         DetailAST last = slist.getLastChild();
         while (last != null && last.getType() == TokenTypes.RCURLY) {

--- a/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
@@ -52,13 +52,6 @@ public final class ImportCohesionCheck extends AbstractFileSetCheck {
         }
     }
 
-    /**
-     * Perform check for empty lines and comments inside imports.
-     * @param first Line number where import occurred first
-     * @param last Line number where import occurred first
-     * @param lines All file line by line
-     * @return True if check is failed
-     */
     private boolean check(final int first, final int last,
         final FileText lines
     ) {

--- a/src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java
@@ -104,12 +104,6 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Report every non-compact paragraph tag inside the comment body.
-     * @param lines All lines of the source file
-     * @param start First body line of the comment
-     * @param end Last body line of the comment
-     */
     private void checkParagraphs(final String[] lines, final int start,
         final int end) {
         boolean pre = false;
@@ -131,11 +125,6 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Log a violation for a single Javadoc body line.
-     * @param pos Zero-based index of the line
-     * @param body Trimmed body of the line, without the leading asterisk
-     */
     private void report(final int pos, final String body) {
         if (body.endsWith("<p>")) {
             this.log(pos + 1, JavadocCompactParagraphCheck.MSG_OPEN);
@@ -145,11 +134,6 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Strip the leading asterisk and surrounding blanks from a Javadoc line.
-     * @param line Raw source line
-     * @return Trimmed body of the line, without the leading asterisk
-     */
     private static String body(final String line) {
         String trimmed = line.trim();
         if (trimmed.startsWith("*")) {
@@ -158,11 +142,6 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
         return trimmed;
     }
 
-    /**
-     * Net brace balance of a line (opening minus closing braces).
-     * @param body Trimmed body of the line
-     * @return Number of opening braces minus number of closing braces
-     */
     private static int braces(final String body) {
         int delta = 0;
         for (int pos = 0; pos < body.length(); pos += 1) {
@@ -176,12 +155,6 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
         return delta;
     }
 
-    /**
-     * Check if node has Javadoc.
-     * @param node Node to be checked for Javadoc
-     * @param start Line number where comment starts
-     * @return True when node has Javadoc
-     */
     private static boolean isNodeHavingJavadoc(final DetailAST node,
         final int start) {
         return start > JavadocCompactParagraphCheck.getLineNoOfPreviousNode(
@@ -189,11 +162,6 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
         );
     }
 
-    /**
-     * Returns line number of previous node.
-     * @param node Current node
-     * @return Line number of previous node
-     */
     private static int getLineNoOfPreviousNode(final DetailAST node) {
         int start = 0;
         final DetailAST previous = node.getPreviousSibling();
@@ -203,24 +171,12 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
         return start;
     }
 
-    /**
-     * Find Javadoc starting comment.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found starting comment or -1 otherwise
-     */
     private static int findCommentStart(final String[] lines, final int start) {
         return JavadocCompactParagraphCheck.findTrimmedTextUp(
             lines, start, "/**"
         );
     }
 
-    /**
-     * Find Javadoc ending comment.
-     * @param lines Array of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found ending comment, or -1 if it wasn't found
-     */
     private static int findCommentEnd(final String[] lines, final int start) {
         int found = -1;
         for (int pos = start - 1; pos >= 0; pos -= 1) {
@@ -233,13 +189,6 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Find a text in lines, by going up.
-     * @param lines Array of lines to check
-     * @param start Start searching from this line number
-     * @param text Text to find
-     * @return Line number with found text, or -1 if it wasn't found
-     */
     private static int findTrimmedTextUp(final String[] lines,
         final int start, final String text) {
         int found = -1;

--- a/src/main/java/com/qulice/checkstyle/JavadocEmptyLineBeforeTagCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocEmptyLineBeforeTagCheck.java
@@ -95,13 +95,6 @@ public final class JavadocEmptyLineBeforeTagCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Inspect the part of the Javadoc that lies between the opening
-     * and the first at-clause.
-     * @param lines All lines of the source file
-     * @param start First Javadoc content line (0-based)
-     * @param tag Line of the first at-clause (0-based)
-     */
     private void inspect(final String[] lines, final int start, final int tag) {
         int body = tag - 1;
         while (body >= start
@@ -132,21 +125,10 @@ public final class JavadocEmptyLineBeforeTagCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Check if Javadoc line is empty.
-     * @param line Javadoc line
-     * @return True when Javadoc line is empty
-     */
     private static boolean isJavadocLineEmpty(final String line) {
         return "*".equals(line.trim());
     }
 
-    /**
-     * Check if node has Javadoc.
-     * @param node Node to be checked for Javadoc
-     * @param start Line number where comment starts
-     * @return True when node has Javadoc
-     */
     private static boolean isNodeHavingJavadoc(final DetailAST node,
         final int start) {
         int previous = 0;
@@ -157,22 +139,10 @@ public final class JavadocEmptyLineBeforeTagCheck extends AbstractCheck {
         return start > previous;
     }
 
-    /**
-     * Find Javadoc starting comment.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found starting comment or -1 otherwise
-     */
     private static int findCommentStart(final String[] lines, final int start) {
         return JavadocEmptyLineBeforeTagCheck.findTrimmedTextUp(lines, start, "/**");
     }
 
-    /**
-     * Find Javadoc ending comment.
-     * @param lines Array of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found ending comment, or -1 if it wasn't found
-     */
     private static int findCommentEnd(final String[] lines, final int start) {
         int found = -1;
         for (int pos = start - 1; pos >= 0; pos -= 1) {
@@ -185,13 +155,6 @@ public final class JavadocEmptyLineBeforeTagCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Find the first at-clause line inside the Javadoc comment.
-     * @param lines All lines of the file
-     * @param start First Javadoc content line (0-based)
-     * @param end Last Javadoc content line (0-based)
-     * @return Line number of the first at-clause, or -1 if not found
-     */
     private static int findFirstTag(final String[] lines, final int start,
         final int end) {
         int found = -1;
@@ -205,13 +168,6 @@ public final class JavadocEmptyLineBeforeTagCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Find a text in lines, by going up.
-     * @param lines Array of lines to check
-     * @param start Start searching from this line number
-     * @param text Text to find
-     * @return Line number with found text, or -1 if it wasn't found
-     */
     private static int findTrimmedTextUp(final String[] lines,
         final int start, final String text) {
         int found = -1;

--- a/src/main/java/com/qulice/checkstyle/JavadocEmptyLineCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocEmptyLineCheck.java
@@ -92,31 +92,15 @@ public final class JavadocEmptyLineCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Check if Javadoc line is empty.
-     * @param line Javadoc line
-     * @return True when Javadoc line is empty
-     */
     private static boolean isJavadocLineEmpty(final String line) {
         return "*".equals(line.trim());
     }
 
-    /**
-     * Check if node has Javadoc.
-     * @param node Node to be checked for Javadoc
-     * @param start Line number where comment starts
-     * @return True when node has Javadoc
-     */
     private static boolean isNodeHavingJavadoc(final DetailAST node,
         final int start) {
         return start > getLineNoOfPreviousNode(node);
     }
 
-    /**
-     * Returns line number of previous node.
-     * @param node Current node
-     * @return Line number of previous node
-     */
     private static int getLineNoOfPreviousNode(final DetailAST node) {
         int start = 0;
         final DetailAST previous = node.getPreviousSibling();
@@ -126,22 +110,10 @@ public final class JavadocEmptyLineCheck extends AbstractCheck {
         return start;
     }
 
-    /**
-     * Find Javadoc starting comment.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found starting comment or -1 otherwise
-     */
     private static int findCommentStart(final String[] lines, final int start) {
         return JavadocEmptyLineCheck.findTrimmedTextUp(lines, start, "/**");
     }
 
-    /**
-     * Find Javadoc ending comment.
-     * @param lines Array of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found ending comment, or -1 if it wasn't found
-     */
     private static int findCommentEnd(final String[] lines, final int start) {
         int found = -1;
         for (int pos = start - 1; pos >= 0; pos -= 1) {
@@ -154,13 +126,6 @@ public final class JavadocEmptyLineCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Find a text in lines, by going up.
-     * @param lines Array of lines to check
-     * @param start Start searching from this line number
-     * @param text Text to find
-     * @return Line number with found text, or -1 if it wasn't found
-     */
     private static int findTrimmedTextUp(final String[] lines,
         final int start, final String text) {
         int found = -1;

--- a/src/main/java/com/qulice/checkstyle/JavadocFirstLineCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocFirstLineCheck.java
@@ -73,12 +73,6 @@ public final class JavadocFirstLineCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Find the line that opens the Javadoc right above a node.
-     * @param lines All lines of the file
-     * @param below Line index of the node (0-based)
-     * @return Line index (0-based) of the opening, or -1 if not found
-     */
     private static int findOpeningLine(final String[] lines, final int below) {
         int found = -1;
         for (int pos = below - 1; pos >= 0; pos -= 1) {
@@ -95,12 +89,6 @@ public final class JavadocFirstLineCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Check that the found Javadoc directly precedes the node.
-     * @param node Node being inspected
-     * @param start Line index (0-based) of the Javadoc opening
-     * @return True when no other declaration sits between
-     */
     private static boolean belongsToNode(final DetailAST node, final int start) {
         final DetailAST previous = node.getPreviousSibling();
         boolean owns = true;
@@ -110,22 +98,12 @@ public final class JavadocFirstLineCheck extends AbstractCheck {
         return owns;
     }
 
-    /**
-     * Check if a line has any text after the opening {@code /**}.
-     * @param line The opening line
-     * @return True when text sits on the same line
-     */
     private static boolean hasTextAfterOpening(final String line) {
         final String trimmed = line.trim();
         final String rest = trimmed.substring("/**".length()).trim();
         return !rest.isEmpty() && !"/".equals(rest);
     }
 
-    /**
-     * Check if the Javadoc closes on the same line.
-     * @param line The opening line
-     * @return True when the closing delimiter is on the same line
-     */
     private static boolean hasClosingOnSameLine(final String line) {
         return line.trim().endsWith("*/");
     }

--- a/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
@@ -60,11 +60,6 @@ public final class JavadocLocationCheck extends AbstractCheck {
         this.checkAnnotationAboveJavadoc(ast, lines);
     }
 
-    /**
-     * Check that there are no empty lines between the javadoc and the subject.
-     * @param ast The AST node of the subject
-     * @param lines The file lines
-     */
     private void checkEmptyLines(final DetailAST ast, final String... lines) {
         final int current = JavadocLocationCheck.javadocEnd(
             ast.getLineNo() - 1, lines
@@ -80,14 +75,6 @@ public final class JavadocLocationCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Walks upward from the given line and returns the line number of
-     * the closing javadoc marker if only blank lines separate it from
-     * the subject, otherwise zero.
-     * @param from Line just above the subject (one-based)
-     * @param lines The file lines
-     * @return Line number of the javadoc end, or zero if none
-     */
     private static int javadocEnd(final int from, final String... lines) {
         int current = from;
         int result = 0;
@@ -105,11 +92,6 @@ public final class JavadocLocationCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Check that no annotation is placed above the javadoc of the subject.
-     * @param ast The AST node of the subject
-     * @param lines The file lines
-     */
     private void checkAnnotationAboveJavadoc(
         final DetailAST ast, final String... lines
     ) {
@@ -128,12 +110,6 @@ public final class JavadocLocationCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Returns the line number of the first annotation under the given
-     * modifiers node, or {@link Integer#MAX_VALUE} when there is none.
-     * @param modifiers The MODIFIERS token
-     * @return Line number of the first annotation
-     */
     private static int firstAnnotationLine(final DetailAST modifiers) {
         int line = Integer.MAX_VALUE;
         DetailAST child = modifiers.getFirstChild();
@@ -147,15 +123,6 @@ public final class JavadocLocationCheck extends AbstractCheck {
         return line;
     }
 
-    /**
-     * Tells whether any javadoc opening or closing marker appears
-     * between the given lines (exclusive of the start, exclusive of the
-     * end).
-     * @param start Lower bound line, exclusive
-     * @param end Upper bound line, exclusive
-     * @param lines The file lines
-     * @return True when a javadoc marker is found in the range
-     */
     private static boolean javadocBetween(final int start, final int end,
         final String... lines) {
         boolean found = false;
@@ -169,13 +136,6 @@ public final class JavadocLocationCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Returns {@code TRUE} if a specified node is something that should have
-     * a Javadoc, which includes classes, interface, class methods, and
-     * class variables.
-     * @param node Node to check
-     * @return Is it a Javadoc-required entity?
-     */
     private static boolean isField(final DetailAST node) {
         boolean yes = true;
         if (TokenTypes.VARIABLE_DEF == node.getType()) {

--- a/src/main/java/com/qulice/checkstyle/JavadocNoIndentCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocNoIndentCheck.java
@@ -86,12 +86,6 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Check the body of the Javadoc for extra indentation.
-     * @param lines Code of the whole class
-     * @param start First line of the Javadoc body
-     * @param end Last line of the Javadoc body
-     */
     private void check(final String[] lines, final int start, final int end) {
         boolean pre = false;
         boolean tagged = false;
@@ -112,23 +106,11 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Is this line inside a region where indentation is preserved.
-     * @param pre Are we inside a {@code <pre>} block
-     * @param depth Current brace depth of an open {@code @snippet} block
-     * @param line The line being examined
-     * @return True when the line's indentation must be left alone
-     */
     private static boolean region(final boolean pre, final int depth,
         final String line) {
         return pre || depth > 0 || line.contains("{@snippet");
     }
 
-    /**
-     * The text that follows the leading asterisk of a Javadoc line.
-     * @param line The Javadoc line
-     * @return Everything after the first asterisk, or empty if there is none
-     */
     private static String afterAsterisk(final String line) {
         final int star = line.indexOf('*');
         final String result;
@@ -140,11 +122,6 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Does the body start with more than one space before its first word.
-     * @param body The text after the leading asterisk
-     * @return True when the body is over-indented
-     */
     private static boolean overIndented(final String body) {
         int spaces = 0;
         while (spaces < body.length() && body.charAt(spaces) == ' ') {
@@ -153,12 +130,6 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         return spaces > 1 && spaces < body.length();
     }
 
-    /**
-     * Compute the {@code <pre>} flag for the next line.
-     * @param pre Whether the current line is inside a {@code <pre>} block
-     * @param line The current line
-     * @return Whether the next line is inside a {@code <pre>} block
-     */
     private static boolean nextPre(final boolean pre, final String line) {
         final String lower = line.toLowerCase(Locale.ENGLISH);
         final boolean result;
@@ -170,12 +141,6 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Compute the {@code @snippet} brace depth after this line.
-     * @param depth The brace depth before this line
-     * @param line The current line
-     * @return The brace depth after this line
-     */
     private static int nextDepth(final int depth, final String line) {
         final int result;
         if (depth > 0) {
@@ -193,11 +158,6 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Net number of opening minus closing braces in the text.
-     * @param text The text to scan
-     * @return The brace balance
-     */
     private static int braces(final String text) {
         int delta = 0;
         for (int pos = 0; pos < text.length(); pos += 1) {
@@ -211,22 +171,11 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         return delta;
     }
 
-    /**
-     * Check if node has Javadoc.
-     * @param node Node to be checked for Javadoc
-     * @param start Line number where comment starts
-     * @return True when node has Javadoc
-     */
     private static boolean isNodeHavingJavadoc(final DetailAST node,
         final int start) {
         return start > JavadocNoIndentCheck.getLineNoOfPreviousNode(node);
     }
 
-    /**
-     * Returns line number of previous node.
-     * @param node Current node
-     * @return Line number of previous node
-     */
     private static int getLineNoOfPreviousNode(final DetailAST node) {
         int start = 0;
         final DetailAST previous = node.getPreviousSibling();
@@ -236,22 +185,10 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         return start;
     }
 
-    /**
-     * Find Javadoc starting comment.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found starting comment or -1 otherwise
-     */
     private static int findCommentStart(final String[] lines, final int start) {
         return JavadocNoIndentCheck.findTrimmedTextUp(lines, start, "/**");
     }
 
-    /**
-     * Find Javadoc ending comment.
-     * @param lines Array of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found ending comment, or -1 if it wasn't found
-     */
     private static int findCommentEnd(final String[] lines, final int start) {
         int found = -1;
         for (int pos = start - 1; pos >= 0; pos -= 1) {
@@ -264,13 +201,6 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Find a text in lines, by going up.
-     * @param lines Array of lines to check
-     * @param start Start searching from this line number
-     * @param text Text to find
-     * @return Line number with found text, or -1 if it wasn't found
-     */
     private static int findTrimmedTextUp(final String[] lines,
         final int start, final String text) {
         int found = -1;

--- a/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -94,11 +94,6 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Returns the param tags in a javadoc comment.
-     * @param comment The Javadoc comment
-     * @return The param tags found
-     */
     private static List<JavadocTag> getMethodTags(final TextBlock comment) {
         final String[] lines = comment.getText();
         final List<JavadocTag> tags = new ArrayList<>(0);
@@ -144,13 +139,6 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
         return tags;
     }
 
-    /**
-     * Calculates column number using Javadoc tag matcher.
-     * @param matcher Found javadoc tag matcher
-     * @param line Line number of Javadoc tag in comment
-     * @param start Column number of Javadoc comment beginning
-     * @return Column number
-     */
     private static int calculateTagColumn(
         final Matcher matcher, final int line, final int start
     ) {
@@ -161,15 +149,6 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
         return col;
     }
 
-    /**
-     * Gets multiline Javadoc tags with arguments.
-     * @param matcher Javadoc tag Matcher
-     * @param column Column number of Javadoc tag
-     * @param lines Comment text lines
-     * @param index Line number that contains the javadoc tag
-     * @param line Javadoc tag line number in file
-     * @return Javadoc tags with arguments
-     */
     private static List<JavadocTag> getMultilineArgTags(
         final Matcher matcher, final int column, final String[] lines,
         final int index, final int line) {
@@ -194,12 +173,6 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
         return tags;
     }
 
-    /**
-     * Checks method parameters order to comply with what is defined in method
-     * javadoc.
-     * @param ast The method node
-     * @param doc Javadoc text block
-     */
     private void checkParameters(final DetailAST ast, final TextBlock doc) {
         final List<JavadocTag> tags = getMethodTags(doc);
         final Arguments args = new Arguments(ast);

--- a/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -102,13 +102,6 @@ public final class JavadocTagsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Find a text in lines, by going up.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @param text Text to find
-     * @return Line number with found text, or -1 if it wasn't found
-     */
     private static int findTrimmedTextUp(
         final String[] lines,
         final int start,
@@ -124,34 +117,14 @@ public final class JavadocTagsCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Find javadoc starting comment.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found starting comment or -1 otherwise
-     */
     private static int findCommentStart(final String[] lines, final int start) {
         return JavadocTagsCheck.findTrimmedTextUp(lines, start, "/**");
     }
 
-    /**
-     * Find javadoc ending comment.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found ending comment, or -1 if it wasn't found
-     */
     private static int findCommentEnd(final String[] lines, final int start) {
         return JavadocTagsCheck.findTrimmedTextUp(lines, start, "*/");
     }
 
-    /**
-     * Check if the tag text matches the format from pattern.
-     * @param lines List of all lines
-     * @param start Line number where AST starts
-     * @param cstart Line number where comment starts
-     * @param cend Line number where comment ends
-     * @param tag Name of the tag
-     */
     private void findProhibited(
         final String[] lines,
         final int start,
@@ -170,14 +143,6 @@ public final class JavadocTagsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Find given tag in comment lines.
-     * @param lines Lines to search for the tag
-     * @param start Starting line number
-     * @param end Ending line number
-     * @param tag Name of the tag to look for
-     * @return Line number with found tag or -1 otherwise
-     */
     private List<Integer> findTagLineNum(
         final String[] lines,
         final int start,

--- a/src/main/java/com/qulice/checkstyle/JavadocTagsDotCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocTagsDotCheck.java
@@ -82,12 +82,6 @@ public final class JavadocTagsDotCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Inspect Javadoc comment and report tags that end with a dot.
-     * @param lines All lines of the file
-     * @param cstart Line index (0-based) where the comment opens
-     * @param cend Line index (0-based) where the comment closes
-     */
     private void inspect(final String[] lines, final int cstart, final int cend) {
         int tag = -1;
         for (int pos = cstart + 1; pos <= cend; pos += 1) {
@@ -104,12 +98,6 @@ public final class JavadocTagsDotCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Verify that the last non-empty line of a tag does not end with a dot.
-     * @param lines All lines of the file
-     * @param from Line index (0-based) of the tag opening
-     * @param until Line index (0-based) of the last line that belongs to the tag
-     */
     private void verify(final String[] lines, final int from, final int until) {
         for (int pos = until; pos >= from; pos -= 1) {
             final String content = JavadocTagsDotCheck.stripMarker(lines[pos]);
@@ -122,12 +110,6 @@ public final class JavadocTagsDotCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Check whether the trimmed line starts a {@code @param} or
-     * {@code @return} tag.
-     * @param trimmed Trimmed line content
-     * @return True when the line opens one of the watched tags
-     */
     private static boolean isParamOrReturn(final String trimmed) {
         final String tag;
         if (trimmed.startsWith("* @")) {
@@ -140,11 +122,6 @@ public final class JavadocTagsDotCheck extends AbstractCheck {
             || "return".equals(tag);
     }
 
-    /**
-     * Strip the leading {@code *} and surrounding whitespace from a line.
-     * @param line A raw line of the file
-     * @return Content without the Javadoc asterisk marker
-     */
     private static String stripMarker(final String line) {
         String result = line.trim();
         if (result.startsWith("*")) {
@@ -153,13 +130,6 @@ public final class JavadocTagsDotCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Find a line with given text by going up from a position.
-     * @param lines All lines of the file
-     * @param start Position (0-based) to start searching from
-     * @param text Text to find (compared against the trimmed line)
-     * @return Line index (0-based) where the text was found, or -1 otherwise
-     */
     private static int findTrimmedTextUp(
         final String[] lines,
         final int start,

--- a/src/main/java/com/qulice/checkstyle/JavadocThrowsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocThrowsCheck.java
@@ -110,12 +110,6 @@ public final class JavadocThrowsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Collect simple names of the exceptions declared in the
-     * {@code throws} clause of a method or constructor.
-     * @param ast Method/constructor definition node
-     * @return Simple names of declared checked exceptions
-     */
     private static Set<String> declared(final DetailAST ast) {
         final Set<String> names = new HashSet<>(0);
         final DetailAST clause = ast.findFirstToken(TokenTypes.LITERAL_THROWS);
@@ -133,12 +127,6 @@ public final class JavadocThrowsCheck extends AbstractCheck {
         return names;
     }
 
-    /**
-     * Extract the simple name from a possibly qualified type reference
-     * as written in javadoc text.
-     * @param text Full textual type reference
-     * @return Simple name (last dot-separated segment)
-     */
     private static String simple(final String text) {
         final int dot = text.lastIndexOf('.');
         final String result;
@@ -150,12 +138,6 @@ public final class JavadocThrowsCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Walk down a DOT-chained name and return the rightmost identifier
-     * text (i.e. the simple name of a qualified reference in the AST).
-     * @param dot AST node of type {@code DOT}
-     * @return Rightmost identifier's text
-     */
     private static String rightmost(final DetailAST dot) {
         DetailAST right = dot.getLastChild();
         while (right.getType() == TokenTypes.DOT) {

--- a/src/main/java/com/qulice/checkstyle/JnaBinding.java
+++ b/src/main/java/com/qulice/checkstyle/JnaBinding.java
@@ -68,22 +68,11 @@ final class JnaBinding {
         return answer;
     }
 
-    /**
-     * Does this type declare JNA's interface as its supertype?
-     * @param type The CLASS_DEF or INTERFACE_DEF node
-     * @return TRUE if it does
-     */
     private static boolean mapped(final DetailAST type) {
         return JnaBinding.declares(type, TokenTypes.EXTENDS_CLAUSE)
             || JnaBinding.declares(type, TokenTypes.IMPLEMENTS_CLAUSE);
     }
 
-    /**
-     * Does this clause of the type name JNA's interface?
-     * @param type The CLASS_DEF or INTERFACE_DEF node
-     * @param clause The token of the clause to look into
-     * @return TRUE if it does
-     */
     private static boolean declares(final DetailAST type, final int clause) {
         final DetailAST names = type.findFirstToken(clause);
         final boolean answer;
@@ -96,11 +85,6 @@ final class JnaBinding {
         return answer;
     }
 
-    /**
-     * Is this name the one of a JNA interface?
-     * @param name The IDENT or DOT node of a supertype
-     * @return TRUE if it is
-     */
     private static boolean library(final DetailAST name) {
         final String text = FullIdent.createFullIdent(name).getText();
         return JnaBinding.LIBRARIES.stream().anyMatch(
@@ -110,12 +94,6 @@ final class JnaBinding {
         );
     }
 
-    /**
-     * Does the file that holds this node import this interface?
-     * @param node The node to start the walk from
-     * @param known Canonical name of the interface
-     * @return TRUE if it does
-     */
     private static boolean imported(final DetailAST node, final String known) {
         DetailAST root = node;
         while (root.getParent() != null) {
@@ -126,12 +104,6 @@ final class JnaBinding {
         );
     }
 
-    /**
-     * Does this node import this interface?
-     * @param node The node of a top-level declaration
-     * @param known Canonical name of the interface
-     * @return TRUE if it does
-     */
     private static boolean importing(final DetailAST node, final String known) {
         return node.getType() == TokenTypes.IMPORT
             && JnaBinding.brings(
@@ -139,31 +111,15 @@ final class JnaBinding {
             );
     }
 
-    /**
-     * Does this imported name bring this interface in?
-     * @param text The name of the import
-     * @param known Canonical name of the interface
-     * @return TRUE if it does
-     */
     private static boolean brings(final String text, final String known) {
         return known.equals(text)
             || String.format("%s.*", JnaBinding.pack(known)).equals(text);
     }
 
-    /**
-     * Simple name of this canonical name.
-     * @param known Canonical name of an interface
-     * @return The name without its package
-     */
     private static String simple(final String known) {
         return known.substring(known.lastIndexOf('.') + 1);
     }
 
-    /**
-     * Package of this canonical name.
-     * @param known Canonical name of an interface
-     * @return The name without its last part
-     */
     private static String pack(final String known) {
         return known.substring(0, known.lastIndexOf('.'));
     }

--- a/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
@@ -64,12 +64,6 @@ public final class MethodBodyCommentsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Replace with empty strings the lines that belong to the body of any
-     * anonymous class found anywhere in the given subtree.
-     * @param node Root of the subtree to scan
-     * @param lines Lines to be modified in place
-     */
     private void maskAnonymous(final DetailAST node, final String... lines) {
         for (DetailAST child = node.getFirstChild(); child != null;
             child = child.getNextSibling()) {
@@ -89,12 +83,6 @@ public final class MethodBodyCommentsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks method body for comments.
-     * @param lines Array of lines, containing code to check
-     * @param start Start line of the method body
-     * @param end End line of the method body
-     */
     private void checkMethod(final String[] lines, final int start,
         final int end) {
         final boolean oneliner = start == end - 1;
@@ -110,19 +98,6 @@ public final class MethodBodyCommentsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Is the comment on the given line the only line inside its
-     * immediately enclosing braces?
-     *
-     * <p>A comment sitting alone between an opening and a closing brace
-     * documents an otherwise empty block. Some Checkstyle modules, such
-     * as {@code EmptyCatchBlock}, require exactly such a comment, so it
-     * must not be reported as a prohibited in-body comment.
-     *
-     * @param lines All lines of the file being checked
-     * @param pos Zero-based index of the comment line
-     * @return TRUE if the comment is alone between its enclosing braces
-     */
     private static boolean alone(final String[] lines, final int pos) {
         return pos > 0 && pos + 1 < lines.length
             && lines[pos - 1].trim().endsWith("{")

--- a/src/main/java/com/qulice/checkstyle/MethodDeclarationLengthCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodDeclarationLengthCheck.java
@@ -84,11 +84,6 @@ public final class MethodDeclarationLengthCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks whether the joined declaration fits on one line.
-     * @param start First non-annotation token of the declaration
-     * @param end Token that terminates the declaration (SLIST or SEMI)
-     */
     private void verify(final DetailAST start, final DetailAST end) {
         final String[] lines = this.getLines();
         final int first = start.getLineNo();
@@ -111,12 +106,6 @@ public final class MethodDeclarationLengthCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Returns the first child of the method/constructor that is not an
-     * annotation (i.e., the first keyword or type of the signature).
-     * @param def METHOD_DEF or CTOR_DEF node
-     * @return First non-annotation child token, or null if absent
-     */
     private static DetailAST head(final DetailAST def) {
         final DetailAST modifiers = def.findFirstToken(TokenTypes.MODIFIERS);
         DetailAST child = modifiers.getFirstChild();
@@ -136,12 +125,6 @@ public final class MethodDeclarationLengthCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Returns the token that closes the declaration: the opening brace
-     * of the body, or the terminating semicolon for abstract methods.
-     * @param def METHOD_DEF or CTOR_DEF node
-     * @return SLIST or SEMI child, or null if neither is present
-     */
     private static DetailAST tail(final DetailAST def) {
         DetailAST end = def.findFirstToken(TokenTypes.SLIST);
         if (end == null) {

--- a/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
@@ -55,10 +55,6 @@ public final class MethodsOrderCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks class definition to satisfy the rule.
-     * @param node Tree node, containing class definition (CLASS_DEF)
-     */
     private void checkClass(final DetailAST node) {
         final DetailAST obj = node.findFirstToken(TokenTypes.OBJBLOCK);
         if (obj != null) {
@@ -70,10 +66,6 @@ public final class MethodsOrderCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks order of methods.
-     * @param methods Nodes representing class methods
-     */
     private void checkOrder(final Iterable<DetailAST> methods) {
         MethodsOrderCheck.Modifiers prev = MethodsOrderCheck.Modifiers.PUB;
         for (final DetailAST method : methods) {
@@ -90,11 +82,6 @@ public final class MethodsOrderCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Get method modifier as enum {@code Modifiers}.
-     * @param method DetailAST of method
-     * @return Element of {@code Modifiers} enum
-     */
     private static MethodsOrderCheck.Modifiers getModifierType(
         final DetailAST method
     ) {
@@ -125,12 +112,6 @@ public final class MethodsOrderCheck extends AbstractCheck {
         return mod;
     }
 
-    /**
-     * Search for all children of given type.
-     * @param base Parent node to start from
-     * @param type Node type
-     * @return Iterable
-     */
     private static Iterable<DetailAST> findAllChildren(final DetailAST base,
         final int type) {
         final List<DetailAST> children = new ArrayList<>(base.getChildCount());
@@ -144,11 +125,6 @@ public final class MethodsOrderCheck extends AbstractCheck {
         return children;
     }
 
-    /**
-     * Get Modifiers enum constant by TokenType id.
-     * @param type TokenType
-     * @return Modifiers constant
-     */
     private static MethodsOrderCheck.Modifiers getByType(final int type) {
         return MethodsOrderCheck.Modifiers.mdos.get(type);
     }

--- a/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
@@ -77,12 +77,6 @@ public final class MultilineJavadocTagsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks method's Java Doc for satisfy indentation rules.
-     * @param lines Code of the whole class
-     * @param start Start line of the Java Doc
-     * @param end End line of the Java Doc
-     */
     @SuppressWarnings("PMD.InefficientEmptyStringCheck")
     private void checkJavaDoc(final String[] lines, final int start,
         final int end) {
@@ -111,12 +105,6 @@ public final class MultilineJavadocTagsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Find javadoc starting comment.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found starting comment or -1 otherwise
-     */
     private static int findCommentStart(final String[] lines, final int start) {
         return Math.max(
             MultilineJavadocTagsCheck.findTrimmedTextUp(lines, start, "/**"),
@@ -124,23 +112,10 @@ public final class MultilineJavadocTagsCheck extends AbstractCheck {
         );
     }
 
-    /**
-     * Find javadoc ending comment.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @return Line number with found ending comment, or -1 if it wasn't found
-     */
     private static int findCommentEnd(final String[] lines, final int start) {
         return MultilineJavadocTagsCheck.findTrimmedTextUp(lines, start, "*/");
     }
 
-    /**
-     * Find a text in lines, by going up.
-     * @param lines List of lines to check
-     * @param start Start searching from this line number
-     * @param text Text to find
-     * @return Line number with found text, or -1 if it wasn't found
-     */
     private static int findTrimmedTextUp(final String[] lines,
         final int start, final String text) {
         int found = -1;

--- a/src/main/java/com/qulice/checkstyle/NoJavadocForPrivateMethodsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/NoJavadocForPrivateMethodsCheck.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Checks that there is no Javadoc for private methods, both static
+ * and non-static ones.
+ *
+ * <p>A private method is an implementation detail of its own class and
+ * has no users outside of it. Its name, the names of its parameters and
+ * its body say everything a reader needs, while a Javadoc block above it
+ * only repeats them and then rots, staying behind after the method is
+ * renamed or its contract changes.
+ *
+ * <p>Private constructors are not affected, since a constructor is not
+ * a method and its Javadoc often carries the only explanation of why
+ * the class must not be instantiated.
+ *
+ * @since 0.73.4
+ */
+public final class NoJavadocForPrivateMethodsCheck extends AbstractCheck {
+
+    /**
+     * Default constructor.
+     */
+    public NoJavadocForPrivateMethodsCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {TokenTypes.METHOD_DEF};
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void visitToken(final DetailAST ast) {
+        final boolean prv = ast.findFirstToken(TokenTypes.MODIFIERS)
+            .findFirstToken(TokenTypes.LITERAL_PRIVATE) != null;
+        if (prv && this.getFileContents().getJavadocBefore(ast.getLineNo()) != null) {
+            final DetailAST name = ast.findFirstToken(TokenTypes.IDENT);
+            this.log(
+                name,
+                String.format(
+                    "Private method \"%s\" must not have Javadoc",
+                    name.getText()
+                )
+            );
+        }
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -85,13 +85,6 @@ public final class NonStaticMethodCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Check that non static class method refer {@code this}. Methods that
-     * are {@code native}, {@code abstract} or annotated with {@code @Override}
-     * are excluded.  Additionally, if the method only throws an exception, it
-     * too is excluded.
-     * @param method DetailAST of method
-     */
     private void checkClassMethod(final DetailAST method) {
         final DetailAST modifiers = method
             .findFirstToken(TokenTypes.MODIFIERS);
@@ -116,11 +109,6 @@ public final class NonStaticMethodCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Determines whether a method is {@code abstract} or {@code native}.
-     * @param method Method to check
-     * @return True if method is abstract or native
-     */
     private static boolean isInAbstractOrNativeMethod(final DetailAST method) {
         final BranchContains checker = new BranchContains(
             method.findFirstToken(TokenTypes.MODIFIERS)
@@ -129,12 +117,6 @@ public final class NonStaticMethodCheck extends AbstractCheck {
             || checker.check(TokenTypes.LITERAL_NATIVE);
     }
 
-    /**
-     * Determines the number semicolons in a method excluding those in
-     * comments.
-     * @param method Method to count
-     * @return The number of semicolons in the method as an int
-     */
     @SuppressWarnings("deprecation")
     private int countSemiColons(final DetailAST method) {
         final DetailAST openingbrace = method.findFirstToken(TokenTypes.SLIST);

--- a/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
@@ -46,16 +46,6 @@ public final class ParameterNumberCheck
         }
     }
 
-    /**
-     * May this node keep its long list of parameters?
-     *
-     * <p>A constructor may, when it takes no more parameters than the
-     * number of attributes of its class. A method may, when it is
-     * private or when it belongs to a JNA binding.</p>
-     *
-     * @param ast The CTOR_DEF or METHOD_DEF node
-     * @return TRUE if the check has to stay silent about it
-     */
     private static boolean tolerated(final DetailAST ast) {
         final boolean answer;
         if (ast.getType() == TokenTypes.CTOR_DEF) {
@@ -69,26 +59,11 @@ public final class ParameterNumberCheck
         return answer;
     }
 
-    /**
-     * How many parameters does this constructor take?
-     * @param ctor The CTOR_DEF node
-     * @return Number of parameters
-     */
     private static int parameters(final DetailAST ctor) {
         return ctor.findFirstToken(TokenTypes.PARAMETERS)
             .getChildCount(TokenTypes.PARAMETER_DEF);
     }
 
-    /**
-     * How many attributes does the class of this constructor have?
-     *
-     * <p>Static fields stay out of the count, since they belong to the
-     * class and not to its objects. Components of a record count in, as
-     * they are the attributes the canonical constructor has to take.</p>
-     *
-     * @param ctor The CTOR_DEF node
-     * @return Number of attributes
-     */
     private static long attributes(final DetailAST ctor) {
         final DetailAST block = ctor.getParent();
         return ParameterNumberCheck.components(block.getParent())
@@ -99,11 +74,6 @@ public final class ParameterNumberCheck
             ).count();
     }
 
-    /**
-     * How many components does this type declare, if it is a record?
-     * @param type The node of the type declaration
-     * @return Number of record components
-     */
     private static int components(final DetailAST type) {
         final DetailAST components = type.findFirstToken(TokenTypes.RECORD_COMPONENTS);
         final int count;

--- a/src/main/java/com/qulice/checkstyle/ProhibitFieldsInTestClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitFieldsInTestClassesCheck.java
@@ -90,14 +90,6 @@ public final class ProhibitFieldsInTestClassesCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Is this VARIABLE_DEF an instance field of the top-level type
-     * that is neither static nor annotated? Fields of nested or
-     * anonymous types are not considered, because they belong to a
-     * helper rather than to the test class itself.
-     * @param node Variable definition node
-     * @return True if the field should be flagged
-     */
     private static boolean isUnannotatedInstanceField(final DetailAST node) {
         boolean flag = false;
         final DetailAST parent = node.getParent();
@@ -110,25 +102,12 @@ public final class ProhibitFieldsInTestClassesCheck extends AbstractCheck {
         return flag;
     }
 
-    /**
-     * Is this AST node a type declaration that sits at the top level
-     * of the compilation unit (i.e. its parent is not an
-     * {@code OBJBLOCK} of an enclosing type, and it is not the body
-     * of an anonymous inner class spawned by {@code LITERAL_NEW})?
-     * @param type Candidate type declaration node
-     * @return True if it is the file's top-level type
-     */
     private static boolean isTopLevelType(final DetailAST type) {
         return type != null
             && ProhibitFieldsInTestClassesCheck.isTypeDef(type)
             && ProhibitFieldsInTestClassesCheck.hasTopLevelParent(type);
     }
 
-    /**
-     * Is this AST node a class, enum, record, or interface declaration?
-     * @param type Candidate node
-     * @return True if it is one of the four type-defining tokens
-     */
     private static boolean isTypeDef(final DetailAST type) {
         final int kind = type.getType();
         return kind == TokenTypes.CLASS_DEF
@@ -137,14 +116,6 @@ public final class ProhibitFieldsInTestClassesCheck extends AbstractCheck {
             || kind == TokenTypes.INTERFACE_DEF;
     }
 
-    /**
-     * Is the parent of this type node such that the type is at the top
-     * level of the compilation unit, i.e. not nested inside an
-     * enclosing type's {@code OBJBLOCK} and not the body of an
-     * anonymous class created via {@code LITERAL_NEW}?
-     * @param type Type declaration node
-     * @return True if the parent indicates a top-level position
-     */
     private static boolean hasTopLevelParent(final DetailAST type) {
         final DetailAST parent = type.getParent();
         return parent != null

--- a/src/main/java/com/qulice/checkstyle/ProhibitLineSeparatorInStringsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitLineSeparatorInStringsCheck.java
@@ -72,13 +72,6 @@ public final class ProhibitLineSeparatorInStringsCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks if the literal source text contains an unescaped
-     * {@code \n} or {@code \r} escape sequence.
-     * @param text Raw source text of the string literal, including quotes
-     *  (e.g. {@code "\n"} or {@code "a\\nb"})
-     * @return True if the literal embeds a line separator escape
-     */
     private static boolean hasLineSeparator(final String text) {
         final Matcher matcher =
             ProhibitLineSeparatorInStringsCheck.ESCAPE.matcher(text);

--- a/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
@@ -101,11 +101,6 @@ public final class ProhibitNonFinalClassesCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Get qualified class name from given class Ast.
-     * @param classast Class to get qualified class name
-     * @return Qualified class name of a class
-     */
     private String qualifiedClassName(final DetailAST classast) {
         String outer = null;
         if (!this.classes.isEmpty()) {
@@ -118,15 +113,6 @@ public final class ProhibitNonFinalClassesCheck extends AbstractCheck {
         );
     }
 
-    /**
-     * Calculate qualified class name(package + class name) laying inside given
-     * outer class.
-     * @param pack Package name, empty string on default package
-     * @param outer Qualified name(package + class) of outer
-     *  class, null if doesn't exist
-     * @param name Class name
-     * @return Qualified class name(package + class name)
-     */
     private static String getQualifiedClassName(
         final String pack,
         final String outer,
@@ -158,11 +144,6 @@ public final class ProhibitNonFinalClassesCheck extends AbstractCheck {
         return qualified;
     }
 
-    /**
-     * Get class name from qualified name.
-     * @param qualified Qualified class name
-     * @return Class Name
-     */
     private static String getClassNameFromQualifiedName(
         final String qualified
     ) {

--- a/src/main/java/com/qulice/checkstyle/ProhibitStaticNestedClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitStaticNestedClassesCheck.java
@@ -82,11 +82,6 @@ public final class ProhibitStaticNestedClassesCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Is this CLASS_DEF a static class nested inside another type?
-     * @param ast Class definition node
-     * @return True if the class is nested and declared as static
-     */
     private static boolean isStaticNestedClass(final DetailAST ast) {
         final DetailAST parent = ast.getParent();
         return parent != null && parent.getType() == TokenTypes.OBJBLOCK

--- a/src/main/java/com/qulice/checkstyle/ProhibitTestExpectedCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitTestExpectedCheck.java
@@ -57,11 +57,6 @@ public final class ProhibitTestExpectedCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Is this a JUnit {@code @Test} annotation (short or fully-qualified)?
-     * @param ast The ANNOTATION node
-     * @return True if its simple name is {@code Test}
-     */
     private static boolean isTest(final DetailAST ast) {
         final DetailAST ident = ast.findFirstToken(TokenTypes.IDENT);
         final boolean match;
@@ -76,11 +71,6 @@ public final class ProhibitTestExpectedCheck extends AbstractCheck {
         return match;
     }
 
-    /**
-     * Does this annotation have an {@code expected} member?
-     * @param ast The ANNOTATION node
-     * @return True if an {@code expected = ...} pair is present
-     */
     private static boolean hasExpected(final DetailAST ast) {
         boolean found = false;
         DetailAST child = ast.getFirstChild();

--- a/src/main/java/com/qulice/checkstyle/ProhibitTestMethodNameCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitTestMethodNameCheck.java
@@ -68,11 +68,6 @@ public final class ProhibitTestMethodNameCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Does this method declaration carry a JUnit {@code @Test} annotation?
-     * @param ast The METHOD_DEF node
-     * @return True if annotated with {@code @Test}
-     */
     private static boolean isTest(final DetailAST ast) {
         final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
         boolean found = false;
@@ -90,12 +85,6 @@ public final class ProhibitTestMethodNameCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Is this ANNOTATION node the JUnit {@code @Test} annotation
-     * (either the short or fully-qualified form)?
-     * @param ast The ANNOTATION node
-     * @return True if its simple name is {@code Test}
-     */
     private static boolean isTestAnnotation(final DetailAST ast) {
         final DetailAST ident = ast.findFirstToken(TokenTypes.IDENT);
         final boolean match;
@@ -110,24 +99,11 @@ public final class ProhibitTestMethodNameCheck extends AbstractCheck {
         return match;
     }
 
-    /**
-     * Does the name begin with a forbidden prefix?
-     * @param name The method name
-     * @return True if it starts with {@code should} or with {@code test}
-     *  but not with {@code tests}
-     */
     private static boolean startsWithForbidden(final String name) {
         return startsWithWord(name, "should")
             || startsWithWord(name, "test") && !startsWithWord(name, "tests");
     }
 
-    /**
-     * Does {@code name} start with {@code prefix} as a whole lowercase
-     * word (either equal, or followed by an uppercase/underscore boundary)?
-     * @param name The method name
-     * @param prefix The prefix to check
-     * @return True if the prefix is a word at the start of the name
-     */
     private static boolean startsWithWord(final String name, final String prefix) {
         final boolean result;
         if (name.startsWith(prefix)) {

--- a/src/main/java/com/qulice/checkstyle/ProhibitUnusedPrivateConstructorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitUnusedPrivateConstructorCheck.java
@@ -47,11 +47,6 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Collects all private constructors in a given object block.
-     * @param objblock Node which contains constructors
-     * @return List of DetailAST nodes representing the private constructors
-     */
     private static List<DetailAST> collectPrivateConstructors(final DetailAST objblock) {
         final List<DetailAST> prvctors = new ArrayList<>(0);
         final DetailAST firstchld = objblock.getFirstChild();
@@ -63,12 +58,6 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
         return prvctors;
     }
 
-    /**
-     * Checks if a private constructor is used in the object block.
-     * @param privatector Node representing the private constructor
-     * @param objblock Node which contains constructors
-     * @return True if the private constructor is used, False otherwise
-     */
     private static boolean isPrivateConstructorUsed(
         final DetailAST privatector, final DetailAST objblock) {
         return
@@ -77,12 +66,6 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
             isPrivateCtorUsedInMethods(privatector, objblock);
     }
 
-    /**
-     * Checks if a private constructor is used in other constructors.
-     * @param privatector Node representing the private constructor
-     * @param objblock Node containing constructors
-     * @return True if the private constructor is used, False otherwise
-     */
     private static boolean isPrivateCtorUsedInOtherCtors(
         final DetailAST privatector, final DetailAST objblock) {
         return collectAllConstructors(objblock).stream().anyMatch(
@@ -92,12 +75,6 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
         );
     }
 
-    /**
-     * Checks if a private constructor is used in methods of the object block.
-     * @param privatector Node representing the private constructor
-     * @param objblock Node containing methods
-     * @return True if the private constructor is used, False otherwise
-     */
     private static boolean isPrivateCtorUsedInMethods(
         final DetailAST privatector, final DetailAST objblock) {
         boolean result = false;
@@ -113,11 +90,6 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Collects all constructors in a given object block.
-     * @param objblock Node which contains constructors
-     * @return List of DetailAST nodes representing all the constructors
-     */
     private static List<DetailAST> collectAllConstructors(final DetailAST objblock) {
         final List<DetailAST> allctors = new ArrayList<>(0);
         final DetailAST firstchld = objblock.getFirstChild();
@@ -129,13 +101,6 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
         return allctors;
     }
 
-    /**
-     * Returns true if specified node has modifiers of type
-     * <code>PRIVATE</code>.
-     * @param node Node to check
-     * @return True if specified node contains modifiers of type
-     *  <code>PRIVATE</code>, else returns <code>false</code>
-     */
     private static boolean isPrivate(final DetailAST node) {
         return node.findFirstToken(TokenTypes.MODIFIERS)
             .getChildCount(TokenTypes.LITERAL_PRIVATE) > 0;
@@ -177,11 +142,6 @@ public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {
             .getChildCount(TokenTypes.PARAMETER_DEF);
     }
 
-    /**
-     * Checks if private constructors are used.
-     * Logs a message if a private constructor is not used.
-     * @param objblock Node which contains constructors
-     */
     private void checkConstructors(final DetailAST objblock) {
         final List<DetailAST> prvctors = collectPrivateConstructors(objblock);
         for (final DetailAST ctor : prvctors) {

--- a/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
@@ -54,10 +54,6 @@ public final class ProtectedMethodInFinalClassCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks methods in current class have no protected modifier.
-     * @param ast DetailAST of CLASS_DEF
-     */
     private void checkMethods(final DetailAST ast) {
         final DetailAST objblock = ast.findFirstToken(TokenTypes.OBJBLOCK);
         for (final DetailAST method
@@ -83,12 +79,6 @@ public final class ProtectedMethodInFinalClassCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Search for all children of given type.
-     * @param base Parent node to start from
-     * @param type Node type
-     * @return Iterable
-     */
     private static Iterable<DetailAST> findAllChildren(final DetailAST base,
         final int type) {
         final List<DetailAST> children = new ArrayList<>(base.getChildCount());

--- a/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
+++ b/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
@@ -72,10 +72,6 @@ public final class QualifyInnerClassCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Checks if class to be instantiated is nested and unqualified.
-     * @param expr EXPR LITERAL_NEW node that needs to be checked
-     */
     private void visitNewExpression(final DetailAST expr) {
         final DetailAST child = expr.getFirstChild();
         if (child != null
@@ -85,10 +81,6 @@ public final class QualifyInnerClassCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * If provided class is top-level, scans it for nested classes.
-     * @param node Class-like AST node
-     */
     private void scanForNestedClassesIfNecessary(final DetailAST node) {
         if (!this.root) {
             this.root = true;
@@ -96,10 +88,6 @@ public final class QualifyInnerClassCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Scans class for all nested sub-classes.
-     * @param node Class-like AST node that needs to be checked
-     */
     private void scanClass(final DetailAST node) {
         final DetailAST content = node.findFirstToken(TokenTypes.OBJBLOCK);
         if (content == null) {
@@ -119,11 +107,6 @@ public final class QualifyInnerClassCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Returns class name.
-     * @param clazz Class-like AST node
-     * @return Class name
-     */
     private static String getClassName(final DetailAST clazz) {
         for (
             DetailAST child = clazz.getFirstChild();

--- a/src/main/java/com/qulice/checkstyle/RedundantSuperConstructorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/RedundantSuperConstructorCheck.java
@@ -69,11 +69,6 @@ public final class RedundantSuperConstructorCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Find the enclosing {@code CLASS_DEF} of the given constructor node.
-     * @param ctor Constructor node
-     * @return The CLASS_DEF, or null if the enclosing type is not a class
-     */
     private static DetailAST enclosingClass(final DetailAST ctor) {
         DetailAST result = null;
         final DetailAST block = ctor.getParent();
@@ -86,12 +81,6 @@ public final class RedundantSuperConstructorCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Report any direct {@code super(...)} call inside the constructor body.
-     * Nested anonymous class bodies and lambdas are skipped because their
-     * {@code super(...)} calls belong to a different enclosing class.
-     * @param node Root of the constructor body subtree
-     */
     private void reportSuperCalls(final DetailAST node) {
         for (DetailAST child = node.getFirstChild();
             child != null; child = child.getNextSibling()) {

--- a/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
+++ b/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
@@ -107,13 +107,6 @@ final class RequiredJavaDocTag {
         }
     }
 
-    /**
-     * Log either "missing" or "malformed" depending on whether a loose
-     * match was found in the comment.
-     * @param start Line number where the comment starts
-     * @param looseline Line number where a loose match was found, or
-     *  {@code null} if none was found
-     */
     private void logMissing(final int start, final Integer looseline) {
         if (looseline == null) {
             this.reporter.log(
@@ -130,11 +123,6 @@ final class RequiredJavaDocTag {
         }
     }
 
-    /**
-     * Log a violation for every tag whose text does not match the
-     * configured pattern.
-     * @param found Map of line number to tag text
-     */
     private void logMismatches(final Map<Integer, String> found) {
         for (final Map.Entry<Integer, String> item : found.entrySet()) {
             if (!this.content.matcher(item.getValue()).matches()) {
@@ -148,22 +136,12 @@ final class RequiredJavaDocTag {
         }
     }
 
-    /**
-     * Finds the tag name and the following sentences.
-     * @param matcher Tag name matcher
-     * @return True if the tag and its clauses are found
-     */
     private static boolean tagFound(final Matcher matcher) {
         return matcher.matches()
             && !RequiredJavaDocTag.empty(matcher.group("name"))
             && !RequiredJavaDocTag.empty(matcher.group("cont"));
     }
 
-    /**
-     * Checks for an empty string.
-     * @param str Line to check
-     * @return True if str is empty
-     */
     private static boolean empty(final String str) {
         return str == null || str.chars().allMatch(Character::isWhitespace);
     }

--- a/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
+++ b/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
@@ -90,13 +90,6 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Returns the STRING_LITERAL node that is the first argument of a
-     * split call with one or two arguments, if any.
-     * @param call METHOD_CALL AST node
-     * @return Node of the literal regex, or empty when the call is not a
-     *  split with a literal first argument
-     */
     private static Optional<DetailAST> regexLiteral(final DetailAST call) {
         Optional<DetailAST> result = Optional.empty();
         if (SimpleStringSplitCheck.isSplitCall(call)) {
@@ -105,11 +98,6 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Tells whether the method call invokes a method named "split".
-     * @param call METHOD_CALL AST node
-     * @return True when the call is of the form receiver.split(...)
-     */
     private static boolean isSplitCall(final DetailAST call) {
         final DetailAST dot = call.getFirstChild();
         final boolean result;
@@ -123,12 +111,6 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Finds the first STRING_LITERAL argument when the call has one or two
-     * arguments.
-     * @param call METHOD_CALL AST node
-     * @return STRING_LITERAL node, or empty when the shape does not match
-     */
     private static Optional<DetailAST> firstLiteralArg(final DetailAST call) {
         final DetailAST elist = call.findFirstToken(TokenTypes.ELIST);
         Optional<DetailAST> result = Optional.empty();
@@ -141,31 +123,16 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Tells whether the given ELIST holds one or two EXPR children.
-     * @param elist ELIST AST node
-     * @return True if ELIST has 1 or 2 EXPR children
-     */
     private static boolean isOneOrTwoArgs(final DetailAST elist) {
         final int args = elist.getChildCount(TokenTypes.EXPR);
         return args == 1 || args == 2;
     }
 
-    /**
-     * Tells whether the given EXPR is a lone STRING_LITERAL.
-     * @param expr EXPR AST node
-     * @return True if EXPR has a single STRING_LITERAL child
-     */
     private static boolean isLoneStringLiteral(final DetailAST expr) {
         return expr.getChildCount() == 1
             && expr.getFirstChild().getType() == TokenTypes.STRING_LITERAL;
     }
 
-    /**
-     * Tells whether the given regex string would hit the JDK fastpath.
-     * @param regex Runtime regex string
-     * @return True if JDK fastpath applies
-     */
     private static boolean optimized(final String regex) {
         final boolean result;
         final int len = regex.length();
@@ -179,43 +146,20 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Tells whether the given character is an ASCII letter or digit.
-     * @param chr Character to test
-     * @return True if ASCII letter or digit
-     */
     private static boolean isAsciiAlphanumeric(final char chr) {
         return SimpleStringSplitCheck.isAsciiDigit(chr)
             || SimpleStringSplitCheck.isAsciiLetter(chr);
     }
 
-    /**
-     * Tells whether the given character is an ASCII digit 0-9.
-     * @param chr Character to test
-     * @return True if ASCII digit
-     */
     private static boolean isAsciiDigit(final char chr) {
         return chr >= '0' && chr <= '9';
     }
 
-    /**
-     * Tells whether the given character is an ASCII letter a-z or A-Z.
-     * @param chr Character to test
-     * @return True if ASCII letter
-     */
     private static boolean isAsciiLetter(final char chr) {
         return chr >= 'a' && chr <= 'z'
             || chr >= 'A' && chr <= 'Z';
     }
 
-    /**
-     * Decodes a Java string literal (with surrounding double quotes) to the
-     * runtime string it denotes. Returns empty when the literal contains
-     * escape sequences the check does not understand, so the check can stay
-     * silent rather than guess.
-     * @param text Raw token text including the surrounding double quotes
-     * @return Decoded runtime string, or empty on unsupported escapes
-     */
     private static Optional<String> decode(final String text) {
         final String body = text.substring(1, text.length() - 1);
         final StringBuilder out = new StringBuilder(body.length());
@@ -238,13 +182,6 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         return result;
     }
 
-    /**
-     * Advances one step through the string literal body.
-     * @param body Literal body without surrounding quotes
-     * @param idx Current index
-     * @param out Receiver for the decoded char
-     * @return Number of source chars consumed, or -1 on unsupported escape
-     */
     private static int step(
         final String body, final int idx, final StringBuilder out
     ) {
@@ -259,13 +196,6 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         return advance;
     }
 
-    /**
-     * Handles a backslash escape starting at {@code idx} in {@code body}.
-     * @param body Literal body without surrounding quotes
-     * @param idx Index of the backslash
-     * @param out Receiver for the decoded char
-     * @return Number of source chars consumed, or -1 on unsupported escape
-     */
     private static int handleEscape(
         final String body, final int idx, final StringBuilder out
     ) {
@@ -286,11 +216,6 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         return advance;
     }
 
-    /**
-     * Translates a single Java escape letter to its runtime character.
-     * @param chr Character after the backslash
-     * @return Runtime character code, or -1 for unsupported escapes
-     */
     private static int escape(final char chr) {
         return switch (chr) {
             case 'n' -> '\n';

--- a/src/main/java/com/qulice/checkstyle/SingleLineCommentCheck.java
+++ b/src/main/java/com/qulice/checkstyle/SingleLineCommentCheck.java
@@ -120,12 +120,6 @@ public final class SingleLineCommentCheck extends AbstractCheck {
         this.message = msg;
     }
 
-    /**
-     * Checks for the end of a comment line.
-     * @param ast Checkstyle's AST nodes
-     * @return True if this is the end of the comment
-     *  and the starting line number is equal to the ending line number
-     */
     private boolean singleLineCStyleComment(final DetailAST ast) {
         return ast.getType() == TokenTypes.BLOCK_COMMENT_END && this.begin == ast.getLineNo();
     }

--- a/src/main/java/com/qulice/checkstyle/StaticAccessViaInstanceCheck.java
+++ b/src/main/java/com/qulice/checkstyle/StaticAccessViaInstanceCheck.java
@@ -83,11 +83,6 @@ public final class StaticAccessViaInstanceCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Reports the dot expression if it accesses a static member via
-     * {@code this}.
-     * @param dot DOT node
-     */
     private void checkDot(final DetailAST dot) {
         final DetailAST left = dot.getFirstChild();
         if (!this.scopes.isEmpty()
@@ -101,13 +96,6 @@ public final class StaticAccessViaInstanceCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Tells whether the node is an IDENT whose text is in the set of known
-     * static member names.
-     * @param node Node to check
-     * @param names Known static names
-     * @return True if the node matches
-     */
     private static boolean isStaticIdent(
         final DetailAST node, final Set<String> names) {
         return node != null
@@ -115,12 +103,6 @@ public final class StaticAccessViaInstanceCheck extends AbstractCheck {
             && names.contains(node.getText());
     }
 
-    /**
-     * Collects the names of all static methods and fields directly declared
-     * in the given class-like node.
-     * @param clazz CLASS_DEF, ENUM_DEF or INTERFACE_DEF node
-     * @return Set of static member names
-     */
     private static Set<String> collectStatic(final DetailAST clazz) {
         final Set<String> names = new HashSet<>(0);
         final DetailAST body = clazz.findFirstToken(TokenTypes.OBJBLOCK);
@@ -133,12 +115,6 @@ public final class StaticAccessViaInstanceCheck extends AbstractCheck {
         return names;
     }
 
-    /**
-     * Tells whether the node is a static method or a static field
-     * declaration.
-     * @param node Node to check
-     * @return True if it is a static method or field
-     */
     private static boolean isStaticMember(final DetailAST node) {
         final int type = node.getType();
         final boolean member = type == TokenTypes.METHOD_DEF

--- a/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
@@ -71,15 +71,6 @@ public final class StringLiteralsConcatenationCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Recursively traverse the <code>tree</code> and return all ASTs subtrees
-     * matching any type from <code>types</code>.
-     * @param tree AST to traverse
-     * @param types Token types to match against
-     * @return All ASTs subtrees with token types matching any from
-     *  <tt>types</tt>
-     * @see TokenTypes
-     */
     private List<DetailAST> findChildAstsOfType(final DetailAST tree,
         final int... types) {
         final List<DetailAST> children = new ArrayList<>(0);
@@ -95,15 +86,6 @@ public final class StringLiteralsConcatenationCheck extends AbstractCheck {
         return children;
     }
 
-    /**
-     * Checks whether an operand of the given PLUS/PLUS_ASSIGN node is a
-     * string literal. Traverses only through nested PLUS/PLUS_ASSIGN nodes
-     * so that STRING_LITERALs nested inside method-call arguments or other
-     * sub-expressions of an operand do not count.
-     * @param node PLUS or PLUS_ASSIGN node to inspect
-     * @return True if any operand of the concatenation chain is a string
-     *  literal, false otherwise
-     */
     private boolean hasStringLiteralOperand(final DetailAST node) {
         boolean found = false;
         DetailAST child = node.getFirstChild();
@@ -123,13 +105,6 @@ public final class StringLiteralsConcatenationCheck extends AbstractCheck {
         return found;
     }
 
-    /**
-     * Checks if this <code>ast</code> is of any type from <code>types</code>.
-     * @param ast AST to check
-     * @param types Token types to match against
-     * @return True if of type, false otherwise
-     * @see TokenTypes
-     */
     private static boolean isOfType(final DetailAST ast, final int... types) {
         boolean yes = false;
         for (final int type : types) {

--- a/src/main/java/com/qulice/checkstyle/SuppressionTag.java
+++ b/src/main/java/com/qulice/checkstyle/SuppressionTag.java
@@ -82,11 +82,6 @@ final class SuppressionTag {
         return events.stream().noneMatch(this::covers);
     }
 
-    /**
-     * Does this suppression cover this event?
-     * @param event Event to check
-     * @return True if the event is of the check and in the range
-     */
     private boolean covers(final AuditEvent event) {
         return event.getSourceName().contains(this.check)
             && event.getLine() >= this.first

--- a/src/main/java/com/qulice/checkstyle/Suppressions.java
+++ b/src/main/java/com/qulice/checkstyle/Suppressions.java
@@ -100,12 +100,6 @@ final class Suppressions implements Iterable<SuppressionTag> {
         return tags.iterator();
     }
 
-    /**
-     * Collect the {@code (N lines)} suppressions on one line.
-     * @param line Text of the line
-     * @param number Number of the line
-     * @param tags Where to add the suppressions found
-     */
     private static void nearby(final String line, final int number,
         final Collection<SuppressionTag> tags) {
         final Matcher matcher = Suppressions.NEARBY.matcher(line);
@@ -120,13 +114,6 @@ final class Suppressions implements Iterable<SuppressionTag> {
         }
     }
 
-    /**
-     * Blank out the string and character literals of a line, so that a
-     * {@code @checkstyle} tag inside them is not mistaken for a real
-     * suppression comment.
-     * @param line Text of the line
-     * @return The line with the literals turned into spaces
-     */
     private static String code(final String line) {
         final StringBuilder out = new StringBuilder(line.length());
         char quote = 0;

--- a/src/main/java/com/qulice/checkstyle/UnknownSuppressionCheck.java
+++ b/src/main/java/com/qulice/checkstyle/UnknownSuppressionCheck.java
@@ -84,12 +84,6 @@ public final class UnknownSuppressionCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * How many lines of the comment precede this position?
-     * @param text Text of the comment
-     * @param position Position of the suppression inside the text
-     * @return Number of line breaks before the position
-     */
     private static int breaks(final String text, final int position) {
         int count = 0;
         for (int idx = 0; idx < position; ++idx) {

--- a/src/main/java/com/qulice/checkstyle/UnnecessaryJavaLangCheck.java
+++ b/src/main/java/com/qulice/checkstyle/UnnecessaryJavaLangCheck.java
@@ -109,11 +109,6 @@ public final class UnnecessaryJavaLangCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Blank out every line spanned by a text-block content node. Those
-     * lines hold only string data, so the pattern must never match there.
-     * @param ast The {@code TEXT_BLOCK_CONTENT} node
-     */
     private void blankBlock(final DetailAST ast) {
         final String text = ast.getText();
         int span = 0;
@@ -131,13 +126,6 @@ public final class UnnecessaryJavaLangCheck extends AbstractCheck {
         }
     }
 
-    /**
-     * Replace with spaces a run of characters on a single line, so that
-     * the {@code java.lang.} pattern cannot match inside it.
-     * @param line One-based line number
-     * @param column Zero-based column where the run starts
-     * @param length Number of characters to blank
-     */
     private void blank(final int line, final int column, final int length) {
         final int index = line - 1;
         if (index >= 0 && index < this.lines.length) {

--- a/src/main/java/com/qulice/checkstyle/UnusedSuppressions.java
+++ b/src/main/java/com/qulice/checkstyle/UnusedSuppressions.java
@@ -85,11 +85,6 @@ final class UnusedSuppressions {
         return results;
     }
 
-    /**
-     * Run Checkstyle over the files with the nearby filters removed.
-     * @param files Files to process
-     * @param sink Listener that gathers the events
-     */
     private void collect(final Collection<File> files,
         final CheckstyleListener sink) {
         final Checker checker = new Checker();
@@ -111,12 +106,6 @@ final class UnusedSuppressions {
         }
     }
 
-    /**
-     * The dead suppressions of one file.
-     * @param file File to inspect
-     * @param events Events collected with the nearby filters removed
-     * @return Violations, one per dead suppression
-     */
     private Collection<Violation> unused(final File file,
         final Collection<AuditEvent> events) {
         final Collection<Violation> results = new ArrayList<>(0);
@@ -149,11 +138,6 @@ final class UnusedSuppressions {
         return results;
     }
 
-    /**
-     * Read the text of a file, in the encoding of the environment.
-     * @param file File to read
-     * @return Its text
-     */
     private String read(final File file) {
         try {
             return Files.readString(file.toPath(), this.env.encoding());
@@ -164,10 +148,6 @@ final class UnusedSuppressions {
         }
     }
 
-    /**
-     * A fresh cache file, so the second run reprocesses every file.
-     * @return Path to an empty cache file
-     */
     private File cache() {
         final File dir = new File(this.env.tempdir(), "checkstyle");
         if (!dir.exists() && !dir.mkdirs()) {
@@ -184,11 +164,6 @@ final class UnusedSuppressions {
         }
     }
 
-    /**
-     * The configuration of {@code checks.xml} without the nearby filters.
-     * @param cache Cache file for the run
-     * @return The configuration
-     */
     private Configuration configuration(final File cache) {
         final Properties props = new Properties();
         props.setProperty("cache.file", cache.getPath());
@@ -211,10 +186,6 @@ final class UnusedSuppressions {
         return config;
     }
 
-    /**
-     * Remove the nearby suppression filters from a configuration tree.
-     * @param config Configuration to strip, modified in place
-     */
     private static void strip(final Configuration config) {
         for (final Configuration child : config.getChildren()) {
             final String name = child.getName();

--- a/src/main/java/com/qulice/errorprone/Batches.java
+++ b/src/main/java/com/qulice/errorprone/Batches.java
@@ -112,20 +112,6 @@ public final class Batches {
         return batches;
     }
 
-    /**
-     * The name of the batch of the given source root.
-     *
-     * <p>Batch names end up inside file names, so the path of the root is
-     * reduced to letters and digits. The position of the root among the
-     * ones the project declares is prepended, because that reduction is not
-     * injective — {@code src/mock-java} and {@code src/mock/java} share a
-     * shape — and two roots sharing a name would land in one batch, which
-     * is the very thing this split prevents.</p>
-     *
-     * @param root The source root
-     * @param index Its position among the roots, one-based
-     * @return Name of the batch, safe to use in a file name
-     */
     private String label(final File root, final int index) {
         return String.format(
             "test-%d-%s",
@@ -138,19 +124,6 @@ public final class Batches {
         );
     }
 
-    /**
-     * The batch a source file belongs to: the root it sits under, or the
-     * main batch when it sits under none of them.
-     *
-     * <p>The longest matching root wins, so that a root nested inside
-     * another one — {@code src/test} and {@code src/test/java} both
-     * declared, say — claims its own files instead of leaving them to the
-     * root above.</p>
-     *
-     * @param path Normalized absolute path of the file
-     * @param roots Batch name by root path, each ending with a slash
-     * @return Name of the batch
-     */
     private static String owner(final String path,
         final Map<String, String> roots) {
         String name = Batches.MAIN;
@@ -165,14 +138,6 @@ public final class Batches {
         return name;
     }
 
-    /**
-     * The absolute path of a file, in one shape: forward slashes, no
-     * {@code .} or {@code ..} steps. Source roots arrive from the POM
-     * while sources arrive from walking the disk, so only a normalized
-     * form makes the two comparable as text.
-     * @param file File to render
-     * @return Its absolute path
-     */
     private static String slashed(final File file) {
         final String absolute = file.getAbsolutePath();
         String path = FilenameUtils.normalize(absolute, true);

--- a/src/main/java/com/qulice/errorprone/Diagnostics.java
+++ b/src/main/java/com/qulice/errorprone/Diagnostics.java
@@ -102,14 +102,6 @@ final class Diagnostics {
         return violations;
     }
 
-    /**
-     * Turn one parsed diagnostic into a violation.
-     * @param file Source file the compiler pointed at
-     * @param lines Line number inside that file
-     * @param check Name of the check or lint category
-     * @param message Diagnostic body, without the bracketed name
-     * @return The violation
-     */
     private Violation violation(final String file, final String lines,
         final String check, final String message) {
         return new Violation.Default(
@@ -121,12 +113,6 @@ final class Diagnostics {
         );
     }
 
-    /**
-     * Name of the check a diagnostic belongs to, falling back to
-     * {@code javac} for the diagnostics the compiler leaves unlabelled.
-     * @param name Bracketed name the diagnostic carried, or {@code null}
-     * @return Name to report the violation under
-     */
     private static String check(final String name) {
         return Optional.ofNullable(name).orElse(Diagnostics.JAVAC);
     }

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -141,12 +141,6 @@ public final class ErrorProneValidator implements ResourceValidator {
         ).patterns();
     }
 
-    /**
-     * Run the forked {@code javac} process with ErrorProne enabled.
-     * @param batch Name of the batch being compiled
-     * @param sources Java source files to feed
-     * @return Combined stdout/stderr of the process, line by line
-     */
     private List<String> run(final String batch, final List<File> sources) {
         final Result result = new Jaxec(this.command(batch, sources))
             .withRedirect(true)
@@ -162,32 +156,6 @@ public final class ErrorProneValidator implements ResourceValidator {
         return lines;
     }
 
-    /**
-     * Build the {@code javac} command line. To stay below the
-     * Windows {@code CreateProcess} 32 KB command-line limit even on
-     * projects with thousands of sources or long classpaths, every
-     * argument other than the launcher itself and the {@code -J}
-     * flags (which {@code javac} forbids inside argfiles) is written
-     * to a temporary argfile and passed as {@code @argfile}.
-     *
-     * <p>{@code -Xlint:-options} turns off the one lint category that
-     * would report Qulice to the project instead of the project to the
-     * user: {@code options} complains about the {@code -source}/
-     * {@code -target} pair {@link Release} deliberately builds in place of
-     * {@code --release} (see
-     * <a href="https://github.com/yegor256/qulice/issues/1716">#1716</a>),
-     * and no change to the project could ever silence it.</p>
-     *
-     * <p>{@code -encoding} is the project's own
-     * {@code project.build.sourceEncoding}, so that a source file holding
-     * characters outside ASCII reads the same on every host, instead of
-     * through whatever charset the machine running Maven happens to
-     * default to.</p>
-     *
-     * @param batch Name of the batch being compiled
-     * @param sources Java source files to feed
-     * @return Argv
-     */
     private List<String> command(final String batch, final List<File> sources) {
         final List<String> command = new ArrayList<>(
             ErrorProneValidator.JVM_FLAGS.size() + 2
@@ -244,11 +212,6 @@ public final class ErrorProneValidator implements ResourceValidator {
         return command;
     }
 
-    /**
-     * Filters out non-Java and excluded files from further validation.
-     * @param files Files to validate
-     * @return List of relevant files
-     */
     private List<File> relevant(final Collection<File> files) {
         final List<File> sources = new ArrayList<>(files.size());
         for (final File file : files) {
@@ -264,10 +227,6 @@ public final class ErrorProneValidator implements ResourceValidator {
         return sources;
     }
 
-    /**
-     * Resolve the {@code javac} executable from the running JDK.
-     * @return Absolute path to {@code ${java.home}/bin/javac}
-     */
     private static String javac() {
         return new File(
             new File(System.getProperty("java.home"), "bin"),
@@ -275,22 +234,6 @@ public final class ErrorProneValidator implements ResourceValidator {
         ).getAbsolutePath();
     }
 
-    /**
-     * Build the {@code -processorpath} value passed to the forked
-     * {@code javac}. Combines two sources: every URL on the
-     * {@link URLClassLoader} chain starting from the thread context
-     * classloader (the qulice plugin's own {@code ClassRealm} plus its
-     * URL-based parents, which carries ErrorProne when this code runs
-     * inside a Maven plugin execution), and the jar locations of a few
-     * classes ErrorProne needs at runtime that Maven's classworlds
-     * imports from a non-URL parent realm (notably
-     * {@link javax.inject.Inject}, which the
-     * {@code ErrorProneInjector} reads to find injectable constructors).
-     * Both are required: without the realm URLs there's no
-     * {@code error_prone_core}, without the protection-domain lookup
-     * there's no {@code javax.inject}.
-     * @return Path-separator joined list of jar paths
-     */
     private static String pluginClasspath() {
         final Set<String> entries = new LinkedHashSet<>();
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -315,14 +258,6 @@ public final class ErrorProneValidator implements ResourceValidator {
         return String.join(File.pathSeparator, entries);
     }
 
-    /**
-     * Append the jar that contains the given class to {@code entries},
-     * resolved via {@link Class#getProtectionDomain()}. Silently ignored
-     * if the class is loaded from a non-file location (e.g. a JRT module
-     * or an exploded directory).
-     * @param entries Set to append to
-     * @param klass Class whose code source jar should be included
-     */
     private static void addCodeSource(
         final Set<String> entries, final Class<?> klass
     ) {

--- a/src/main/java/com/qulice/errorprone/Release.java
+++ b/src/main/java/com/qulice/errorprone/Release.java
@@ -92,13 +92,6 @@ final class Release {
         return flags;
     }
 
-    /**
-     * The flags a given trio of Maven properties asks for.
-     * @param release Name of the property holding the release level
-     * @param source Name of the property holding the source level
-     * @param target Name of the property holding the target level
-     * @return Source-level flags, empty when neither release nor source is set
-     */
     private List<String> pinned(
         final String release, final String source, final String target
     ) {
@@ -117,17 +110,6 @@ final class Release {
         return flags;
     }
 
-    /**
-     * The {@code -target} level to forward alongside {@code -source}.
-     *
-     * <p>Reads the given property, falling back to the given source level when
-     * the project does not pin a target of its own, so that {@code javac}'s
-     * requirement of {@code target >= source} is always met.</p>
-     *
-     * @param property Name of the property holding the target level
-     * @param fallback The source level to use when no target is pinned
-     * @return The target level
-     */
     private int target(final String property, final int fallback) {
         int level = Release.major(this.env.param(property, ""));
         if (level < 0) {
@@ -136,11 +118,6 @@ final class Release {
         return level;
     }
 
-    /**
-     * Parse a Java version string into its major number.
-     * @param value Version, e.g. {@code "8"}, {@code "1.8"} or {@code "17"}
-     * @return The major version, or {@code -1} if it cannot be parsed
-     */
     private static int major(final String value) {
         int result = -1;
         if (value != null) {

--- a/src/main/java/com/qulice/errorprone/Xplugin.java
+++ b/src/main/java/com/qulice/errorprone/Xplugin.java
@@ -111,11 +111,6 @@ public final class Xplugin {
             .size();
     }
 
-    /**
-     * The {@code -Xep} flags, Qulice's own first and the project's after
-     * them.
-     * @return Flags, in the order ErrorProne reads them
-     */
     private List<String> flags() {
         final List<String> flags = new ArrayList<>(
             Xplugin.DISABLED.size() + 4
@@ -125,15 +120,6 @@ public final class Xplugin {
         return flags;
     }
 
-    /**
-     * The flags of the project, one by one.
-     *
-     * <p>Whitespace and commas both separate them, so that a list of
-     * configuration elements and a single POM property arrive here in the
-     * same shape.</p>
-     *
-     * @return Flags, in the order the project wrote them, possibly empty
-     */
     private List<String> extras() {
         return Xplugin.SEPARATOR.splitAsStream(this.extra.trim())
             .filter(flag -> !flag.isEmpty())
@@ -141,18 +127,6 @@ public final class Xplugin {
             .toList();
     }
 
-    /**
-     * Refuse a flag ErrorProne would not understand.
-     *
-     * <p>Only ErrorProne's own flags make sense here, since they travel
-     * inside the {@code -Xplugin:ErrorProne} argument and never reach
-     * {@code javac} itself. Anything else is refused right here, rather
-     * than handed to the forked compiler, which would report the
-     * misconfiguration as a violation of the project.</p>
-     *
-     * @param flag The flag the project supplied
-     * @return The same flag
-     */
     private static String checked(final String flag) {
         if (!flag.startsWith("-Xep")) {
             throw new IllegalArgumentException(

--- a/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/src/main/java/com/qulice/maven/CheckMojo.java
@@ -129,11 +129,6 @@ public final class CheckMojo extends AbstractQuliceMojo {
         return filtered;
     }
 
-    /**
-     * Run them all.
-     * @return What was checked, for the final log line
-     * @throws ValidationException If any of them fail
-     */
     @SuppressWarnings("PMD.CognitiveComplexity")
     private String run() throws ValidationException {
         final List<Violation> results = new ArrayList<>(0);
@@ -200,11 +195,6 @@ public final class CheckMojo extends AbstractQuliceMojo {
         return new Summary(files, resources).toString();
     }
 
-    /**
-     * Provider of validators, the one that was set or the default one.
-     * @param env Maven environment for the default provider
-     * @return The provider
-     */
     private ValidatorsProvider validators(final MavenEnvironment env) {
         final ValidatorsProvider prov;
         if (this.provider == null) {
@@ -215,13 +205,6 @@ public final class CheckMojo extends AbstractQuliceMojo {
         return prov;
     }
 
-    /**
-     * Submit validators to executor.
-     * @param env Maven environment
-     * @param files List of files to validate
-     * @param validators Validators to use
-     * @return List of futures
-     */
     private Collection<Future<Collection<Violation>>> submit(
         final MavenEnvironment env, final Collection<File> files,
         final Collection<ResourceValidator> validators
@@ -238,10 +221,6 @@ public final class CheckMojo extends AbstractQuliceMojo {
         return futures;
     }
 
-    /**
-     * Timeout value for timeout.
-     * @return Timeout value
-     */
     private long timeoutValue() {
         final String clear = this.clearTimeout();
         final long res;
@@ -255,10 +234,6 @@ public final class CheckMojo extends AbstractQuliceMojo {
         return res;
     }
 
-    /**
-     * Time unit for timeout.
-     * @return Time unit
-     */
     private TimeUnit timeoutUnits() {
         final String clear = this.clearTimeout();
         final TimeUnit unit;
@@ -274,10 +249,6 @@ public final class CheckMojo extends AbstractQuliceMojo {
         return unit;
     }
 
-    /**
-     * Clear timeout string.
-     * @return Cleaned timeout
-     */
     private String clearTimeout() {
         final String clear;
         if (this.timeout == null) {

--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -311,20 +311,6 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         return Charset.forName(this.charset);
     }
 
-    /**
-     * Collect source directories declared by the Maven project.
-     *
-     * <p>Uses compile and test source roots together with declared resources
-     * so that a project configuring {@code <sourceDirectory>} or
-     * {@code <testSourceDirectory>} in its POM is honored. Falls back to
-     * {@code src} under the basedir when the project exposes no directories,
-     * which preserves the historical behavior for minimal stubs. Roots that
-     * live under the project's build directory (e.g.
-     * {@code target/generated-sources/...}) are filtered out, since those
-     * are generated build outputs and not user-authored code (issue #1560).
-     *
-     * @return Absolute directories to scan for files
-     */
     private Collection<File> sources() {
         final Collection<File> dirs = new ArrayList<>(0);
         final Build build = this.iproject.getBuild();
@@ -341,11 +327,6 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         return dirs;
     }
 
-    /**
-     * Resolve the project's build directory.
-     * @param build Build descriptor, may be null
-     * @return Canonical build directory, or null if not declared
-     */
     @Nullable
     private File buildDirectory(@Nullable final Build build) {
         File dir = null;
@@ -355,12 +336,6 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         return dir;
     }
 
-    /**
-     * Add resolved roots to the given collection.
-     * @param dirs Collection to fill
-     * @param roots Source roots, may be null
-     * @param output Build output directory, may be null
-     */
     private void addRoots(final Collection<File> dirs,
         final List<String> roots, @Nullable final File output) {
         if (roots != null) {
@@ -379,12 +354,6 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         }
     }
 
-    /**
-     * Add resolved resource directories to the given collection.
-     * @param dirs Collection to fill
-     * @param resources Resources, may be null
-     * @param output Build output directory, may be null
-     */
     private void addResources(final Collection<File> dirs,
         final List<Resource> resources, @Nullable final File output) {
         if (resources != null) {
@@ -403,12 +372,6 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         }
     }
 
-    /**
-     * Check that the file does not live inside the given parent.
-     * @param file Candidate
-     * @param parent Possibly enclosing directory, may be null
-     * @return True when the file is outside the parent
-     */
     private static boolean outside(final File file,
         @Nullable final File parent) {
         boolean answer = true;
@@ -427,11 +390,6 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         return answer;
     }
 
-    /**
-     * Resolve a directory path against the project basedir.
-     * @param path Absolute or relative path
-     * @return Absolute file
-     */
     private File resolve(final String path) {
         final File file = new File(path);
         final File resolved;

--- a/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -96,11 +96,6 @@ final class DependenciesValidator implements MavenValidator {
         Logger.info(this, "No dependency problems found");
     }
 
-    /**
-     * Analyze the project.
-     * @param env The environment
-     * @return The result of analysis
-     */
     private static ProjectDependencyAnalysis analyze(
         final MavenEnvironment env) {
         try {
@@ -115,11 +110,6 @@ final class DependenciesValidator implements MavenValidator {
         }
     }
 
-    /**
-     * Find unused artifacts.
-     * @param env Environment
-     * @return Collection of unused artifacts
-     */
     private static Collection<String> used(final MavenEnvironment env) {
         final ProjectDependencyAnalysis analysis =
             DependenciesValidator.analyze(env);
@@ -130,19 +120,6 @@ final class DependenciesValidator implements MavenValidator {
         return used;
     }
 
-    /**
-     * Find unused artifacts.
-     *
-     * <p>Bytecode analysis cannot detect dependencies used only through
-     * annotations with source retention or through inlined compile-time
-     * constants. To avoid such false positives, artifacts flagged as
-     * unused by {@link ProjectDependencyAnalyzer} are cross-checked
-     * against {@code import} statements in the project's source files;
-     * any artifact referenced by an import is treated as used.</p>
-     *
-     * @param env Environment
-     * @return Collection of unused artifacts
-     */
     private static Collection<String> unused(final MavenEnvironment env) {
         final ProjectDependencyAnalysis analysis =
             DependenciesValidator.analyze(env);
@@ -166,12 +143,6 @@ final class DependenciesValidator implements MavenValidator {
         return unused;
     }
 
-    /**
-     * Collect fully-qualified imports from all Java source files
-     * in the project's compile source roots.
-     * @param env Environment
-     * @return Set of imported class names and wildcard package imports
-     */
     private static Set<String> imports(final MavenEnvironment env) {
         final Set<String> imports = new HashSet<>();
         final Collection<String> roots =
@@ -187,11 +158,6 @@ final class DependenciesValidator implements MavenValidator {
         return imports;
     }
 
-    /**
-     * Walk the given directory and collect imports from every Java file.
-     * @param dir Source root directory
-     * @param acc Accumulator to populate with imports
-     */
     private static void scanJavaFiles(final Path dir, final Set<String> acc) {
         try (Stream<Path> walk = Files.walk(dir)) {
             walk
@@ -204,12 +170,6 @@ final class DependenciesValidator implements MavenValidator {
         }
     }
 
-    /**
-     * Read import statements from a single Java source file into the
-     * given accumulator.
-     * @param file Java source file
-     * @param acc Accumulator to populate
-     */
     private static void readImports(final Path file, final Set<String> acc) {
         try {
             for (final String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
@@ -241,12 +201,6 @@ final class DependenciesValidator implements MavenValidator {
         }
     }
 
-    /**
-     * Is the given artifact referenced by any of the collected imports?
-     * @param imports Imports collected from project sources
-     * @param artifact Artifact whose JAR is inspected
-     * @return TRUE if at least one class from the JAR is imported
-     */
     private static boolean imported(final Set<String> imports,
         final Artifact artifact) {
         final File file = artifact.getFile();
@@ -270,14 +224,6 @@ final class DependenciesValidator implements MavenValidator {
         return found;
     }
 
-    /**
-     * Does the given JAR entry name represent a class imported by the
-     * project sources?
-     * @param imports Imports collected from project sources
-     * @param entry JAR entry name (e.g. "com/example/Foo.class")
-     * @return TRUE if the entry's fully-qualified class name or its
-     *  package is imported
-     */
     private static boolean matches(final Set<String> imports,
         final String entry) {
         boolean match = false;

--- a/src/main/java/com/qulice/maven/MojoExecutor.java
+++ b/src/main/java/com/qulice/maven/MojoExecutor.java
@@ -121,12 +121,6 @@ public final class MojoExecutor {
         return xpp;
     }
 
-    /**
-     * Create descriptor.
-     * @param plugin The plugin
-     * @param goal Maven plugin goal to execute
-     * @return The descriptor
-     */
     private MojoDescriptor descriptor(final Plugin plugin, final String goal) {
         try {
             return new DefaultMavenPluginManagerHelper(this.manager)
@@ -141,11 +135,6 @@ public final class MojoExecutor {
         }
     }
 
-    /**
-     * Create mojo.
-     * @param execution The execution
-     * @return The mojo
-     */
     private Mojo mojo(final MojoExecution execution) {
         final Mojo mojo;
         try {
@@ -160,12 +149,6 @@ public final class MojoExecutor {
         return mojo;
     }
 
-    /**
-     * Convert a single value into an Xpp3Dom node.
-     * @param name Name of the node
-     * @param value Value to convert
-     * @return The Xpp3Dom node
-     */
     private Xpp3Dom toNode(final String name, final Object value) {
         final Xpp3Dom node;
         if (value instanceof String) {
@@ -193,12 +176,6 @@ public final class MojoExecutor {
         return node;
     }
 
-    /**
-     * Append a collection item to its parent node.
-     * @param parent Parent node receiving the item
-     * @param name Name used for the item when it is not a Properties map
-     * @param item The item to append
-     */
     private void appendItem(
         final Xpp3Dom parent, final String name, final Object item
     ) {
@@ -215,12 +192,6 @@ public final class MojoExecutor {
         }
     }
 
-    /**
-     * Recursively convert PLEXUS config to Xpp3Dom.
-     * @param config The config to convert
-     * @return The Xpp3Dom document
-     * @see #execute(String,String,Properties)
-     */
     private Xpp3Dom toXppDom(final PlexusConfiguration config) {
         final Xpp3Dom result = new Xpp3Dom(config.getName());
         result.setValue(config.getValue(null));

--- a/src/main/java/com/qulice/maven/PomXpathValidator.java
+++ b/src/main/java/com/qulice/maven/PomXpathValidator.java
@@ -40,12 +40,6 @@ public final class PomXpathValidator implements MavenValidator {
         PomXpathValidator.validate(PomXpathValidator.pom(env), env.asserts());
     }
 
-    /**
-     * Validate pom against xpath queries.
-     * @param pom POM
-     * @param xpaths Xpath queries
-     * @throws ValidationException validation exception
-     */
     private static void validate(final XML pom, final Iterable<String> xpaths)
         throws ValidationException {
         for (final String xpath : xpaths) {
@@ -59,11 +53,6 @@ public final class PomXpathValidator implements MavenValidator {
         }
     }
 
-    /**
-     * Parse pom.xml.
-     * @param env Environment
-     * @return XML instance
-     */
     private static XML pom(final Environment env) {
         try {
             return new XMLDocument(

--- a/src/main/java/com/qulice/maven/SnapshotsValidator.java
+++ b/src/main/java/com/qulice/maven/SnapshotsValidator.java
@@ -33,11 +33,6 @@ public final class SnapshotsValidator implements MavenValidator {
         }
     }
 
-    /**
-     * Check all plugins and deps.
-     * @param env Environment
-     * @throws ValidationException If fails
-     */
     private void check(final MavenEnvironment env) throws ValidationException {
         int errors = 0;
         for (final Extension ext : env.project().getBuildExtensions()) {
@@ -82,11 +77,6 @@ public final class SnapshotsValidator implements MavenValidator {
         }
     }
 
-    /**
-     * Whether this version is a snapshot?
-     * @param version The version
-     * @return TRUE if yes
-     */
     private static boolean isSnapshot(final String version) {
         return version.endsWith("-SNAPSHOT");
     }

--- a/src/main/java/com/qulice/maven/Summary.java
+++ b/src/main/java/com/qulice/maven/Summary.java
@@ -57,17 +57,6 @@ final class Summary {
         );
     }
 
-    /**
-     * How many rules each validator applies, by validator name, leaving
-     * out the ones that count none.
-     *
-     * <p>A module without a single file to read runs no validator at all,
-     * so nobody is asked to count: the counting itself is expensive, since
-     * it makes Checkstyle load its configuration and PMD resolve its
-     * ruleset.</p>
-     *
-     * @return Rule counts, in the order the validators ran
-     */
     private Map<String, Integer> counts() {
         final Map<String, Integer> counts =
             new LinkedHashMap<>(this.validators.size());
@@ -82,10 +71,6 @@ final class Summary {
         return counts;
     }
 
-    /**
-     * The Java files among them, counted and named.
-     * @return Text, e.g. {@code "42 .java files"}
-     */
     private String javas() {
         final long count = this.files.stream().filter(
             file -> file.getName().toLowerCase(Locale.ROOT).endsWith(".java")
@@ -99,12 +84,6 @@ final class Summary {
         return text;
     }
 
-    /**
-     * Spell the rule counts out, validator by validator.
-     * @param counts Rule counts by validator name
-     * @return Text in brackets, e.g. {@code " (253 Checkstyle, 132 PMD)"},
-     *  or empty when nobody counted anything
-     */
     private static String breakdown(final Map<String, Integer> counts) {
         final String text;
         if (counts.isEmpty()) {

--- a/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -93,10 +93,6 @@ final class SourceValidator {
         return total;
     }
 
-    /**
-     * The PMD configuration, with the Qulice ruleset in it.
-     * @return Configuration to run PMD with
-     */
     private PMDConfiguration configured() {
         this.config.setRuleSets(new ListOf<>("com/qulice/pmd/ruleset.xml"));
         this.config.setThreads(0);
@@ -107,21 +103,6 @@ final class SourceValidator {
         return this.config;
     }
 
-    /**
-     * Tells whether a processing error should be reported as a violation.
-     * Some PMD rules crash internally with an {@link IllegalStateException}
-     * while analyzing perfectly valid Java. For example {@code
-     * UseDiamondOperator} throws {@code "overload resolution is not
-     * complete"} when it probes an overloaded method reference such as
-     * {@code BigDecimal::multiply} (see #1686). PMD itself only logs such a
-     * crash as a warning and keeps going, so it is a bug in the tool, not a
-     * problem in the code under analysis. We do the same here: log it as a
-     * warning and do not turn it into a build-breaking violation, since the
-     * user cannot fix it in their code. The full stack trace is logged too,
-     * so the crash can still be diagnosed and reported upstream.
-     * @param error The processing error to inspect
-     * @return True if it must be reported, false if it is an internal crash
-     */
     private boolean reportable(final Report.ProcessingError error) {
         final boolean crash = SourceValidator.crashed(error.getError());
         if (crash) {
@@ -136,13 +117,6 @@ final class SourceValidator {
         return !crash;
     }
 
-    /**
-     * Tells whether a throwable is (or was caused by) an internal PMD rule
-     * crash, recognized by an {@link IllegalStateException} anywhere in its
-     * cause chain.
-     * @param error The throwable to inspect
-     * @return True if the cause chain contains an IllegalStateException
-     */
     private static boolean crashed(final Throwable error) {
         boolean crash = false;
         Throwable cause = error;
@@ -156,14 +130,6 @@ final class SourceValidator {
         return crash;
     }
 
-    /**
-     * Tells whether a violation reports a {@code @SuppressWarnings} that
-     * tries to suppress {@code PMD.UnnecessaryWarningSuppression} itself.
-     * The PMD rule cannot suppress its own violations, so suppressing it is
-     * effectively a no-op and must not be reported as unused.
-     * @param violation Violation to inspect
-     * @return True if the violation is self-referential
-     */
     private static boolean suppressesItself(final RuleViolation violation) {
         final String name = "UnnecessaryWarningSuppression";
         boolean result = false;

--- a/src/main/java/com/qulice/pmd/rules/ImplicitFunctionalInterfaceRule.java
+++ b/src/main/java/com/qulice/pmd/rules/ImplicitFunctionalInterfaceRule.java
@@ -53,26 +53,12 @@ public final class ImplicitFunctionalInterfaceRule
         return null;
     }
 
-    /**
-     * Tells whether the given type is an interface that could carry a
-     * {@code @FunctionalInterface} annotation but does not, ignoring sealed
-     * interfaces that cannot be functional at all.
-     * @param node The type declaration to inspect
-     * @return True if the interface is a candidate for the annotation
-     */
     private static boolean implicit(final ASTClassDeclaration node) {
         return node.isRegularInterface()
             && !node.isAnnotationPresent(FunctionalInterface.class)
             && !node.hasModifiers(JModifier.SEALED);
     }
 
-    /**
-     * Tells whether every super-interface in the whole hierarchy of the given
-     * type has been resolved by PMD. Only when they all resolve can the total
-     * number of inherited abstract methods be trusted.
-     * @param type The interface type to inspect
-     * @return True if the entire super-interface hierarchy is resolved
-     */
     private static boolean resolved(final JClassType type) {
         boolean result = true;
         for (final JClassType parent : type.getSuperInterfaces()) {

--- a/src/main/java/com/qulice/pmd/rules/UnitTestShouldIncludeAssertRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UnitTestShouldIncludeAssertRule.java
@@ -52,22 +52,11 @@ public final class UnitTestShouldIncludeAssertRule
         return data;
     }
 
-    /**
-     * Does this call look like a test assertion?
-     * @param call The method call to inspect
-     * @return True if it is a recognised assertion
-     */
     private static boolean isAssertion(final ASTMethodCall call) {
         return TestFrameworksUtil.isProbableAssertCall(call)
             || UnitTestShouldIncludeAssertRule.isAffirmCall(call);
     }
 
-    /**
-     * Is this a no-argument {@code affirm()} call on an {@code Assertion}
-     * object, as used by cactoos-matchers?
-     * @param call The method call to inspect
-     * @return True if it is a cactoos-matchers assertion
-     */
     private static boolean isAffirmCall(final ASTMethodCall call) {
         final ASTExpression qualifier = call.getQualifier();
         return "affirm".equals(call.getMethodName())
@@ -76,14 +65,6 @@ public final class UnitTestShouldIncludeAssertRule
             && UnitTestShouldIncludeAssertRule.isAssertion(qualifier);
     }
 
-    /**
-     * Is the given expression of a type named {@code Assertion}? The
-     * comparison is by simple name so that it still holds when
-     * cactoos-matchers is absent from the classpath and the type therefore
-     * cannot be fully resolved.
-     * @param expr The expression to inspect
-     * @return True if its type's simple name is {@code Assertion}
-     */
     private static boolean isAssertion(final ASTExpression expr) {
         final JTypeDeclSymbol symbol = expr.getTypeMirror().getSymbol();
         return symbol != null

--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
@@ -121,17 +121,6 @@ final class UnnecessaryLocalSkips {
         return found;
     }
 
-    /**
-     * A statement sits between the declaration and its use inside the block
-     * that encloses the declaration. The use is measured through its nearest
-     * ancestor statement in that common block, so a use buried in an {@code
-     * if} or loop body (whose immediate block differs from the declaration's)
-     * is still compared against the intervening statements rather than being
-     * treated as adjacent. See issue #1700.
-     * @param variable The variable declarator
-     * @param use The single use of the variable
-     * @return True if a statement intervenes between init and its use
-     */
     private static boolean intervenes(
         final ASTVariableDeclarator variable,
         final ASTVariableAccess use

--- a/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
@@ -47,14 +47,6 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
         return data;
     }
 
-    /**
-     * Is this an {@code isEmpty()}-equivalent comparison, assuming the
-     * {@code length()} call is the left operand and the literal is the right?
-     * @param operator The comparison operator
-     * @param length The candidate {@code String.length()} call
-     * @param literal The candidate numeric literal
-     * @return True if the comparison can be rewritten with {@code isEmpty()}
-     */
     private static boolean isEmptyEquivalent(
         final BinaryOp operator,
         final ASTExpression length,
@@ -63,14 +55,6 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
         return isStringLength(length) && isWhitelisted(operator, literal);
     }
 
-    /**
-     * Is the pair of operator and literal one of the six allowed
-     * {@code isEmpty()} equivalents ({@code == 0}, {@code != 0}, {@code > 0},
-     * {@code <= 0}, {@code < 1}, {@code >= 1})?
-     * @param operator The comparison operator
-     * @param literal The candidate numeric literal
-     * @return True if the pairing matches the whitelist
-     */
     private static boolean isWhitelisted(
         final BinaryOp operator,
         final ASTExpression literal
@@ -87,12 +71,6 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
         return result;
     }
 
-    /**
-     * Mirror an operator so a {@code literal OP length()} comparison can be
-     * evaluated as if {@code length()} were on the left.
-     * @param operator The operator as written
-     * @return The operator with its operands swapped
-     */
     private static BinaryOp mirror(final BinaryOp operator) {
         return switch (operator) {
             case GT -> BinaryOp.LT;
@@ -103,12 +81,6 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
         };
     }
 
-    /**
-     * Is the expression a no-argument {@code length()} call on a
-     * {@link String}?
-     * @param expr The expression to check
-     * @return True if it is a {@code String.length()} call
-     */
     private static boolean isStringLength(final ASTExpression expr) {
         boolean result = false;
         if (expr instanceof ASTMethodCall call && call.getQualifier() != null) {
@@ -119,11 +91,6 @@ public final class UseStringIsEmptyRule extends AbstractJavaRulechainRule {
         return result;
     }
 
-    /**
-     * Checks if the expression is of {@link String} type.
-     * @param expr The expression to check
-     * @return True if expression has {@link String} type
-     */
     private static boolean isStringExpression(final ASTExpression expr) {
         final JTypeMirror type = expr.getTypeMirror();
         return type.isClassOrInterface()

--- a/src/main/java/com/qulice/spi/Environment.java
+++ b/src/main/java/com/qulice/spi/Environment.java
@@ -343,10 +343,6 @@ public interface Environment {
             return StandardCharsets.UTF_8;
         }
 
-        /**
-         * Creates a fresh basedir in a temporary directory.
-         * @return The directory
-         */
         private static File temporary() {
             try {
                 final File temp = Files.createTempDirectory("mock-qulice").toFile();
@@ -363,11 +359,6 @@ public interface Environment {
             }
         }
 
-        /**
-         * Creates the directory of compiled classes for the given basedir.
-         * @param base The basedir
-         * @return Paths to put on the classpath
-         */
         private static Set<String> outputs(final File base) {
             final File out = new File(base, "target/classes");
             if (!out.mkdirs() && !out.isDirectory()) {

--- a/src/main/java/com/qulice/spi/Violation.java
+++ b/src/main/java/com/qulice/spi/Violation.java
@@ -136,13 +136,6 @@ public interface Violation extends Comparable<Violation> {
             return Default.ORDER.compare(this, other);
         }
 
-        /**
-         * Numeric line number, or {@link Integer#MAX_VALUE} when the
-         * field cannot be parsed as a single integer (e.g. a range like
-         * {@code "10-12"}). Numeric ordering keeps line 9 before line 42.
-         * @param violation The violation to inspect
-         * @return Parsed line number, or {@code MAX_VALUE} as a fallback
-         */
         private static int lineNumber(final Violation violation) {
             int parsed;
             try {

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -461,6 +461,7 @@
     </module>
     <module name="com.qulice.checkstyle.MultilineJavadocTagsCheck"/>
     <module name="com.qulice.checkstyle.NoJavadocForOverriddenMethodsCheck"/>
+    <module name="com.qulice.checkstyle.NoJavadocForPrivateMethodsCheck"/>
     <module name="com.qulice.checkstyle.MethodBodyCommentsCheck"/>
     <module name="com.qulice.checkstyle.MethodsOrderCheck"/>
     <module name="com.qulice.checkstyle.ConstructorsOrderCheck"/>

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -100,13 +100,6 @@ final class ChecksTest {
         );
     }
 
-    /**
-     * Check one file.
-     * @param dir Directory where test scripts are located
-     * @param name The name of the check
-     * @param listener The listener
-     * @throws Exception If something goes wrong inside
-     */
     private void run(
         final String dir, final String name, final AuditListener listener
     ) throws Exception {
@@ -138,30 +131,14 @@ final class ChecksTest {
         checker.destroy();
     }
 
-    /**
-     * Arguments stream of (dir, InvalidXxx.java) pairs for all checks.
-     * @return Stream of Arguments
-     */
     private static Stream<Arguments> invalids() {
         return ChecksTest.checks().flatMap(dir -> ChecksTest.files(dir, "Invalid"));
     }
 
-    /**
-     * Arguments stream of (dir, ValidXxx.java) pairs for all checks.
-     * @return Stream of Arguments
-     */
     private static Stream<Arguments> valids() {
         return ChecksTest.checks().flatMap(dir -> ChecksTest.files(dir, "Valid"));
     }
 
-    /**
-     * Find all files in the given resource directory whose name is
-     * either {@code prefix.java} or starts with {@code prefix-} and
-     * ends with {@code .java}.
-     * @param dir Resource directory (e.g. {@code ChecksTest/FooCheck})
-     * @param prefix File prefix (e.g. {@code Invalid} or {@code Valid})
-     * @return Stream of (dir, fileName) Arguments
-     */
     private static Stream<Arguments> files(
         final String dir, final String prefix
     ) {
@@ -189,10 +166,6 @@ final class ChecksTest {
         return result;
     }
 
-    /**
-     * Returns full list of checks.
-     * @return The list
-     */
     private static Stream<String> checks() {
         return Stream.of(
             "MethodsOrderCheck",
@@ -236,6 +209,7 @@ final class ChecksTest {
             "SimpleStringSplitCheck",
             "ProhibitFieldsInTestClassesCheck",
             "ProhibitStaticNestedClassesCheck",
+            "NoJavadocForPrivateMethodsCheck",
             "ParameterNumberCheck"
         ).map(s -> String.format("ChecksTest/%s", s));
     }

--- a/src/test/java/com/qulice/checkstyle/CheckstyleTextFileTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleTextFileTest.java
@@ -154,14 +154,6 @@ final class CheckstyleTextFileTest {
         );
     }
 
-    /**
-     * Runs Checkstyle validation over a file whose content is supplied
-     * in-place (as opposed to loaded from a resource).
-     * @param file Name of the file to check
-     * @param content Bytes to write as the file content
-     * @return Violations reported by the validator
-     * @throws IOException If some IO problem
-     */
     private Collection<Violation> runValidationWithContent(final String file,
         final String content) throws IOException {
         final Environment.Mock mock = new Environment.Mock();

--- a/src/test/java/com/qulice/checkstyle/CheckstyleUseEnhancedSwitchTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleUseEnhancedSwitchTest.java
@@ -98,12 +98,6 @@ final class CheckstyleUseEnhancedSwitchTest {
         );
     }
 
-    /**
-     * Run the validator over the sample file with the given source level.
-     * @param source Value for {@code maven.compiler.source}, or {@code null}
-     * @return Collection of violations
-     * @throws IOException If some IO problem
-     */
     private Collection<Violation> runValidation(final String source)
         throws IOException {
         final Environment.Mock mock = new Environment.Mock();

--- a/src/test/java/com/qulice/checkstyle/License.java
+++ b/src/test/java/com/qulice/checkstyle/License.java
@@ -97,11 +97,6 @@ public final class License {
         return license;
     }
 
-    /**
-     * Save package-info.java to the directory.
-     * @param dir The directory
-     * @throws IOException If something wrong happens inside
-     */
     private void makePackageInfo(final File dir) throws IOException {
         final StringBuilder body = new StringBuilder(100);
         body.append("/*").append(this.eol);

--- a/src/test/java/com/qulice/checkstyle/ViolationMatcher.java
+++ b/src/test/java/com/qulice/checkstyle/ViolationMatcher.java
@@ -74,21 +74,11 @@ final class ViolationMatcher extends TypeSafeMatcher<Violation> {
         description.appendText("doesn't match");
     }
 
-    /**
-     * Check name matches.
-     * @param item Item to check
-     * @return True if check name matches
-     */
     private boolean checkMatches(final Violation item) {
         return this.check.isEmpty()
             || !this.check.isEmpty() && item.name().equals(this.check);
     }
 
-    /**
-     * Check that given line matches.
-     * @param item Item to check
-     * @return True if line matches
-     */
     private boolean lineMatches(final Violation item) {
         return this.line.isEmpty()
             || !this.line.isEmpty() && item.lines().equals(this.line);

--- a/src/test/java/com/qulice/errorprone/ErrorPronePatternMatchingInstanceofTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorPronePatternMatchingInstanceofTest.java
@@ -85,13 +85,6 @@ final class ErrorPronePatternMatchingInstanceofTest {
         );
     }
 
-    /**
-     * Run the validator over the sample file with the given source level and
-     * return the names of the checks that produced violations.
-     * @param source Value for {@code maven.compiler.source}, or {@code null}
-     * @return Names of the checks that fired
-     * @throws IOException If some IO problem
-     */
     private Collection<String> checks(final String source) throws IOException {
         final Environment.Mock mock = new Environment.Mock();
         if (source != null) {

--- a/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
@@ -442,12 +442,6 @@ final class ErrorProneValidatorTest {
         );
     }
 
-    /**
-     * A class that every Java compiler accepts, no matter how old the
-     * source level it is pinned to.
-     * @param name Name of the class
-     * @return Its source code
-     */
     private static String ancient(final String name) {
         return String.join(
             System.lineSeparator(),
@@ -462,12 +456,6 @@ final class ErrorProneValidatorTest {
         );
     }
 
-    /**
-     * A class that only a Java 15 or newer compiler accepts, since it
-     * holds a text block.
-     * @param name Name of the class
-     * @return Its source code
-     */
     private static String modern(final String name) {
         return String.join(
             System.lineSeparator(),

--- a/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -313,12 +313,6 @@ final class DependenciesValidatorTest {
         );
     }
 
-    /**
-     * Build a MavenEnvironment wired with a given dependency analysis.
-     * @param analysis Dependency analysis to inject
-     * @return Wired environment
-     * @throws Exception If something wrong happens inside
-     */
     private static MavenEnvironment envWith(
         final ProjectDependencyAnalysis analysis
     ) throws Exception {
@@ -329,15 +323,6 @@ final class DependenciesValidatorTest {
         ).mock();
     }
 
-    /**
-     * Build a MavenEnvironment where exactly one artifact is reported as
-     * "unused declared" and the given source root is part of the project.
-     * @param src Directory containing Java sources
-     * @param jar JAR file to attach to the artifact
-     * @param coord Artifact coordinate in the form {@code groupId:artifactId}
-     * @return Wired environment
-     * @throws Exception If something wrong happens inside
-     */
     private static MavenEnvironment envWithUnused(final Path src,
         final File jar, final String coord) throws Exception {
         final String[] parts = coord.split(":");
@@ -359,14 +344,6 @@ final class DependenciesValidatorTest {
         return env;
     }
 
-    /**
-     * Create a JAR file at the given path containing the given class entries.
-     * @param dir Parent directory
-     * @param name JAR file name
-     * @param entries Names of class entries to include
-     * @return The created JAR file
-     * @throws Exception If something wrong happens inside
-     */
     private static File jar(final Path dir, final String name,
         final String... entries) throws Exception {
         final File jar = dir.resolve(name).toFile();
@@ -384,25 +361,12 @@ final class DependenciesValidatorTest {
         return jar;
     }
 
-    /**
-     * Create a compile source root directory under the given temp dir.
-     * @param dir Temporary directory
-     * @return Created source root
-     * @throws Exception If something wrong happens inside
-     */
     private static Path sourceRoot(final Path dir) throws Exception {
         final Path src = dir.resolve("src").resolve("main").resolve("java");
         Files.createDirectories(src);
         return src;
     }
 
-    /**
-     * Write the given Java source file under the source root.
-     * @param src Source root
-     * @param path Relative path for the source file
-     * @param content File content
-     * @throws Exception If something wrong happens inside
-     */
     private static void writeJava(final Path src, final String path,
         final String content) throws Exception {
         final Path target = src.resolve(path);

--- a/src/test/java/com/qulice/maven/ValidationExclusionTest.java
+++ b/src/test/java/com/qulice/maven/ValidationExclusionTest.java
@@ -149,13 +149,6 @@ final class ValidationExclusionTest {
         );
     }
 
-    /**
-     * Create a temporary Java file from resource.
-     * @param dir Directory to create the file in
-     * @param resource Resource to read the content from
-     * @return Created file with content from resource
-     * @throws Exception If something goes wrong
-     */
     private static File java(final Path dir, final String resource) throws Exception {
         final File file = File.createTempFile(
             "Test", ValidationExclusionTest.JAVA_EXT, dir.toFile()

--- a/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
@@ -86,12 +86,6 @@ final class UseStringIsEmptyRuleTest {
         ).assertOk();
     }
 
-    /**
-     * Constructs StringContains matcher for error message.
-     * @param file File name
-     * @param line Line number
-     * @return StringContains matcher
-     */
     private static Matcher<String> containsMatcher(
         final String file, final int line
     ) {

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/Invalid-Annotated.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/Invalid-Annotated.java
@@ -1,0 +1,14 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class InvalidAnnotated {
+    /**
+     * Read the value.
+     * @return The value
+     */
+    @Deprecated
+    private int value() {
+        return 1;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/Invalid.java
@@ -1,0 +1,25 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class Invalid {
+    /**
+     * Calculate the sum.
+     * @param left Left operand
+     * @param right Right operand
+     * @return The sum
+     */
+    private int sum(final int left, final int right) {
+        return left + right;
+    }
+
+    /**
+     * Calculate the difference.
+     * @param left Left operand
+     * @param right Right operand
+     * @return The difference
+     */
+    private static int diff(final int left, final int right) {
+        return left - right;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/Valid.java
@@ -1,0 +1,32 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class Valid {
+    /**
+     * Ctor.
+     * @param num The number
+     */
+    private Valid(final int num) {
+        // nothing to do
+    }
+
+    /**
+     * Calculate the sum.
+     * @param left Left operand
+     * @param right Right operand
+     * @return The sum
+     */
+    public int sum(final int left, final int right) {
+        return this.diff(left, right);
+    }
+
+    private int diff(final int left, final int right) {
+        return left - right;
+    }
+
+    private static int mul(final int left, final int right) {
+        // A private static method needs no Javadoc.
+        return left * right;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.NoJavadocForPrivateMethodsCheck"/>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/violations-Annotated.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/violations-Annotated.txt
@@ -1,0 +1,1 @@
+11:Private method "value" must not have Javadoc

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/NoJavadocForPrivateMethodsCheck/violations.txt
@@ -1,0 +1,2 @@
+12:Private method "sum" must not have Javadoc
+22:Private method "diff" must not have Javadoc

--- a/src/test/resources/com/qulice/checkstyle/InstanceMethodRef.java
+++ b/src/test/resources/com/qulice/checkstyle/InstanceMethodRef.java
@@ -8,18 +8,11 @@ package foo;
  */
 public final class InstanceMethodRef {
 
-    /**
-     * Start. Check fails in this method.
-     */
     private void start() {
         Collections.singletonList("1")
             .forEach(this::doSomething);
     }
 
-    /**
-     * Method to be referenced.
-     * @param value Value to print
-     */
     private static void doSomething(final String value) {
         System.out.println(value);
     }

--- a/src/test/resources/com/qulice/checkstyle/PrivateFourParameters.java
+++ b/src/test/resources/com/qulice/checkstyle/PrivateFourParameters.java
@@ -30,14 +30,6 @@ public final class PrivateFourParameters {
         return this.sum(1, 2, 3, 4);
     }
 
-    /**
-     * Sum of all numbers and the base.
-     * @param one First number
-     * @param two Second number
-     * @param three Third number
-     * @param four Fourth number
-     * @return The sum
-     */
     private int sum(final int one, final int two, final int three, final int four) {
         return this.base + one + two + three + four;
     }


### PR DESCRIPTION
Closes #1774

A private method is an implementation detail of its own class. It has no
external users, so a Javadoc block above it documents nothing that the method
name, its parameters and its body do not already say, and it rots in place once
the method is renamed or its contract changes.

Neither Checkstyle nor PMD ships an inverse of `MissingJavadocMethod` (that one
only demands Javadoc for `public` scope and never objects to a private method
that has one), so this needed a custom check.

## What changed

* New `NoJavadocForPrivateMethodsCheck`, which visits `METHOD_DEF` and reports
  a Javadoc block placed above any method carrying `LITERAL_PRIVATE` — static
  and non-static alike, including private methods of interfaces. The violation
  is logged at the method's identifier, so an annotated method is flagged on
  its declaration line rather than on the annotation.
* Private constructors are deliberately untouched: a `CTOR_DEF` is not a
  `METHOD_DEF`, and a private constructor's Javadoc is often the only place
  where the "do not instantiate" intent lives.
* The check is enabled in `checks.xml`, next to
  `NoJavadocForOverriddenMethodsCheck`.
* `ChecksTest` fixtures: `Invalid.java` (private and private-static method),
  `Invalid-Annotated.java` (Javadoc above an annotated private method),
  `Valid.java` (private constructor with Javadoc, plus undocumented private and
  private-static methods) and the matching `violations*.txt`.
* Enabling the check against Qulice's own sources meant stripping the Javadoc
  from the 307 private methods that carried one, in `src/main/java` and
  `src/test/java`, plus the two `src/test/resources` fixtures that are run
  through the full `checks.xml` by `CheckstyleParameterNumberTest` and
  `CheckstyleValidatorTest`.

## Verification

* `mvn test` — 479 tests, 0 failures.
* `mvn install -DskipTests -DskipITs` followed by
  `mvn verify -Pqulice -DskipTests -DskipITs` — BUILD SUCCESS, i.e. Qulice's own
  sources pass with the new check switched on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVopiUqGpt9NT61LZBQCSz)_