### PR TITLE
fix(pmd): #1775 move ExcessiveParameterList and TooManyFields exemptions into custom rules

### DIFF
--- a/src/main/java/com/qulice/pmd/rules/ExcessiveParameterListRule.java
+++ b/src/main/java/com/qulice/pmd/rules/ExcessiveParameterListRule.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd.rules;
+
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+
+/**
+ * Rule to check that a method does not take too many parameters. Unlike the
+ * PMD built-in {@code ExcessiveParameterList} rule, which exempts private
+ * constructors only, this implementation skips every constructor: a value
+ * object with many immutable attributes gets a parameter count that tracks
+ * its field count rather than its complexity, and the class has nowhere
+ * else to accept those attributes. The rule stays active for methods,
+ * where a long parameter list is a design smell worth reporting.
+ * Skipping constructors here instead of through a
+ * {@code violationSuppressXPath} keeps a redundant
+ * {@code @SuppressWarnings("PMD.ExcessiveParameterList")} visible to
+ * {@code UnnecessaryWarningSuppression}, which PMD credits to the
+ * annotation whenever the annotation suppressor runs first.
+ * @since 1.0
+ */
+public final class ExcessiveParameterListRule
+    extends AbstractJavaRulechainRule {
+
+    /**
+     * The number of parameters at or above which a method is reported.
+     */
+    private static final int THRESHOLD = 10;
+
+    /**
+     * Default constructor.
+     */
+    public ExcessiveParameterListRule() {
+        super(ASTFormalParameters.class);
+    }
+
+    @Override
+    public Object visit(final ASTFormalParameters params, final Object data) {
+        final int count = params.size();
+        if (count >= ExcessiveParameterListRule.THRESHOLD
+            && !(params.getParent() instanceof ASTConstructorDeclaration)) {
+            this.asCtx(data).addViolation(
+                params, count, ExcessiveParameterListRule.THRESHOLD
+            );
+        }
+        return data;
+    }
+}

--- a/src/main/java/com/qulice/pmd/rules/NamedSupertype.java
+++ b/src/main/java/com/qulice/pmd/rules/NamedSupertype.java
@@ -45,36 +45,18 @@ final class NamedSupertype {
                 || this.imported(clause.getRoot()));
     }
 
-    /**
-     * Simple name of the type.
-     * @return Name without the package
-     */
     private String simple() {
         return this.canonical.substring(this.canonical.lastIndexOf('.') + 1);
     }
 
-    /**
-     * Package of the type.
-     * @return Name without the simple name
-     */
     private String pack() {
         return this.canonical.substring(0, this.canonical.lastIndexOf('.'));
     }
 
-    /**
-     * Does the given file import this type?
-     * @param unit File being analyzed
-     * @return TRUE if the type is imported, directly or on demand
-     */
     private boolean imported(final ASTCompilationUnit unit) {
         return unit.children(ASTImportDeclaration.class).any(this::brings);
     }
 
-    /**
-     * Does the given import bring this type in?
-     * @param imported Import declaration
-     * @return TRUE if the import names this type or its package
-     */
     private boolean brings(final ASTImportDeclaration imported) {
         return this.canonical.equals(imported.getImportedName())
             || imported.isImportOnDemand()

--- a/src/main/java/com/qulice/pmd/rules/NamedSupertype.java
+++ b/src/main/java/com/qulice/pmd/rules/NamedSupertype.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd.rules;
+
+import net.sourceforge.pmd.lang.java.ast.ASTClassType;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
+
+/**
+ * A supertype recognised by the name it is given in an {@code extends} or
+ * an {@code implements} clause. Qulice runs PMD without an auxiliary
+ * classpath, so a supertype that lives outside the file being analyzed
+ * never resolves to a type and only the name written in the clause is
+ * available. That name is trusted when it is fully qualified, or when the
+ * file imports the type, either directly or on demand from its package.
+ * @since 1.0
+ */
+final class NamedSupertype {
+
+    /**
+     * Canonical name of the type, e.g. {@code com.sun.jna.Library}.
+     */
+    private final String canonical;
+
+    /**
+     * Constructor.
+     * @param name Canonical name of the type
+     */
+    NamedSupertype(final String name) {
+        this.canonical = name;
+    }
+
+    /**
+     * Does the given clause name this very type?
+     * @param clause Type named in an extends or implements clause,
+     *  may be NULL when the clause is absent
+     * @return TRUE if the clause names this type
+     */
+    boolean matches(final ASTClassType clause) {
+        return clause != null
+            && this.simple().equals(clause.getSimpleName())
+            && (this.pack().equals(clause.getPackageQualifier())
+                || this.imported(clause.getRoot()));
+    }
+
+    /**
+     * Simple name of the type.
+     * @return Name without the package
+     */
+    private String simple() {
+        return this.canonical.substring(this.canonical.lastIndexOf('.') + 1);
+    }
+
+    /**
+     * Package of the type.
+     * @return Name without the simple name
+     */
+    private String pack() {
+        return this.canonical.substring(0, this.canonical.lastIndexOf('.'));
+    }
+
+    /**
+     * Does the given file import this type?
+     * @param unit File being analyzed
+     * @return TRUE if the type is imported, directly or on demand
+     */
+    private boolean imported(final ASTCompilationUnit unit) {
+        return unit.children(ASTImportDeclaration.class).any(this::brings);
+    }
+
+    /**
+     * Does the given import bring this type in?
+     * @param imported Import declaration
+     * @return TRUE if the import names this type or its package
+     */
+    private boolean brings(final ASTImportDeclaration imported) {
+        return this.canonical.equals(imported.getImportedName())
+            || imported.isImportOnDemand()
+            && this.pack().equals(imported.getImportedName());
+    }
+}

--- a/src/main/java/com/qulice/pmd/rules/TooManyFieldsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyFieldsRule.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd.rules;
+
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.JModifier;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+
+/**
+ * Rule to check that a class does not declare too many fields. Like the PMD
+ * built-in {@code TooManyFields} rule, this implementation counts the
+ * fields declared in the body of the class, skipping the static and the
+ * final ones, since those are constants rather than state. Unlike the
+ * built-in rule, it skips a class that extends
+ * {@code org.apache.maven.plugin.AbstractMojo}: a Maven Mojo declares one
+ * field per {@code @Parameter} it exposes to users of the plugin goal,
+ * because the Maven Plugin API requires each configurable parameter as a
+ * directly annotated field on the Mojo, so that count tracks the number of
+ * options the goal accepts rather than the cohesion of the class.
+ * Skipping them here instead of through a
+ * {@code violationSuppressXPath} keeps a redundant
+ * {@code @SuppressWarnings("PMD.TooManyFields")} visible to
+ * {@code UnnecessaryWarningSuppression}, which PMD credits to the
+ * annotation whenever the annotation suppressor runs first.
+ * @since 1.0
+ */
+public final class TooManyFieldsRule extends AbstractJavaRulechainRule {
+
+    /**
+     * The largest number of non-static non-final fields a class may declare.
+     */
+    private static final int MAX = 15;
+
+    /**
+     * The base class of every Maven Mojo.
+     */
+    private static final NamedSupertype MOJO = new NamedSupertype(
+        "org.apache.maven.plugin.AbstractMojo"
+    );
+
+    /**
+     * Default constructor.
+     */
+    public TooManyFieldsRule() {
+        super(ASTClassDeclaration.class);
+    }
+
+    @Override
+    public Object visit(final ASTClassDeclaration type, final Object data) {
+        if (!TooManyFieldsRule.MOJO.matches(type.getSuperClassTypeNode())
+            && TooManyFieldsRule.state(type) > TooManyFieldsRule.MAX) {
+            this.asCtx(data).addViolation(type);
+        }
+        return data;
+    }
+
+    /**
+     * How many fields does this class use to keep its state?
+     * @param type Class to inspect
+     * @return Number of non-static non-final fields in the class body
+     */
+    private static long state(final ASTClassDeclaration type) {
+        return type.getDeclarations(ASTFieldDeclaration.class)
+            .filter(TooManyFieldsRule::mutable)
+            .count();
+    }
+
+    /**
+     * Is this field a part of the state of its class?
+     * @param field Field to inspect
+     * @return TRUE if the field is neither static nor final
+     */
+    private static boolean mutable(final ASTFieldDeclaration field) {
+        return !field.hasModifiers(JModifier.FINAL)
+            && !field.hasModifiers(JModifier.STATIC);
+    }
+}

--- a/src/main/java/com/qulice/pmd/rules/TooManyFieldsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyFieldsRule.java
@@ -57,22 +57,12 @@ public final class TooManyFieldsRule extends AbstractJavaRulechainRule {
         return data;
     }
 
-    /**
-     * How many fields does this class use to keep its state?
-     * @param type Class to inspect
-     * @return Number of non-static non-final fields in the class body
-     */
     private static long state(final ASTClassDeclaration type) {
         return type.getDeclarations(ASTFieldDeclaration.class)
             .filter(TooManyFieldsRule::mutable)
             .count();
     }
 
-    /**
-     * Is this field a part of the state of its class?
-     * @param field Field to inspect
-     * @return TRUE if the field is neither static nor final
-     */
     private static boolean mutable(final ASTFieldDeclaration field) {
         return !field.hasModifiers(JModifier.FINAL)
             && !field.hasModifiers(JModifier.STATIC);

--- a/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
@@ -5,12 +5,11 @@
 package com.qulice.pmd.rules;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassType;
-import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
-import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
@@ -45,12 +44,11 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
     private static final int MAX = 10;
 
     /**
-     * Canonical names of the JNA interfaces that mark a type as a native
-     * binding.
+     * The JNA interfaces that mark a type as a native binding.
      */
-    private static final Collection<String> LIBRARIES = Set.of(
-        "com.sun.jna.Library",
-        "com.sun.jna.win32.StdCallLibrary"
+    private static final Collection<NamedSupertype> LIBRARIES = List.of(
+        new NamedSupertype("com.sun.jna.Library"),
+        new NamedSupertype("com.sun.jna.win32.StdCallLibrary")
     );
 
     /**
@@ -112,35 +110,8 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
 
     private static boolean jna(final ASTClassType parent) {
         return TooManyMethodsRule.LIBRARIES.stream().anyMatch(
-            known -> TooManyMethodsRule.simple(known)
-                .equals(parent.getSimpleName())
-                && (TooManyMethodsRule.pack(known)
-                    .equals(parent.getPackageQualifier())
-                    || TooManyMethodsRule.imported(parent.getRoot(), known))
+            known -> known.matches(parent)
         );
-    }
-
-    private static boolean imported(
-        final ASTCompilationUnit unit, final String known) {
-        return unit.children(ASTImportDeclaration.class).any(
-            imported -> TooManyMethodsRule.brings(imported, known)
-        );
-    }
-
-    private static boolean brings(
-        final ASTImportDeclaration imported, final String known) {
-        return known.equals(imported.getImportedName())
-            || imported.isImportOnDemand()
-            && TooManyMethodsRule.pack(known)
-                .equals(imported.getImportedName());
-    }
-
-    private static String simple(final String known) {
-        return known.substring(known.lastIndexOf('.') + 1);
-    }
-
-    private static String pack(final String known) {
-        return known.substring(0, known.lastIndexOf('.'));
     }
 
     private static boolean tested(final ASTClassDeclaration type) {

--- a/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -395,62 +395,36 @@
     -->
     <exclude name="ExceptionAsFlowControl"/>
     <!--
-    ExcessiveParameterList is excluded from the bulk import here and
-    re-enabled below with a violationSuppressXPath that ignores
-    constructors. The rule only special-cases private constructors, so a
-    public value object with many immutable attributes gets blamed for a
-    parameter count that tracks its field count, not its complexity; the
-    rule stays active for methods, where a long parameter list is a
-    design smell worth reporting.
+    ExcessiveParameterList is excluded because it only special-cases
+    private constructors, so a public value object with many immutable
+    attributes gets blamed for a parameter count that tracks its field
+    count, not its complexity. Exempting constructors through a
+    violationSuppressXPath is not an option: PMD consults the
+    @SuppressWarnings suppressor before the XPath one, so a redundant
+    @SuppressWarnings("PMD.ExcessiveParameterList") on a constructor is
+    credited with the suppression and never reported by
+    UnnecessaryWarningSuppression. We use our own
+    ExcessiveParameterListRule instead, which skips every constructor and
+    stays active for methods, where a long parameter list is a design
+    smell worth reporting.
     Downstream: https://github.com/yegor256/qulice/issues/1763
+    Downstream: https://github.com/yegor256/qulice/issues/1775
     -->
     <exclude name="ExcessiveParameterList"/>
     <!--
-    TooManyFields is re-enabled below with a violationSuppressXPath that
-    ignores classes extending org.apache.maven.plugin.AbstractMojo.
+    TooManyFields is excluded because it counts the fields of a Maven
+    Mojo, which declares one field per @Parameter it exposes to users of
+    the plugin goal. Exempting such classes through a
+    violationSuppressXPath is not an option either, for the same reason
+    as above: a redundant @SuppressWarnings("PMD.TooManyFields") on a
+    Mojo would be credited with the suppression and never reported by
+    UnnecessaryWarningSuppression. We use our own TooManyFieldsRule
+    instead, which skips classes extending
+    org.apache.maven.plugin.AbstractMojo.
     Downstream: https://github.com/yegor256/qulice/issues/1767
+    Downstream: https://github.com/yegor256/qulice/issues/1775
     -->
     <exclude name="TooManyFields"/>
-  </rule>
-  <rule ref="category/java/design.xml/ExcessiveParameterList">
-    <properties>
-      <property name="violationSuppressXPath" value=".[parent::ConstructorDeclaration]"/>
-    </properties>
-  </rule>
-  <!--
-  TooManyFields asks a class to keep few fields, but a Maven Mojo
-  declares one field per @Parameter it exposes to users of the plugin
-  goal, since the Maven Plugin API requires each configurable parameter
-  as a directly annotated field on the Mojo. That count tracks the
-  number of options the goal accepts, not the cohesion of the class, so
-  the suppression below skips classes extending
-  org.apache.maven.plugin.AbstractMojo. Qulice runs PMD without an
-  auxiliary classpath, so the superclass never resolves to a type and
-  the name in the extends clause is trusted only when it is fully
-  qualified or when the file imports it from its own package.
-  Downstream: https://github.com/yegor256/qulice/issues/1767
-  -->
-  <rule ref="category/java/design.xml/TooManyFields">
-    <properties>
-      <property name="violationSuppressXPath">
-        <value><![CDATA[
-          .[
-            ExtendsList
-              /ClassType[
-                @SimpleName = 'AbstractMojo'
-                and (
-                  @PackageQualifier = 'org.apache.maven.plugin'
-                  or ancestor::CompilationUnit
-                    /ImportDeclaration[
-                      @ImportedName = 'org.apache.maven.plugin.AbstractMojo'
-                      or @ImportedName = 'org.apache.maven.plugin'
-                    ]
-                )
-              ]
-          ]
-        ]]></value>
-      </property>
-    </properties>
   </rule>
   <rule ref="category/java/documentation.xml">
     <!--
@@ -628,6 +602,32 @@
       their method count beyond any useful threshold. Types that extend
       com.sun.jna.Library are skipped too, since they mirror a native
       library method by method.
+    </description>
+    <priority>3</priority>
+  </rule>
+  <rule name="ExcessiveParameterList" message="Avoid long parameter lists ({0} parameters - threshold is {1})." language="java" class="com.qulice.pmd.rules.ExcessiveParameterListRule">
+    <description>
+      Methods with numerous parameters are a challenge to maintain and
+      increase the risk of bugs, since callers have to match arguments to
+      parameters by position. Unlike PMD's ExcessiveParameterList rule,
+      which exempts private constructors only, this variant skips every
+      constructor: a value object with many immutable attributes gets a
+      parameter count that tracks its field count rather than its
+      complexity, and it has nowhere else to accept those attributes.
+    </description>
+    <priority>3</priority>
+  </rule>
+  <rule name="TooManyFields" message="Too many fields" language="java" class="com.qulice.pmd.rules.TooManyFieldsRule">
+    <description>
+      Classes that have too many fields can become unwieldy and could be
+      redesigned to have fewer fields, possibly through grouping related
+      fields in new objects. Like PMD's TooManyFields rule, this variant
+      counts the fields declared in the body of the class and skips the
+      static and the final ones, since those are constants rather than
+      state. Unlike it, classes extending
+      org.apache.maven.plugin.AbstractMojo are not checked at all, since a
+      Maven Mojo declares one field per @Parameter it exposes to users of
+      the plugin goal.
     </description>
     <priority>3</priority>
   </rule>

--- a/src/test/java/com/qulice/pmd/PmdExcessiveParameterListTest.java
+++ b/src/test/java/com/qulice/pmd/PmdExcessiveParameterListTest.java
@@ -4,60 +4,63 @@
  */
 package com.qulice.pmd;
 
-import com.qulice.spi.Environment;
-import com.qulice.spi.Violation;
-import java.io.File;
-import java.util.Collections;
-import java.util.stream.Collectors;
-import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for ExcessiveParameterList rule wiring in qulice ruleset.
- * The rule is suppressed on constructors but stays active on methods.
+ * Test case for {@link PmdValidator}'s handling of the
+ * {@code ExcessiveParameterList} rule, which skips constructors but stays
+ * active on methods, and which lets
+ * {@code UnnecessaryWarningSuppression} report a suppression left on a
+ * constructor.
+ * Regression test for https://github.com/yegor256/qulice/issues/1763
+ * and https://github.com/yegor256/qulice/issues/1775
  * @since 1.0
  */
 final class PmdExcessiveParameterListTest {
 
     @Test
     void doesNotFireOnConstructorWithManyParameters() throws Exception {
-        final String file = "ExcessiveParameterListInConstructor.java";
-        final Environment.Mock mock = new Environment.Mock();
-        final String name = String.format("src/main/java/foo/%s", file);
-        final Environment env = mock.withFile(
-            name,
-            new TextOf(
-                this.getClass().getResourceAsStream(file)
-            ).asString()
-        );
-        MatcherAssert.assertThat(
-            "ExcessiveParameterList must not fire on a constructor with many parameters",
-            new PmdValidator(env).validate(
-                Collections.singletonList(new File(env.basedir(), name))
-            ).stream().map(Violation::name).collect(Collectors.toList()),
-            Matchers.not(Matchers.hasItem("ExcessiveParameterList"))
-        );
+        new PmdAssert(
+            "ExcessiveParameterListInConstructor.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("(ExcessiveParameterList)")
+            )
+        ).assertOk();
     }
 
     @Test
     void firesOnMethodWithManyParameters() throws Exception {
-        final String file = "ExcessiveParameterListInMethod.java";
-        final Environment.Mock mock = new Environment.Mock();
-        final String name = String.format("src/main/java/foo/%s", file);
-        final Environment env = mock.withFile(
-            name,
-            new TextOf(
-                this.getClass().getResourceAsStream(file)
-            ).asString()
-        );
-        MatcherAssert.assertThat(
-            "ExcessiveParameterList must fire on a method with many parameters",
-            new PmdValidator(env).validate(
-                Collections.singletonList(new File(env.basedir(), name))
-            ).stream().map(Violation::name).collect(Collectors.toList()),
-            Matchers.hasItem("ExcessiveParameterList")
-        );
+        new PmdAssert(
+            "ExcessiveParameterListInMethod.java",
+            Matchers.is(false),
+            Matchers.containsString("(ExcessiveParameterList)")
+        ).assertOk();
+    }
+
+    @Test
+    void reportsRedundantSuppressionOnConstructor() throws Exception {
+        new PmdAssert(
+            "ExcessiveParameterListSuppressedInConstructor.java",
+            Matchers.is(false),
+            Matchers.containsString("(UnnecessaryWarningSuppression)")
+        ).assertOk();
+    }
+
+    @Test
+    void honoursSuppressionOnMethod() throws Exception {
+        new PmdAssert(
+            "ExcessiveParameterListSuppressedInMethod.java",
+            Matchers.any(Boolean.class),
+            Matchers.allOf(
+                Matchers.not(
+                    Matchers.containsString("(ExcessiveParameterList)")
+                ),
+                Matchers.not(
+                    Matchers.containsString("(UnnecessaryWarningSuppression)")
+                )
+            )
+        ).assertOk();
     }
 }

--- a/src/test/java/com/qulice/pmd/PmdTooManyFieldsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyFieldsTest.java
@@ -4,61 +4,72 @@
  */
 package com.qulice.pmd;
 
-import com.qulice.spi.Environment;
-import com.qulice.spi.Violation;
-import java.io.File;
-import java.util.Collections;
-import java.util.stream.Collectors;
-import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for TooManyFields rule wiring in qulice ruleset.
- * The rule is suppressed on classes extending AbstractMojo but stays
- * active on plain classes.
+ * Test case for {@link PmdValidator}'s handling of the
+ * {@code TooManyFields} rule, which skips classes extending
+ * {@code AbstractMojo} but stays active on plain classes, and which lets
+ * {@code UnnecessaryWarningSuppression} report a suppression left on a
+ * Mojo.
+ * Regression test for https://github.com/yegor256/qulice/issues/1767
+ * and https://github.com/yegor256/qulice/issues/1775
  * @since 1.0
  */
 final class PmdTooManyFieldsTest {
 
     @Test
     void doesNotFireOnMojoWithManyFields() throws Exception {
-        final String file = "TooManyFieldsInMojo.java";
-        final Environment.Mock mock = new Environment.Mock();
-        final String name = String.format("src/main/java/foo/%s", file);
-        final Environment env = mock.withFile(
-            name,
-            new TextOf(
-                this.getClass().getResourceAsStream(file)
-            ).asString()
-        );
-        MatcherAssert.assertThat(
-            "TooManyFields must not fire on a class extending AbstractMojo",
-            new PmdValidator(env).validate(
-                Collections.singletonList(new File(env.basedir(), name))
-            ).stream().map(Violation::name).collect(Collectors.toList()),
-            Matchers.not(Matchers.hasItem("TooManyFields"))
-        );
+        new PmdAssert(
+            "TooManyFieldsInMojo.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("(TooManyFields)")
+            )
+        ).assertOk();
     }
 
     @Test
     void firesOnPlainClassWithManyFields() throws Exception {
-        final String file = "TooManyFieldsInPlainClass.java";
-        final Environment.Mock mock = new Environment.Mock();
-        final String name = String.format("src/main/java/foo/%s", file);
-        final Environment env = mock.withFile(
-            name,
-            new TextOf(
-                this.getClass().getResourceAsStream(file)
-            ).asString()
-        );
-        MatcherAssert.assertThat(
-            "TooManyFields must fire on a plain class with many fields",
-            new PmdValidator(env).validate(
-                Collections.singletonList(new File(env.basedir(), name))
-            ).stream().map(Violation::name).collect(Collectors.toList()),
-            Matchers.hasItem("TooManyFields")
-        );
+        new PmdAssert(
+            "TooManyFieldsInPlainClass.java",
+            Matchers.is(false),
+            Matchers.containsString("(TooManyFields)")
+        ).assertOk();
+    }
+
+    @Test
+    void ignoresConstants() throws Exception {
+        new PmdAssert(
+            "TooManyFieldsInConstants.java",
+            Matchers.any(Boolean.class),
+            Matchers.not(
+                Matchers.containsString("(TooManyFields)")
+            )
+        ).assertOk();
+    }
+
+    @Test
+    void reportsRedundantSuppressionOnMojo() throws Exception {
+        new PmdAssert(
+            "TooManyFieldsSuppressedInMojo.java",
+            Matchers.is(false),
+            Matchers.containsString("(UnnecessaryWarningSuppression)")
+        ).assertOk();
+    }
+
+    @Test
+    void honoursSuppressionOnPlainClass() throws Exception {
+        new PmdAssert(
+            "TooManyFieldsSuppressedInPlainClass.java",
+            Matchers.any(Boolean.class),
+            Matchers.allOf(
+                Matchers.not(Matchers.containsString("(TooManyFields)")),
+                Matchers.not(
+                    Matchers.containsString("(UnnecessaryWarningSuppression)")
+                )
+            )
+        ).assertOk();
     }
 }

--- a/src/test/resources/com/qulice/pmd/ExcessiveParameterListSuppressedInConstructor.java
+++ b/src/test/resources/com/qulice/pmd/ExcessiveParameterListSuppressedInConstructor.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class ExcessiveParameterListSuppressedInConstructor {
+
+    private final int total;
+
+    @SuppressWarnings("PMD.ExcessiveParameterList")
+    public ExcessiveParameterListSuppressedInConstructor(
+        final int one, final int two, final int three, final int four,
+        final int five, final int six, final int seven, final int eight,
+        final int nine, final int ten
+    ) {
+        this.total = one + two + three + four + five + six + seven
+            + eight + nine + ten;
+    }
+
+    public int total() {
+        return this.total;
+    }
+}

--- a/src/test/resources/com/qulice/pmd/ExcessiveParameterListSuppressedInMethod.java
+++ b/src/test/resources/com/qulice/pmd/ExcessiveParameterListSuppressedInMethod.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class ExcessiveParameterListSuppressedInMethod {
+
+    @SuppressWarnings("PMD.ExcessiveParameterList")
+    public int total(
+        final int one, final int two, final int three, final int four,
+        final int five, final int six, final int seven, final int eight,
+        final int nine, final int ten
+    ) {
+        return one + two + three + four + five + six + seven
+            + eight + nine + ten;
+    }
+}

--- a/src/test/resources/com/qulice/pmd/TooManyFieldsInConstants.java
+++ b/src/test/resources/com/qulice/pmd/TooManyFieldsInConstants.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+public final class TooManyFieldsInConstants {
+
+    private static final int ONE = 1;
+    private static final int TWO = 2;
+    private static final int THREE = 3;
+    private static final int FOUR = 4;
+    private static final int FIVE = 5;
+    private static final int SIX = 6;
+    private static final int SEVEN = 7;
+    private static final int EIGHT = 8;
+    private static final int NINE = 9;
+    private static final int TEN = 10;
+    private static final int ELEVEN = 11;
+    private static final int TWELVE = 12;
+    private static final int THIRTEEN = 13;
+    private static final int FOURTEEN = 14;
+    private static final int FIFTEEN = 15;
+    private static final int SIXTEEN = 16;
+
+    public int total() {
+        return TooManyFieldsInConstants.ONE + TooManyFieldsInConstants.TWO
+            + TooManyFieldsInConstants.THREE + TooManyFieldsInConstants.FOUR
+            + TooManyFieldsInConstants.FIVE + TooManyFieldsInConstants.SIX
+            + TooManyFieldsInConstants.SEVEN + TooManyFieldsInConstants.EIGHT
+            + TooManyFieldsInConstants.NINE + TooManyFieldsInConstants.TEN
+            + TooManyFieldsInConstants.ELEVEN + TooManyFieldsInConstants.TWELVE
+            + TooManyFieldsInConstants.THIRTEEN
+            + TooManyFieldsInConstants.FOURTEEN
+            + TooManyFieldsInConstants.FIFTEEN
+            + TooManyFieldsInConstants.SIXTEEN;
+    }
+}

--- a/src/test/resources/com/qulice/pmd/TooManyFieldsSuppressedInMojo.java
+++ b/src/test/resources/com/qulice/pmd/TooManyFieldsSuppressedInMojo.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+@SuppressWarnings("PMD.TooManyFields")
+public final class TooManyFieldsSuppressedInMojo extends AbstractMojo {
+
+    private int one;
+    private int two;
+    private int three;
+    private int four;
+    private int five;
+    private int six;
+    private int seven;
+    private int eight;
+    private int nine;
+    private int ten;
+    private int eleven;
+    private int twelve;
+    private int thirteen;
+    private int fourteen;
+    private int fifteen;
+    private int sixteen;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        this.getLog().info(
+            String.valueOf(
+                this.one + this.two + this.three + this.four + this.five
+                    + this.six + this.seven + this.eight + this.nine
+                    + this.ten + this.eleven + this.twelve + this.thirteen
+                    + this.fourteen + this.fifteen + this.sixteen
+            )
+        );
+    }
+}

--- a/src/test/resources/com/qulice/pmd/TooManyFieldsSuppressedInPlainClass.java
+++ b/src/test/resources/com/qulice/pmd/TooManyFieldsSuppressedInPlainClass.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package foo;
+
+@SuppressWarnings("PMD.TooManyFields")
+public final class TooManyFieldsSuppressedInPlainClass {
+
+    private int one;
+    private int two;
+    private int three;
+    private int four;
+    private int five;
+    private int six;
+    private int seven;
+    private int eight;
+    private int nine;
+    private int ten;
+    private int eleven;
+    private int twelve;
+    private int thirteen;
+    private int fourteen;
+    private int fifteen;
+    private int sixteen;
+
+    public int total() {
+        return this.one + this.two + this.three + this.four
+            + this.five + this.six + this.seven + this.eight + this.nine
+            + this.ten + this.eleven + this.twelve + this.thirteen
+            + this.fourteen + this.fifteen + this.sixteen;
+    }
+}


### PR DESCRIPTION
Closes #1775

`ExcessiveParameterList` and `TooManyFields` were re-enabled in `ruleset.xml` with a `violationSuppressXPath` that skipped constructors and `AbstractMojo` subclasses. Both exemptions worked, but they hid dead annotations: PMD consults the `@SuppressWarnings` suppressor before the XPath one, so a leftover `@SuppressWarnings("PMD.ExcessiveParameterList")` on a ten-parameter constructor, or `@SuppressWarnings("PMD.TooManyFields")` on a Mojo, was credited with a suppression the XPath filter would have performed anyway, and `UnnecessaryWarningSuppression` never reported it.

Both exemptions now live in custom rules, the way `TooManyMethodsRule` did for #1656, and the two `violationSuppressXPath` properties are gone.

## Changes

- `ExcessiveParameterListRule` — reports a formal-parameter list of 10 or more parameters, skipping every constructor. Same threshold and report location as PMD's rule, which exempted private constructors only.
- `TooManyFieldsRule` — reports a class declaring more than 15 non-static non-final fields in its body, skipping a class whose `extends` clause names `org.apache.maven.plugin.AbstractMojo`. Counts the same fields the upstream XPath rule counted.
- `NamedSupertype` — the name-based supertype lookup that `TooManyMethodsRule` used for JNA bindings (trust the name when it is fully qualified or imported, since Qulice runs PMD without an auxiliary classpath) is extracted here and shared by both rules.
- `ruleset.xml` — the two rules stay excluded from the bulk `design.xml` import, their comments now explain the suppressor blind spot, and the two custom rules are registered under their original names so existing `@SuppressWarnings("PMD.…")` keys keep working.

## Tests

`PmdExcessiveParameterListTest` and `PmdTooManyFieldsTest` now assert on the rule name in the violation output and cover, for each rule: the exempt case stays silent, the non-exempt case fires, a needed suppression is honoured, and a suppression left on an exempt element is reported as `UnnecessaryWarningSuppression`. `TooManyFieldsInConstants` pins that static final fields are not counted.

`mvn install` (481 tests plus the invoker ITs) and `mvn verify -Pqulice` both pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Las1YtPQAvTYUuiDrhgnYr)_