### PR TITLE
feat: exclude src/test/resources by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Suppress individual checks with `@SuppressWarnings("CheckName")` (the
   `errorprone:` exclude, e.g.
   `<exclude>errorprone:.*/generated/.*</exclude>`.
 
+Files in `src/test/resources`, and in its subdirectories, are left
+  alone by [Checkstyle], [PMD], and [ErrorProne] by default: they are
+  fixtures of your tests, [Maven] compiles none of the `.java` ones, and
+  quite often they are broken on purpose.
+You don't need an `<exclude>` for them.
+
 An entire bug pattern can be switched off for the whole project with
   an `-Xep` flag of your own:
 

--- a/pom.xml
+++ b/pom.xml
@@ -615,6 +615,7 @@
             <pomInclude>pmd-duplicate-string-literals-violations/pom.xml</pomInclude>
             <pomInclude>dependency-not-matches-exclude/pom.xml</pomInclude>
             <pomInclude>binary-files/pom.xml</pomInclude>
+            <pomInclude>test-resources-excluded/pom.xml</pomInclude>
           </pomIncludes>
         </configuration>
       </plugin>
@@ -732,10 +733,7 @@
                 <exclude>
                   errorprone:/src/main/java/com/qulice/maven/MojoExecutor.java
                 </exclude>
-                <exclude>checkstyle:/src/test/resources/.*</exclude>
                 <exclude>errorprone:/src/test/java/.*</exclude>
-                <exclude>errorprone:/src/test/resources/.*</exclude>
-                <exclude>pmd:/src/test/resources/.*</exclude>
                 <exclude>checkstyle:/src/it/.*</exclude>
                 <exclude>pmd:/src/it/.*</exclude>
               </excludes>

--- a/src/it/test-resources-excluded/LICENSE.txt
+++ b/src/it/test-resources-excluded/LICENSE.txt
@@ -1,0 +1,28 @@
+Copyright (c) 2011-2026 Yegor Bugayenko
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met: 1) Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer. 2) Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution. 3) Neither the name of the Qulice.com nor
+the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/it/test-resources-excluded/invoker.properties
+++ b/src/it/test-resources-excluded/invoker.properties
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+invoker.goals = clean verify
+invoker.buildResult = success

--- a/src/it/test-resources-excluded/pom.xml
+++ b/src/it/test-resources-excluded/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.jcabi</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.73.4</version>
+  </parent>
+  <groupId>com.qulice.plugin</groupId>
+  <artifactId>test-resources-excluded</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>test-resources-excluded</name>
+  <prerequisites>
+    <maven>3.0</maven>
+  </prerequisites>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>false</failIfNoTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.qulice</groupId>
+        <artifactId>qulice-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test-resources-excluded/src/main/java/com/qulice/plugin/resources/Thing.java
+++ b/src/it/test-resources-excluded/src/main/java/com/qulice/plugin/resources/Thing.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.plugin.resources;
+
+/**
+ * A clean class that lives next to a broken test resource. It is here to
+ * prove that qulice still validates real sources, while leaving the Java
+ * fixtures in {@code src/test/resources} alone.
+ * @since 1.0
+ */
+public final class Thing {
+
+    /**
+     * Name of the thing.
+     */
+    private final String label;
+
+    /**
+     * Ctor.
+     * @param name Label to use
+     */
+    public Thing(final String name) {
+        this.label = name;
+    }
+
+    /**
+     * Print the label.
+     * @return Human-readable label
+     */
+    public String name() {
+        return this.label;
+    }
+}

--- a/src/it/test-resources-excluded/src/main/java/com/qulice/plugin/resources/package-info.java
+++ b/src/it/test-resources-excluded/src/main/java/com/qulice/plugin/resources/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Integration test for the default exclusion of
+ * {@code src/test/resources}: Java files that live there are fixtures of
+ * the tests, not sources of the product, and neither Checkstyle, PMD nor
+ * ErrorProne may complain about them, even though the project says
+ * nothing about them in its {@code <excludes>}.
+ * @since 1.0
+ */
+package com.qulice.plugin.resources;

--- a/src/it/test-resources-excluded/src/test/resources/com/qulice/plugin/resources/Broken.java
+++ b/src/it/test-resources-excluded/src/test/resources/com/qulice/plugin/resources/Broken.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
 class Broken {
     public int X;
     public Broken() { }

--- a/src/it/test-resources-excluded/src/test/resources/com/qulice/plugin/resources/Broken.java
+++ b/src/it/test-resources-excluded/src/test/resources/com/qulice/plugin/resources/Broken.java
@@ -1,0 +1,9 @@
+class Broken {
+    public int X;
+    public Broken() { }
+    public int Get_It(int  a,int b) {
+        String s = "" + a;
+        if (s.length() == 0) return b;
+        return a;
+    }
+}

--- a/src/it/test-resources-excluded/verify.groovy
+++ b/src/it/test-resources-excluded/verify.groovy
@@ -1,0 +1,10 @@
+/**
+ *
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+def log = new File(basedir, 'build.log')
+assert log.text.contains('Qulice checked')
+assert !log.text.contains('Broken.java')
+assert log.text.contains('BUILD SUCCESS')

--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -13,6 +13,7 @@ import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.qulice.spi.Environment;
+import com.qulice.spi.Fixture;
 import com.qulice.spi.Relative;
 import com.qulice.spi.ResourceValidator;
 import com.qulice.spi.Violation;
@@ -148,6 +149,9 @@ public final class CheckstyleValidator implements ResourceValidator {
         for (final File file : files) {
             final String name = new Relative(this.env.basedir(), file).path();
             if (this.env.exclude("checkstyle", name)) {
+                continue;
+            }
+            if (new Fixture(name).yes()) {
                 continue;
             }
             final int dot = name.lastIndexOf('.');

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -7,6 +7,7 @@ package com.qulice.errorprone;
 import com.google.common.base.Splitter;
 import com.jcabi.log.Logger;
 import com.qulice.spi.Environment;
+import com.qulice.spi.Fixture;
 import com.qulice.spi.Relative;
 import com.qulice.spi.ResourceValidator;
 import com.qulice.spi.Violation;
@@ -217,6 +218,9 @@ public final class ErrorProneValidator implements ResourceValidator {
         for (final File file : files) {
             final String name = new Relative(this.env.basedir(), file).path();
             if (this.env.exclude("errorprone", name)) {
+                continue;
+            }
+            if (new Fixture(name).yes()) {
                 continue;
             }
             if (!name.endsWith(".java")) {

--- a/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -6,6 +6,7 @@ package com.qulice.pmd;
 
 import com.jcabi.log.Logger;
 import com.qulice.spi.Environment;
+import com.qulice.spi.Fixture;
 import com.qulice.spi.Relative;
 import com.qulice.spi.ResourceValidator;
 import com.qulice.spi.Violation;
@@ -83,6 +84,9 @@ public final class PmdValidator implements ResourceValidator {
         for (final File file : files) {
             final String name = new Relative(this.env.basedir(), file).path();
             if (this.env.exclude("pmd", name)) {
+                continue;
+            }
+            if (new Fixture(name).yes()) {
                 continue;
             }
             if (!name.toLowerCase(Locale.ROOT).endsWith(".java")) {

--- a/src/main/java/com/qulice/spi/Fixture.java
+++ b/src/main/java/com/qulice/spi/Fixture.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.spi;
+
+/**
+ * A file that is a fixture of the tests, rather than a source of the
+ * product.
+ *
+ * <p>Whatever lies under {@code src/test/resources} is a fixture: an
+ * input to the tests rather than a part of the product. Maven compiles
+ * none of the {@code .java} files there, and quite often they are
+ * deliberately broken, because that is exactly what the test needs them
+ * to be. Feeding them to Checkstyle, PMD or ErrorProne produces nothing
+ * but noise, so all three validators leave them alone by default,
+ * without the project having to say so through an {@code <exclude>} of
+ * its own.</p>
+ *
+ * <p>The path handed to the constructor is the one {@link Relative}
+ * makes: forward slashes, relative to the base directory of the project
+ * and starting with a slash, or absolute when the file lies outside of
+ * it. Both forms are recognised, and so is a file of a nested Maven
+ * module, whose own {@code src/test/resources} the path merely
+ * contains.</p>
+ *
+ * @since 1.0
+ */
+public final class Fixture {
+
+    /**
+     * The directory test resources live in, by Maven convention.
+     */
+    private static final String DIR = "/src/test/resources/";
+
+    /**
+     * The path of the file.
+     */
+    private final String path;
+
+    /**
+     * Ctor.
+     * @param file Path of the file, the way {@link Relative} makes it
+     */
+    public Fixture(final String file) {
+        this.path = file;
+    }
+
+    /**
+     * Is this file a fixture?
+     * @return TRUE if the file is inside {@code src/test/resources}
+     */
+    public boolean yes() {
+        return this.path.contains(Fixture.DIR);
+    }
+}

--- a/src/test/java/com/qulice/checkstyle/CheckstyleTestResourcesTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleTestResourcesTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CheckstyleValidator} and the test resources of
+ * a project, which it must leave alone without being told to.
+ *
+ * <p>The very same source, when it sits in {@code src/main/java},
+ * produces violations, as {@link CheckstyleValidatorTest} shows.</p>
+ *
+ * @since 1.0
+ */
+final class CheckstyleTestResourcesTest {
+
+    @Test
+    void ignoresJavaFilesInTestResources() throws Exception {
+        final String file = "src/test/resources/com/qulice/Bad.java";
+        final Environment env = new Environment.Mock()
+            .withFile(file, "class Bad { public int x = 0; }");
+        MatcherAssert.assertThat(
+            "Java file under src/test/resources must not be checked",
+            new CheckstyleValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            ),
+            Matchers.<Violation>empty()
+        );
+    }
+
+    @Test
+    void ignoresJavaFilesDeepInTestResources() throws Exception {
+        final String file = "src/test/resources/foo/bar/Bad.java";
+        final Environment env = new Environment.Mock()
+            .withFile(file, "class Bad { public int x = 0; }");
+        MatcherAssert.assertThat(
+            "Java file in a subdirectory of test resources must be skipped",
+            new CheckstyleValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            ),
+            Matchers.<Violation>empty()
+        );
+    }
+}

--- a/src/test/java/com/qulice/errorprone/ErrorProneTestResourcesTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorProneTestResourcesTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.errorprone;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ErrorProneValidator} and the test resources of a
+ * project, which it must leave alone without being told to.
+ *
+ * <p>The same self-assignment in {@code src/main/java} is reported, as
+ * {@link ErrorProneValidatorTest} shows.</p>
+ *
+ * @since 1.0
+ */
+final class ErrorProneTestResourcesTest {
+
+    @Test
+    void ignoresJavaFilesInTestResources() throws Exception {
+        final String file = "src/test/resources/com/qulice/Bad.java";
+        final Environment env = new Environment.Mock().withFile(
+            file,
+            "class Bad { private int value; void set(int v) { this.value = this.value; } }"
+        );
+        MatcherAssert.assertThat(
+            "Java file under src/test/resources must not be compiled",
+            new ErrorProneValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            ),
+            Matchers.<Violation>empty()
+        );
+    }
+}

--- a/src/test/java/com/qulice/pmd/PmdTestResourcesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTestResourcesTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.pmd;
+
+import com.qulice.spi.Environment;
+import com.qulice.spi.Violation;
+import java.io.File;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link PmdValidator} and the test resources of a
+ * project, which it must leave alone without being told to.
+ *
+ * <p>The same source in {@code src/main/java} does produce violations,
+ * as {@link PmdValidatorTest} shows.</p>
+ *
+ * @since 1.0
+ */
+final class PmdTestResourcesTest {
+
+    @Test
+    void ignoresJavaFilesInTestResources() throws Exception {
+        final String file = "src/test/resources/com/qulice/Main.java";
+        final Environment env = new Environment.Mock()
+            .withFile(file, "class Main { int x = 0; }");
+        MatcherAssert.assertThat(
+            "Java file under src/test/resources must not be checked",
+            new PmdValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            ),
+            Matchers.<Violation>empty()
+        );
+    }
+
+    @Test
+    void keepsTestResourcesOutOfTheFileList() throws Exception {
+        final String file = "src/test/resources/foo/bar/Main.java";
+        final Environment env = new Environment.Mock()
+            .withFile(file, "class Main { int x = 0; }");
+        MatcherAssert.assertThat(
+            "Test resource must not even reach the list of sources",
+            new PmdValidator(env).getNonExcludedFiles(
+                Collections.singletonList(new File(env.basedir(), file))
+            ),
+            Matchers.empty()
+        );
+    }
+}

--- a/src/test/java/com/qulice/spi/FixtureTest.java
+++ b/src/test/java/com/qulice/spi/FixtureTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.spi;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Fixture}.
+ * @since 1.0
+ */
+final class FixtureTest {
+
+    @Test
+    void detectsJavaFileAmongTestResources() {
+        MatcherAssert.assertThat(
+            "Java file under src/test/resources must be a fixture",
+            new Fixture("/src/test/resources/com/qulice/Bad.java").yes(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void detectsFileInSubdirectoryOfTestResources() {
+        MatcherAssert.assertThat(
+            "Deeply nested fixture must be recognized too",
+            new Fixture("/src/test/resources/foo/bar/baz/Broken.java").yes(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void detectsFixtureByAbsolutePath() {
+        MatcherAssert.assertThat(
+            "Absolute path must be recognized as well",
+            new Fixture("/home/me/prj/src/test/resources/Bad.java").yes(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNotTouchMainSources() {
+        MatcherAssert.assertThat(
+            "Main source cannot be taken for a fixture",
+            new Fixture("/src/main/java/com/qulice/Good.java").yes(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void doesNotTouchTestSources() {
+        MatcherAssert.assertThat(
+            "Test source cannot be taken for a fixture",
+            new Fixture("/src/test/java/com/qulice/GoodTest.java").yes(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void doesNotTouchMainResources() {
+        MatcherAssert.assertThat(
+            "Main resource cannot be taken for a fixture",
+            new Fixture("/src/main/resources/checks.xml").yes(),
+            Matchers.is(false)
+        );
+    }
+}


### PR DESCRIPTION
Checkstyle, PMD and ErrorProne now leave `src/test/resources`, and all of its subdirectories, alone — no `<exclude>` needed from the project.

Java files that live there are fixtures of the tests, not sources of the product: Maven compiles none of them, and quite often they are broken on purpose, which is exactly what the test needs them to be.

## What changed

* `com.qulice.spi.Fixture` — a new one-method class that answers whether a path sits under `src/test/resources`. The decision lives in one place; all three validators consult it.
* `CheckstyleValidator`, `PmdValidator` and `ErrorProneValidator` skip such files while filtering the files handed to them, right next to where they already honour `<exclude>` patterns.
* `pom.xml` — the three `src/test/resources` excludes Qulice kept for its own build are gone, since they are the default now. The self-check (`-Pqulice`) still passes without them, which is the change proving itself on this repo.
* `README.md` — documents the new default.

The path is matched by Maven convention (`/src/test/resources/`), the same way the removed excludes did, so a project that redirects `<testResources>` elsewhere still needs an `<exclude>` of its own.

Files under `src/test/resources` are skipped whatever their extension, not just `.java`, which matches what the removed `checkstyle:/src/test/resources/.*` exclude used to do — Checkstyle would otherwise inspect `.txt`, `.xml` and `.properties` fixtures too.

One thing left as-is: the summary line still counts every `.java` file handed to the validators, so a project with fixtures reads "checked 3 .java files" when two were checked. That is pre-existing behaviour for `<exclude>`d files as well, so it stays out of this change.

## How it was verified

* `FixtureTest` — 6 cases over the path rule, including main sources, test sources and main resources, which must not be mistaken for fixtures.
* `CheckstyleTestResourcesTest`, `PmdTestResourcesTest`, `ErrorProneTestResourcesTest` — each feeds a violating `.java` file under `src/test/resources` to its validator and expects silence. All five of these fail if `Fixture.yes()` is stubbed to `false`, so they are real regression coverage; the matching control cases (the same sources under `src/main/java`, which do yield violations) already live in the sibling test classes.
* `src/it/test-resources-excluded` — a new integration test: a clean `Thing.java` next to a deliberately awful `src/test/resources/.../Broken.java`, asserting the build stays green, that Qulice actually ran, and that `Broken.java` is never mentioned in the log.
* Full unit suite: 495 tests, 0 failures. Self-check `mvn install -Pqulice`: green. The new IT: green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgaGWfrvQKV3kK8PEE1oTs)_