### PR TITLE
feat(checkstyle): flag a stray trailing asterisk in Javadoc

### DIFF
--- a/src/main/java/com/qulice/checkstyle/JavadocStrayAsteriskCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocStrayAsteriskCheck.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TextBlock;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.Locale;
+
+/**
+ * Check for a stray asterisk at the end of a Javadoc line.
+ *
+ * <p>A paragraph opened with {@code <p>} is sometimes "closed" with a bare
+ * {@code *} appended to the last line of its text, instead of {@code </p>}
+ * or nothing at all. Javadoc renders that asterisk as literal text, right
+ * after the sentence. See
+ * <a href="https://github.com/yegor256/qulice/issues/1783">#1783</a>.
+ *
+ * <p>The following Javadoc will be reported as a violation, since the last
+ * line of the paragraph ends with an asterisk that belongs to no comment
+ * delimiter:
+ * <pre>
+ * &#47;**
+ *  * &lt;p&gt;The sentinel is not a real expression kind, it is
+ *  <span style="color:red" >* the parent for entries pushed at indent zero. *</span>
+ *  *&#47;
+ * </pre>
+ *
+ * <p>And this is how it should be written instead:
+ * <pre>
+ * &#47;**
+ *  * &lt;p&gt;The sentinel is not a real expression kind, it is
+ *  * the parent for entries pushed at indent zero.
+ *  *&#47;
+ * </pre>
+ *
+ * <p>The asterisks that open the comment, prefix its lines, and close it are
+ * not touched. Lines inside a {@code <pre>...</pre>} block or a
+ * {@code {@snippet ...}} block are skipped, since an asterisk may legally
+ * end a line of example code there.
+ *
+ * @since 0.73.4
+ */
+public final class JavadocStrayAsteriskCheck extends AbstractCheck {
+
+    /**
+     * Message about a line ending with a stray asterisk.
+     */
+    private static final String MSG =
+        "Javadoc line must not end with a stray asterisk";
+
+    /**
+     * Default constructor.
+     */
+    public JavadocStrayAsteriskCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+        };
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void visitToken(final DetailAST ast) {
+        final TextBlock doc =
+            this.getFileContents().getJavadocBefore(ast.getLineNo());
+        if (doc != null) {
+            this.check(doc);
+        }
+    }
+
+    private void check(final TextBlock doc) {
+        final String[] lines = doc.getText();
+        boolean pre = false;
+        int depth = 0;
+        for (int pos = 0; pos < lines.length; pos += 1) {
+            final String body = JavadocStrayAsteriskCheck.body(lines[pos]);
+            final String low = body.toLowerCase(Locale.ENGLISH);
+            if (depth > 0) {
+                depth += JavadocStrayAsteriskCheck.braces(body);
+            } else if (low.contains("{@snippet")) {
+                depth = Math.max(0, JavadocStrayAsteriskCheck.braces(body));
+            } else if (pre) {
+                pre = !low.contains("</pre>");
+            } else if (low.contains("<pre>")) {
+                pre = !low.contains("</pre>");
+            } else if (body.endsWith("*")) {
+                this.log(
+                    doc.getStartLineNo() + pos,
+                    JavadocStrayAsteriskCheck.MSG
+                );
+            }
+        }
+    }
+
+    private static String body(final String line) {
+        String trimmed = line.trim();
+        if (trimmed.endsWith("*/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 2).trim();
+        }
+        if (trimmed.startsWith("/**")) {
+            trimmed = trimmed.substring(3).trim();
+        } else if (trimmed.startsWith("*")) {
+            trimmed = trimmed.substring(1).trim();
+        }
+        return trimmed;
+    }
+
+    private static int braces(final String body) {
+        int delta = 0;
+        for (int pos = 0; pos < body.length(); pos += 1) {
+            final char chr = body.charAt(pos);
+            if (chr == '{') {
+                delta += 1;
+            } else if (chr == '}') {
+                delta -= 1;
+            }
+        }
+        return delta;
+    }
+}

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -491,6 +491,12 @@
     <module name="com.qulice.checkstyle.JavadocEmptyLineCheck"/>
     <module name="com.qulice.checkstyle.JavadocEmptyLineBeforeTagCheck"/>
     <module name="com.qulice.checkstyle.JavadocCompactParagraphCheck"/>
+    <!--
+    This one makes sure that no line of a Javadoc block ends with a stray
+    asterisk, which Javadoc renders as literal text.
+    See https://github.com/yegor256/qulice/issues/1783
+    -->
+    <module name="com.qulice.checkstyle.JavadocStrayAsteriskCheck"/>
     <module name="com.qulice.checkstyle.JavadocFirstLineCheck"/>
     <module name="com.qulice.checkstyle.JavadocNoIndentCheck"/>
     <module name="com.qulice.checkstyle.DiamondOperatorCheck"/>

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -195,6 +195,7 @@ final class ChecksTest {
             "JavadocEmptyLineCheck",
             "JavadocEmptyLineBeforeTagCheck",
             "JavadocCompactParagraphCheck",
+            "JavadocStrayAsteriskCheck",
             "JavadocFirstLineCheck",
             "JavadocNoIndentCheck",
             "JavadocTagsCheck",

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/Invalid.java
@@ -1,0 +1,40 @@
+/*
+ * Hello.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is not a real Java class. It won't be compiled ever.
+ *
+ * <p>The paragraph below is closed with a bare asterisk, instead of
+ * being closed with a tag or with nothing at all. *
+ */
+public final class Invalid {
+
+    /**
+     * A field. *
+     */
+    private int number;
+
+    /**
+     * A method.
+     *
+     * <p>Here the asterisk sits on its own line.
+     * *
+     *
+     * @return Nothing
+     */
+    public int method() {
+        return this.number;
+    }
+
+    /**
+     * An annotated method. *
+     *
+     * @return Nothing
+     */
+    @SuppressWarnings("unchecked")
+    public int annotated() {
+        return this.number;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/Valid.java
@@ -1,0 +1,62 @@
+/*
+ * Hello.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is not a real Java class. It won't be compiled ever.
+ *
+ * <p>No line of this comment ends with an asterisk of its own, only the
+ * comment itself is delimited by them.</p>
+ */
+public final class Valid {
+
+    /**
+     * A field.
+     *
+     * <p>A paragraph that is not closed at all is fine here.
+     */
+    private int number;
+
+    /**
+     * A method whose text mentions an asterisk, without ending on one.
+     *
+     * <p>The wildcard is written as {@code *}
+     * and the multiplication sign is <b>*</b> here.
+     *
+     * @return Nothing
+     */
+    public int wildcard() {
+        return this.number;
+    }
+
+    /**
+     * A method with a pre block that shows a literal asterisk.
+     *
+     * <p>Example:
+     * <pre>
+     * int total = first *
+     *     second;
+     * </pre>
+     *
+     * @return Nothing
+     */
+    public int first() {
+        return this.number;
+    }
+
+    /**
+     * A method with a snippet that shows a literal asterisk.
+     *
+     * <p>Here is a snippet:
+     * {@snippet :
+     * int total = first *
+     *     second;
+     * }
+     *
+     * @return Nothing
+     */
+    public int second() {
+        return this.number;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.JavadocStrayAsteriskCheck"/>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/violations.txt
@@ -1,0 +1,4 @@
+10:Javadoc line must not end with a stray asterisk
+15:Javadoc line must not end with a stray asterisk
+23:Javadoc line must not end with a stray asterisk
+32:Javadoc line must not end with a stray asterisk


### PR DESCRIPTION
Closes #1783

## What

Adds `JavadocStrayAsteriskCheck`, which reports any Javadoc line whose text
ends with a bare `*`:

```java
/**
 * <p>The {@link #TOP_LEVEL} sentinel is not a real expression kind — it is
 * the {@code parent_kind} for entries pushed at indent 0 (R-5.2.11), used
 * by close-time checks to recognise top-level naming requirements
 * (R-5.3.1). *
 *
 * @since 0.1
 */
```

That trailing asterisk is not a comment delimiter, so Javadoc renders it as
literal text right after the sentence.

## How

The check visits the same tokens as `JavadocCompactParagraphCheck`, grabs the
Javadoc block via `FileContents.getJavadocBefore`, and for each line strips
the asterisks that belong to the comment itself (`/**` at the start, the
leading `*` prefix, `*/` at the end). Whatever is left is the line's own text;
if it ends with `*`, that is a violation.

Lines inside a `<pre>...</pre>` block or a `{@snippet ...}` block are skipped,
since an asterisk may legitimately end a line of example code there — same
skipping logic as `JavadocCompactParagraphCheck`.

The check is registered in `checks.xml`, so it is on by default.

## Why this shape

The issue offers two ways to catch the pattern. The other one — requiring
every `<p>` to have a matching `</p>` — would contradict the convention this
codebase already documents and enforces: `JavadocCompactParagraphCheck` only
constrains `</p>` "when it is used at all", its own `Valid.java` blesses
`<p>Single paragraph without a closing tag.`, and qulice's own sources are
written that way throughout. So this PR implements the trailing-asterisk rule,
which the issue also notes is the simpler one.

## Testing

`ChecksTest` resources under
`src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocStrayAsteriskCheck/`:

- `Invalid.java` — four violations: a class paragraph closed with ` *`, a
  field one-liner ending in ` *`, an asterisk alone on its own line, and a
  method carrying an annotation between its Javadoc and its signature (this
  last one guards `getJavadocBefore` resolving past the annotation).
- `Valid.java` — a closed paragraph, an unclosed paragraph, text that
  *mentions* an asterisk (`{@code *}`, `<b>*</b>`) without ending on one, and
  `<pre>` / `{@snippet}` blocks whose code lines end in `*`.

Verified locally:

- `mvn test` — 518 tests, 0 failures.
- `mvn verify -Pqulice -DskipTests -DskipITs` — clean, so the new check finds
  nothing to complain about in qulice's own sources.
- Mutation-checked the check actually fires: appending ` *` to a line in
  `Valid.java` produces exactly the expected violation at the expected line,
  and removing the annotated-method case from `Invalid.java` drops that
  violation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZHWBsA9YazG1LZRmQbqXF)_