### PR TITLE
feat(checkstyle): require every Javadoc paragraph to be closed

### DIFF
--- a/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
+++ b/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
@@ -11,7 +11,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * Checks node/closing brackets to be the last symbols on the line.
  *
- * <p>This is how a correct bracket structure should look like:
+ * <p>This is how a correct bracket structure should look like:</p>
  *
  * <pre>
  * String text = String.format(
@@ -26,10 +26,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>The motivation for such formatting is simple - we want to see the entire
  * block as fast as possible. When you look at a block of code you should be
  * able to see where it starts and where it ends. In exactly the same way
- * we organize curled brackets.
+ * we organize curled brackets.</p>
  *
  * <p>In other words, when you open a bracket and can't close it at the same
- * line - you should leave it as the last symbol at this line.
+ * line - you should leave it as the last symbol at this line.</p>
  *
  * @since 0.3
  */

--- a/src/main/java/com/qulice/checkstyle/BranchContains.java
+++ b/src/main/java/com/qulice/checkstyle/BranchContains.java
@@ -15,7 +15,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
  * However, this method was deprecated in upstream due to unintended too
  * deep scanning. It is recommended to write traversal implementation
  * for your needs by yourself to avoid unexpected side effects. So here follows it's
- * simple implementation.
+ * simple implementation.</p>
  *
  * @since 1.0
  */

--- a/src/main/java/com/qulice/checkstyle/ChildStream.java
+++ b/src/main/java/com/qulice/checkstyle/ChildStream.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
  * <p>DetailAST APIs for working with child nodes require writing
  * imperative code, which generally looks less readable then
  * declarative Stream manipulations. This class integrates DetailAST
- * with Java Streams.
+ * with Java Streams.</p>
  *
  * @since 1.0
  */
@@ -38,7 +38,7 @@ class ChildStream {
      * independent.
      *
      * <p>Implementation may be simplified using Stream.iterate when Java 8 support
-     * is dropped.
+     * is dropped.</p>
      *
      * @return Stream of children
      */

--- a/src/main/java/com/qulice/checkstyle/ConfiguredChecks.java
+++ b/src/main/java/com/qulice/checkstyle/ConfiguredChecks.java
@@ -22,7 +22,7 @@ import org.cactoos.scalar.Unchecked;
  * checks suppresses nothing at all, which is what
  * {@link UnknownSuppressionCheck} reports. Both the short name of a
  * module and its name with the {@code Check} suffix count as enabled,
- * since either of them matches the class name of the check.
+ * since either of them matches the class name of the check.</p>
  *
  * @since 1.0
  */
@@ -40,7 +40,7 @@ final class ConfiguredChecks {
      *
      * <p>The filters capture the name as {@code \w+}, which holds no
      * regular expression metacharacter, so their pattern matching comes
-     * down to a search for the name inside the name of a check.
+     * down to a search for the name inside the name of a check.</p>
      *
      * @param name Name from a {@code @checkstyle} suppression comment
      * @return True if the name matches at least one enabled check

--- a/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstructorsCodeFreeCheck.java
@@ -17,23 +17,23 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * (static or instance) from inside a constructor is forbidden,
  * including as the right-hand side of a field assignment
  * (e.g. {@code this.bar = Foo.createBar()}) or as a nested argument
- * to a {@code new} expression.
+ * to a {@code new} expression.</p>
  *
  * <p>A constructor whose only statement is a delegating
  * {@code this(...)} or {@code super(...)} call is exempt: such a
  * constructor performs no work of its own, and the method-call
  * arguments to the delegate (e.g. {@code this(System.currentTimeMillis())})
- * are accepted as a sanctioned factory-style entry point.
+ * are accepted as a sanctioned factory-style entry point.</p>
  *
  * <p>Method calls nested inside lambda bodies or anonymous class bodies
  * are not considered constructor code, because they are not executed
  * at construction time: only the lambda object or the anonymous class
- * instance is created. Such subtrees are skipped.
+ * instance is created. Such subtrees are skipped.</p>
  *
  * <p>Defensive array copy idioms — {@code Arrays.copyOf(...)} and
  * {@code <expr>.clone()} — are also tolerated, since there is no
  * method-call-free way to defensively copy an array field at
- * construction time (Effective Java item 50).
+ * construction time (Effective Java item 50).</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/ConstructorsOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstructorsOrderCheck.java
@@ -18,7 +18,7 @@ import java.util.List;
  * A secondary constructor delegates, as its first statement, to another
  * constructor in the same class. The rule requires the primary constructor
  * to be declared after all secondary ones, so that the delegation chain
- * reads top-down towards the primary.
+ * reads top-down towards the primary.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
+++ b/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * Checks node/closing curly brackets to be the last symbols on the line.
  *
- * <p>This is how a correct curly bracket structure should look like:
+ * <p>This is how a correct curly bracket structure should look like:</p>
  *
  * <pre>
  * String[] array = new String[] {
@@ -22,7 +22,7 @@ import java.util.List;
  * };
  * </pre>
  *
- * <p>or
+ * <p>or</p>
  *
  * <pre>
  * String[] array = new String[] {"first", "second"};
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * <p>The motivation for such formatting is simple - we want to see the entire
  * block as fast as possible. When you look at a block of code you should be
- * able to see where it starts and where it ends.
+ * able to see where it starts and where it ends.</p>
  *
  * @since 0.6
  */

--- a/src/main/java/com/qulice/checkstyle/EmptyLineBeforeFirstMemberCheck.java
+++ b/src/main/java/com/qulice/checkstyle/EmptyLineBeforeFirstMemberCheck.java
@@ -16,17 +16,17 @@ import java.util.regex.Pattern;
  * <p>Some developers add an empty line after the opening brace of a
  * class, interface or enum for aesthetic reasons, while others consider it
  * wasted vertical space. This check enforces the presence of such a blank
- * line so that the style is consistent across the whole codebase.
+ * line so that the style is consistent across the whole codebase.</p>
  *
  * <p>The following code will be reported as a violation because the first
- * member is not preceded by an empty line:
+ * member is not preceded by an empty line:</p>
  * <pre>
  * class Foo {
  *     private int bar;
  * }
  * </pre>
  *
- * <p>Empty type bodies and one-line declarations are not reported.
+ * <p>Empty type bodies and one-line declarations are not reported.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
@@ -17,12 +17,12 @@ import java.util.stream.StreamSupport;
  * <p>We believe that comments and empty lines are evil. If you need to use
  * an empty line in order to add a vertical separator of concepts - refactor
  * your code and make it more cohesive and readable. The bottom line is
- * that every method should look solid and do just <b>one thing</b>.
+ * that every method should look solid and do just <b>one thing</b>.</p>
  *
  * <p>This class is not thread safe. It builds a list of line ranges by visiting
  * each method definition and each anonymous inner type, keeps them in
  * instance fields until finishTree() reports and clears them, so a single
- * instance must not be shared between threads.
+ * instance must not be shared between threads.</p>
  *
  * @since 0.3
  */

--- a/src/main/java/com/qulice/checkstyle/EnumValueNameCheck.java
+++ b/src/main/java/com/qulice/checkstyle/EnumValueNameCheck.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
  * <p>Since enum constants are effectively {@code public static final}
  * references, they must follow the same upper-case, underscore-separated
  * naming convention. Names like {@code anyName} or {@code MixedCase} are
- * forbidden.
+ * forbidden.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/ExtraSemicolonCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ExtraSemicolonCheck.java
@@ -13,7 +13,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * of a class, interface, record, method or constructor declaration.
  *
  * <p>Such semicolons form empty declarations that carry no meaning and
- * clutter the code, for example:
+ * clutter the code, for example:</p>
  *
  * <pre>
  * class Semicolons {
@@ -28,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * direct child of an {@code OBJBLOCK} (a class, interface or record
  * body) or of the root {@code COMPILATION_UNIT}. Enum bodies are
  * excluded because the {@code ;} separator between enum constants and
- * member declarations is mandated by the Java grammar.
+ * member declarations is mandated by the Java grammar.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
@@ -13,7 +13,7 @@ import java.io.File;
  *
  * <p>All {@code import} instructions shall stay together, without any empty
  * lines between them. If you need to separate them because the list is too
- * big - it's time to refactor the class and make is smaller.
+ * big - it's time to refactor the class and make is smaller.</p>
  *
  * @since 0.3
  */

--- a/src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java
@@ -14,14 +14,16 @@ import java.util.Locale;
  *
  * <p>The built-in {@code JavadocParagraph} module governs the blank lines
  * around {@code <p>}, but nothing stops the tag from sitting alone on its
- * own line. This check keeps {@code <p>} glued to the text it opens and,
- * when {@code </p>} is used at all, glued to the text it closes. So a line
- * whose trimmed content ends with {@code <p>}, or whose trimmed content
- * starts with {@code </p>}, is reported as a violation. See
- * <a href="https://github.com/yegor256/qulice/issues/1709">#1709</a>.
+ * own line. This check keeps {@code <p>} glued to the text it opens and
+ * {@code </p>} glued to the text it closes, while
+ * {@link JavadocUnclosedParagraphCheck} is the one that insists on the
+ * closing tag being there. So a line whose trimmed content ends with
+ * {@code <p>}, or whose trimmed content starts with {@code </p>}, is
+ * reported as a violation. See
+ * <a href="https://github.com/yegor256/qulice/issues/1709">#1709</a>.</p>
  *
  * <p>The following Javadoc will be reported as a violation, since the
- * opening tag ends a line and the closing tag starts a line:
+ * opening tag ends a line and the closing tag starts a line:</p>
  * <pre>
  * &#47;**
  *  <span style="color:red" >* &lt;p&gt;</span>
@@ -30,7 +32,7 @@ import java.util.Locale;
  *  *&#47;
  * </pre>
  *
- * <p>And this is how it should be written instead:
+ * <p>And this is how it should be written instead:</p>
  * <pre>
  * &#47;**
  *  * &lt;p&gt;An example of how to configure the check is:&lt;/p&gt;
@@ -39,7 +41,7 @@ import java.util.Locale;
  *
  * <p>Lines inside a {@code <pre>...</pre>} block or a {@code {@snippet ...}}
  * block are skipped, since a literal {@code <p>} or {@code </p>} may appear
- * there as example content rather than as a real tag.
+ * there as example content rather than as a real tag.</p>
  *
  * @since 0.73.3
  */

--- a/src/main/java/com/qulice/checkstyle/JavadocEmptyLineBeforeTagCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocEmptyLineBeforeTagCheck.java
@@ -16,11 +16,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * If the body contains more than one paragraph (separated by empty Javadoc
  * lines), then an empty Javadoc line is required right before the first
  * at-clause. See
- * <a href="https://github.com/yegor256/qulice/issues/708">#708</a>.
+ * <a href="https://github.com/yegor256/qulice/issues/708">#708</a>.</p>
  *
  * <p>The following Javadoc will be reported as a violation, since its body
  * is a single paragraph and yet it is separated from the at-clauses by an
- * empty line:
+ * empty line:</p>
  * <pre>
  * &#47;**
  *  * Just one line here.
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  *
  * <p>And this one will be reported too, since its body has more than one
- * paragraph but there is no empty line before the at-clauses:
+ * paragraph but there is no empty line before the at-clauses:</p>
  * <pre>
  * &#47;**
  *  * First line.

--- a/src/main/java/com/qulice/checkstyle/JavadocEmptyLineCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocEmptyLineCheck.java
@@ -12,9 +12,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Check for empty lines inside Javadoc.
  *
  * <p>You can't have an empty line at the beginning or at the end of Javadoc,
- * and two consecutive empty lines are not allowed anywhere inside it.
+ * and two consecutive empty lines are not allowed anywhere inside it.</p>
  *
- * <p>The following red lines in class Javadoc will be reported as violations.
+ * <p>The following red lines in class Javadoc will be reported as violations.</p>
  * <pre>
  * &#47;**
  *  <span style="color:red" >*</span>

--- a/src/main/java/com/qulice/checkstyle/JavadocFirstLineCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocFirstLineCheck.java
@@ -13,9 +13,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * <p>You can't have a description on the same line as the opening
  * {@code /**}. Either keep the whole Javadoc on a single line, or move
- * the text to a new line under the opening.
+ * the text to a new line under the opening.</p>
  *
- * <p>The following red line will be reported as a violation.
+ * <p>The following red line will be reported as a violation.</p>
  * <pre>
  * <span style="color:red" >&#47;** Some text</span>
  *  *&#47;

--- a/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
@@ -13,10 +13,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * and that no annotation is placed above the javadoc.
  *
  * <p>You can't have empty lines between javadoc block and
- * a class/method/variable. They should stay together, always.
+ * a class/method/variable. They should stay together, always.</p>
  *
  * <p>Annotations must be placed after the javadoc, not before it,
- * so that the javadoc stays next to the subject it describes.
+ * so that the javadoc stays next to the subject it describes.</p>
  *
  * @since 0.3
  */

--- a/src/main/java/com/qulice/checkstyle/JavadocNoIndentCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocNoIndentCheck.java
@@ -14,7 +14,7 @@ import java.util.Locale;
  *
  * <p>Every line of a Javadoc comment must have exactly one space between the
  * leading asterisk and the first word of the text. Extra spaces, used to
- * push a paragraph line to the right, are not allowed:
+ * push a paragraph line to the right, are not allowed:</p>
  *
  * <pre>
  * &#47;**
@@ -26,7 +26,7 @@ import java.util.Locale;
  * <p>Lines inside a {@code <pre>} block or a {@code @snippet} block are left
  * alone, since the indentation there is semantically meaningful and has to be
  * preserved as written. Block tags and their wrapped continuation lines are
- * also left alone, since their indentation is governed by other checks.
+ * also left alone, since their indentation is governed by other checks.</p>
  *
  * @since 0.74
  */

--- a/src/main/java/com/qulice/checkstyle/JavadocStrayAsteriskCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocStrayAsteriskCheck.java
@@ -17,11 +17,11 @@ import java.util.Locale;
  * {@code *} appended to the last line of its text, instead of {@code </p>}
  * or nothing at all. Javadoc renders that asterisk as literal text, right
  * after the sentence. See
- * <a href="https://github.com/yegor256/qulice/issues/1783">#1783</a>.
+ * <a href="https://github.com/yegor256/qulice/issues/1783">#1783</a>.</p>
  *
  * <p>The following Javadoc will be reported as a violation, since the last
  * line of the paragraph ends with an asterisk that belongs to no comment
- * delimiter:
+ * delimiter:</p>
  * <pre>
  * &#47;**
  *  * &lt;p&gt;The sentinel is not a real expression kind, it is
@@ -29,7 +29,7 @@ import java.util.Locale;
  *  *&#47;
  * </pre>
  *
- * <p>And this is how it should be written instead:
+ * <p>And this is how it should be written instead:</p>
  * <pre>
  * &#47;**
  *  * &lt;p&gt;The sentinel is not a real expression kind, it is
@@ -40,7 +40,7 @@ import java.util.Locale;
  * <p>The asterisks that open the comment, prefix its lines, and close it are
  * not touched. Lines inside a {@code <pre>...</pre>} block or a
  * {@code {@snippet ...}} block are skipped, since an asterisk may legally
- * end a line of example code there.
+ * end a line of example code there.</p>
  *
  * @since 0.73.4
  */

--- a/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  * {@code author} or {@code version} tags and has a properly formatted
  * {@code since} tag.
  *
- * <p>Correct format is the following (of a class javadoc):
+ * <p>Correct format is the following (of a class javadoc):</p>
  *
  * <pre>
  * &#47;**

--- a/src/main/java/com/qulice/checkstyle/JavadocTagsDotCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocTagsDotCheck.java
@@ -13,9 +13,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * {@code @return} Javadoc tags.
  *
  * <p>For consistency, descriptions of these tags must not end with
- * a period.
+ * a period.</p>
  *
- * <p>Valid:
+ * <p>Valid:</p>
  *
  * <pre>
  * &#47;**
@@ -24,7 +24,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *  *&#47;
  * </pre>
  *
- * <p>Invalid:
+ * <p>Invalid:</p>
  *
  * <pre>
  * &#47;**

--- a/src/main/java/com/qulice/checkstyle/JavadocThrowsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocThrowsCheck.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
  * not declare is misleading. The same applies when the tag names a
  * different type than what the signature throws, for example when the
  * javadoc says {@code @throws IOException} but the signature declares
- * {@code throws Exception}. Both examples below are rejected:
+ * {@code throws Exception}. Both examples below are rejected:</p>
  *
  * <pre>
  * &#47;**
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
  *
  * <p>Types are compared by their simple name, so a javadoc that uses a
  * fully qualified name (e.g. {@code java.io.IOException}) still
- * matches a signature that uses the unqualified form, and vice-versa.
+ * matches a signature that uses the unqualified form, and vice-versa.</p>
  *
  * @since 0.24.1
  */

--- a/src/main/java/com/qulice/checkstyle/JavadocUnclosedParagraphCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocUnclosedParagraphCheck.java
@@ -1,0 +1,217 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TextBlock;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.Locale;
+
+/**
+ * Check for a Javadoc paragraph that is never closed.
+ *
+ * <p>A paragraph opened with {@code <p>} must be closed with {@code </p>}
+ * before the next {@code <p>} starts and before the comment ends. Leaving
+ * it open makes the reader guess where the paragraph stops, and invites
+ * the habit of "closing" it with something else, such as a bare asterisk.
+ * See <a href="https://github.com/yegor256/qulice/issues/1783">#1783</a>.</p>
+ *
+ * <p>The following Javadoc will be reported as a violation, since the
+ * first paragraph is still open when the second one starts and the second
+ * one is still open when the comment ends:</p>
+ *
+ * <pre>
+ * &#47;**
+ *  <span style="color:red" >* &lt;p&gt;The first paragraph.</span>
+ *  *
+ *  <span style="color:red" >* &lt;p&gt;The second one.</span>
+ *  *&#47;
+ * </pre>
+ *
+ * <p>And this is how it should be written instead:</p>
+ *
+ * <pre>
+ * &#47;**
+ *  * &lt;p&gt;The first paragraph.&lt;/p&gt;
+ *  *
+ *  * &lt;p&gt;The second one.&lt;/p&gt;
+ *  *&#47;
+ * </pre>
+ *
+ * <p>The violation is reported on the line that opens the paragraph, since
+ * that is the tag left dangling. Lines inside a {@code <pre>...</pre>} block
+ * or a {@code {@snippet ...}} block are skipped, and so is the text of an
+ * inline {@code {@code ...}} or {@code {@literal ...}} tag, since a literal
+ * {@code <p>} may appear in any of them as example content rather than as
+ * a real tag.</p>
+ *
+ * @since 0.73.4
+ */
+public final class JavadocUnclosedParagraphCheck extends AbstractCheck {
+
+    /**
+     * Message about a paragraph that is never closed.
+     */
+    private static final String MSG =
+        "Opening paragraph tag <p> must be closed with </p>";
+
+    /**
+     * Opening tag.
+     */
+    private static final String OPEN = "<p>";
+
+    /**
+     * Closing tag.
+     */
+    private static final String CLOSE = "</p>";
+
+    /**
+     * Default constructor.
+     */
+    public JavadocUnclosedParagraphCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.CLASS_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.ANNOTATION_DEF,
+            TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.VARIABLE_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.METHOD_DEF,
+        };
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void visitToken(final DetailAST ast) {
+        final TextBlock doc =
+            this.getFileContents().getJavadocBefore(ast.getLineNo());
+        if (doc != null) {
+            this.check(doc);
+        }
+    }
+
+    private void check(final TextBlock doc) {
+        final String[] lines = JavadocUnclosedParagraphCheck.masked(doc);
+        boolean pre = false;
+        int depth = 0;
+        int open = -1;
+        for (int pos = 0; pos < lines.length; pos += 1) {
+            final String low = lines[pos];
+            if (depth > 0) {
+                depth += JavadocUnclosedParagraphCheck.braces(low);
+            } else if (low.contains("{@snippet")) {
+                depth = Math.max(
+                    0, JavadocUnclosedParagraphCheck.braces(low)
+                );
+            } else if (pre) {
+                pre = !low.contains("</pre>");
+            } else if (low.contains("<pre>")) {
+                pre = !low.contains("</pre>");
+            } else {
+                open = this.scan(doc, pos, low, open);
+            }
+        }
+        if (open >= 0) {
+            this.log(
+                doc.getStartLineNo() + open,
+                JavadocUnclosedParagraphCheck.MSG
+            );
+        }
+    }
+
+    private int scan(final TextBlock doc, final int pos, final String low,
+        final int start) {
+        int open = start;
+        for (int idx = 0; idx < low.length(); idx += 1) {
+            if (low.startsWith(JavadocUnclosedParagraphCheck.OPEN, idx)) {
+                if (open >= 0) {
+                    this.log(
+                        doc.getStartLineNo() + open,
+                        JavadocUnclosedParagraphCheck.MSG
+                    );
+                }
+                open = pos;
+            } else if (low.startsWith(JavadocUnclosedParagraphCheck.CLOSE, idx)) {
+                open = -1;
+            }
+        }
+        return open;
+    }
+
+    private static String[] masked(final TextBlock doc) {
+        final String[] lines = doc.getText();
+        final String[] bodies = new String[lines.length];
+        int inline = 0;
+        for (int pos = 0; pos < lines.length; pos += 1) {
+            final String body = JavadocUnclosedParagraphCheck.body(lines[pos])
+                .toLowerCase(Locale.ENGLISH);
+            final StringBuilder buf = new StringBuilder(body.length());
+            for (int idx = 0; idx < body.length(); idx += 1) {
+                final char chr = body.charAt(idx);
+                if (inline > 0) {
+                    if (chr == '{') {
+                        inline += 1;
+                    } else if (chr == '}') {
+                        inline -= 1;
+                    }
+                    buf.append(' ');
+                } else if (body.startsWith("{@code", idx)
+                    || body.startsWith("{@literal", idx)) {
+                    inline = 1;
+                    buf.append(' ');
+                } else {
+                    buf.append(chr);
+                }
+            }
+            bodies[pos] = buf.toString();
+        }
+        return bodies;
+    }
+
+    private static String body(final String line) {
+        String trimmed = line.trim();
+        if (trimmed.endsWith("*/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 2).trim();
+        }
+        if (trimmed.startsWith("/**")) {
+            trimmed = trimmed.substring(3).trim();
+        } else if (trimmed.startsWith("*")) {
+            trimmed = trimmed.substring(1).trim();
+        }
+        return trimmed;
+    }
+
+    private static int braces(final String body) {
+        int delta = 0;
+        for (int pos = 0; pos < body.length(); pos += 1) {
+            final char chr = body.charAt(pos);
+            if (chr == '{') {
+                delta += 1;
+            } else if (chr == '}') {
+                delta -= 1;
+            }
+        }
+        return delta;
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/JnaBinding.java
+++ b/src/main/java/com/qulice/checkstyle/JnaBinding.java
@@ -17,12 +17,12 @@ import java.util.Set;
  * flavour {@code com.sun.jna.win32.StdCallLibrary}, transcribes a native
  * library function by function. The name of every method and the length of
  * its parameter list come from the native side, so its author has no say in
- * either of them and the checks that judge them have nothing to say here.
+ * either of them and the checks that judge them have nothing to say here.</p>
  *
  * <p>Qulice runs Checkstyle on one file at a time, so neither of the two
  * interfaces is ever resolved to a class. The name in the {@code extends}
  * or {@code implements} clause is therefore trusted only when it is fully
- * qualified or when the file imports it from its own package.
+ * qualified or when the file imports it from its own package.</p>
  *
  * @since 1.0
  */

--- a/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
  * need to use
  * a comment inside a method - your code needs refactoring. Either move that
  * comment to a method javadoc block or add a logging mechanism with the same
- * text.
+ * text.</p>
  *
  * @since 0.3
  */

--- a/src/main/java/com/qulice/checkstyle/MethodDeclarationLengthCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodDeclarationLengthCheck.java
@@ -12,7 +12,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Checks that method and constructor declarations do not span multiple
  * lines when the entire signature can fit on one line within the limit.
  *
- * <p>This is how a correct declaration looks like:
+ * <p>This is how a correct declaration looks like:</p>
  *
  * <pre>
  * public Foo(final int max) throws IOException {
@@ -20,7 +20,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * }
  * </pre>
  *
- * <p>And this is what will be reported:
+ * <p>And this is what will be reported:</p>
  *
  * <pre>
  * public Foo(final int max)
@@ -33,7 +33,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * href="https://www.yegor256.com/2014/04/27/typical-mistakes-in-java-code.html#indentation">this
  * article</a>: one should put as much as possible on one line within the
  * configured limit (80 by default). See <a
- * href="https://github.com/yegor256/qulice/issues/647">#647</a>.
+ * href="https://github.com/yegor256/qulice/issues/647">#647</a>.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/MethodNameCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodNameCheck.java
@@ -13,10 +13,10 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
  * method, while a method of a type that extends {@code com.sun.jna.Library}
  * carries the name of a native function, spelled the way the library that
  * exports it spells it. Renaming it breaks the binding, so the check stays
- * silent there.
+ * silent there.</p>
  *
  * <p>Its messages come from the bundle of the stock check, since the two
- * report the very same things and one wording for them is enough.
+ * report the very same things and one wording for them is enough.</p>
  *
  * @since 1.0
  */

--- a/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * Checks the order of methods declaration.
  *
- * <p>Right order is: public, protected and private
+ * <p>Right order is: public, protected and private</p>
  *
  * @since 0.6
  */

--- a/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
@@ -12,7 +12,7 @@ import org.cactoos.text.Sub;
 /**
  * Check indents in multi line JavaDoc tags.
  *
- * <p>This is how you should format javadoc tags that need a few lines:
+ * <p>This is how you should format javadoc tags that need a few lines:</p>
  *
  * <pre>
  * &#47;**
@@ -30,7 +30,7 @@ import org.cactoos.text.Sub;
  *
  * <p>Keep in mind that all free-text information should go <b>before</b>
  * javadoc tags, or else it will treated as part of the latest tag and
- * qulice will complain.
+ * qulice will complain.</p>
  *
  * @since 0.3
  */

--- a/src/main/java/com/qulice/checkstyle/NoJavadocForPrivateMethodsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/NoJavadocForPrivateMethodsCheck.java
@@ -16,11 +16,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * has no users outside of it. Its name, the names of its parameters and
  * its body say everything a reader needs, while a Javadoc block above it
  * only repeats them and then rots, staying behind after the method is
- * renamed or its contract changes.
+ * renamed or its contract changes.</p>
  *
  * <p>Private constructors are not affected, since a constructor is not
  * a method and its Javadoc often carries the only explanation of why
- * the class must not be instantiated.
+ * the class must not be instantiated.</p>
  *
  * @since 0.73.4
  */

--- a/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -16,15 +16,15 @@ import java.util.regex.Pattern;
  * {@code this}.
  *
  * <p>If your method doesn't need {@code this} than why it is not
- * {@code static}?
+ * {@code static}?</p>
  *
  * <p>The exception here is when method has {@code @Override} annotation. There's
  * no concept of inheritance and polymorphism for static methods even if they
- * don't need {@code this} to perform the actual work.
+ * don't need {@code this} to perform the actual work.</p>
  *
  * <p>Another exception is when method is {@code abstract} or {@code native}.
  * Such methods don't have body so detection based on {@code this} doesn't
- * make sense for them.
+ * make sense for them.</p>
  *
  * @since 0.3
  */

--- a/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ParameterNumberCheck.java
@@ -17,15 +17,15 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * is a symptom of a class with too many attributes, and the class is what
  * has to be blamed, not its constructor. That's why a constructor with no
  * more parameters than the number of attributes of its class passes here,
- * no matter how big the limit is.
+ * no matter how big the limit is.</p>
  *
  * <p>A private method passes too. It is invisible outside its class, its
  * parameters belong to no contract anybody else can see, and wrapping them
- * into a new type only to satisfy the limit buys nothing.
+ * into a new type only to satisfy the limit buys nothing.</p>
  *
  * <p>So does a method of a JNA binding, whose parameter list repeats the
  * signature of a native function and cannot be shortened without breaking
- * the mapping.
+ * the mapping.</p>
  *
  * @since 1.0
  */

--- a/src/main/java/com/qulice/checkstyle/ProhibitFieldsInTestClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitFieldsInTestClassesCheck.java
@@ -22,11 +22,11 @@ import java.util.regex.Pattern;
  * are ignored, because they represent compile-time constants or
  * shared fixtures rather than per-test state. Fields declared on
  * nested helper types (stubs, fakes, recorders) are not flagged,
- * because they belong to the helper, not to the test class.
+ * because they belong to the helper, not to the test class.</p>
  *
  * <p>See also
  * <a href="http://www.yegor256.com/2015/05/25/unit-test-scaffolding.html">
- * Unit Test Scaffolding</a>.
+ * Unit Test Scaffolding</a>.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/ProhibitLineSeparatorInStringsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitLineSeparatorInStringsCheck.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
  * Prohibits hard-coded line separator escape sequences inside string literals.
  *
  * <p>The following constructs are prohibited, because {@code \n} and
- * {@code \r} are OS dependent line separators:
+ * {@code \r} are OS dependent line separators:</p>
  *
  * <pre>
  * String a = "first\nsecond";
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
  *
  * <p>These strings should be rewritten using
  * {@link System#lineSeparator()} or {@link String#format(String, Object[])}
- * with the {@code %n} directive, for example:
+ * with the {@code %n} directive, for example:</p>
  *
  * <pre>
  * String a = "first" + System.lineSeparator() + "second";

--- a/src/main/java/com/qulice/checkstyle/ProhibitStaticNestedClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitStaticNestedClassesCheck.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
  * default {@code *Test.java}, {@code *IT.java}, {@code *ITCase.java})
  * are inspected, since fake/stub helpers nested inside test classes
  * are a normal pattern (see
- * {@link ProhibitFieldsInTestClassesCheck}).
+ * {@link ProhibitFieldsInTestClassesCheck}).</p>
  *
  * @since 0.73.4
  */

--- a/src/main/java/com/qulice/checkstyle/RedundantSuperConstructorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/RedundantSuperConstructorCheck.java
@@ -17,7 +17,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * the {@link Object} constructor, which the compiler inserts on its own.
  * The explicit call is therefore redundant and is most often a sign
  * of confusion between class extension and interface implementation,
- * for example:
+ * for example:</p>
  *
  * <pre>
  * public class NewAgent implements Agent {
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * <p>The rule only applies to constructors of {@code class} declarations.
  * It does not apply to records or enums, where {@code super(...)}
- * either targets a fixed superclass or is illegal.
+ * either targets a fixed superclass or is illegal.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
+++ b/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 /**
  * Check the required JavaDoc tag in the lines.
  *
- * <p>Correct format is the following (of a class javadoc):
+ * <p>Correct format is the following (of a class javadoc):</p>
  *
  * <pre>
  * &#47;**

--- a/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
+++ b/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
@@ -16,13 +16,13 @@ import java.util.Optional;
  * <p>For anything beyond the fastpath, String.split builds a fresh Pattern
  * on every call, which is wasteful in tight loops. Extract the regex into a
  * private static final Pattern field and use Pattern.split(CharSequence)
- * instead.
+ * instead.</p>
  *
  * <p>The JDK fastpath accepts only a one-char string whose sole character is
  * not a regex meta character, or a two-char string whose first character is
- * a backslash and whose second character is not an ASCII letter or digit.
+ * a backslash and whose second character is not an ASCII letter or digit.</p>
  *
- * <p>Examples that are flagged:
+ * <p>Examples that are flagged:</p>
  *
  * <pre>
  * "abxxdexxzy".split("xx");
@@ -30,7 +30,7 @@ import java.util.Optional;
  * "abxxdexxzy".split(".");
  * </pre>
  *
- * <p>Examples that are accepted:
+ * <p>Examples that are accepted:</p>
  *
  * <pre>
  * "abxdexzy".split("x");
@@ -41,7 +41,7 @@ import java.util.Optional;
  *
  * <p>The check only reports calls whose first argument is a string literal:
  * when the regex is a variable the optimization cannot be determined from
- * the AST alone.
+ * the AST alone.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/StaticAccessViaInstanceCheck.java
+++ b/src/main/java/com/qulice/checkstyle/StaticAccessViaInstanceCheck.java
@@ -19,11 +19,11 @@ import java.util.Set;
  * (for example {@code MyClass.staticMethod()}), not through
  * {@code this.staticMethod()}. Accessing a static member through an instance
  * reference is misleading because it looks like a polymorphic call while the
- * dispatch is actually resolved statically at compile time.
+ * dispatch is actually resolved statically at compile time.</p>
  *
  * <p>This check scans every class, enum and interface in the file, collects
  * the names of all declared static methods and fields, and reports every
- * {@code this.name} expression where {@code name} is in that set.
+ * {@code this.name} expression where {@code name} is in that set.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * Checks for not using concatenation of string literals in any form.
  *
- * <p>The following constructs are prohibited:
+ * <p>The following constructs are prohibited:</p>
  *
  * <pre>
  * String a = "done in " + time + " seconds";
@@ -26,10 +26,10 @@ import java.util.List;
  * difficult to understand how the text will look after concatenation,
  * especially if the text is long and there are more than a few {@code +}
  * operators. Second, you won't be able to translate your text to other
- * languages later, if you don't have solid string literals.
+ * languages later, if you don't have solid string literals.</p>
  *
  * <p>There are two alternatives to concatenation: {@link StringBuilder}
- * and {@link String#format(String,Object[])}.
+ * and {@link String#format(String,Object[])}.</p>
  *
  * @since 0.3
  */

--- a/src/main/java/com/qulice/checkstyle/SuppressionTag.java
+++ b/src/main/java/com/qulice/checkstyle/SuppressionTag.java
@@ -17,7 +17,7 @@ import java.util.Collection;
  * one to the other. A tag that influences
  * no violation of its check suppresses nothing and lingers as a lie about
  * the code, which is what {@link Suppressions} finds with the help of this
- * class.
+ * class.</p>
  *
  * @since 1.0
  */
@@ -73,7 +73,7 @@ final class SuppressionTag {
      * <p>The filters match the captured name against the fully qualified
      * class name of the check, which the name is a substring of, so the
      * same test decides here whether an event belongs to the suppressed
-     * check.
+     * check.</p>
      *
      * @param events Events collected with the nearby filters removed
      * @return True if no event of the check falls in the influence range

--- a/src/main/java/com/qulice/checkstyle/UnknownSuppressionCheck.java
+++ b/src/main/java/com/qulice/checkstyle/UnknownSuppressionCheck.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
  * suppresses nothing and stays in the source as a lie about the code.
  * PMD reports the same mistake in {@code @SuppressWarnings} annotations.
  * The other half, a suppression that names an enabled check but covers no
- * violation of it, is reported by {@link UnusedSuppressions}.
+ * violation of it, is reported by {@link UnusedSuppressions}.</p>
  *
  * @since 1.0
  */

--- a/src/main/java/com/qulice/checkstyle/UnnecessaryJavaLangCheck.java
+++ b/src/main/java/com/qulice/checkstyle/UnnecessaryJavaLangCheck.java
@@ -17,13 +17,13 @@ import java.util.regex.Pattern;
  * <p>Classes from the {@code java.lang} package are imported implicitly,
  * so qualifying them with their package name adds nothing. A field whose
  * type is written with the {@code java.lang.} prefix should instead be
- * declared as {@code private final String name}, in both code and Javadoc.
+ * declared as {@code private final String name}, in both code and Javadoc.</p>
  *
  * <p>Unlike a plain line-based regular expression, this check ignores the
  * prefix when it appears inside a string literal or a text block. A string
  * constant that happens to contain the {@code java.lang.} substring is data,
  * not a type reference, and must not be reported. See
- * <a href="https://github.com/yegor256/qulice/issues/1703">#1703</a>.
+ * <a href="https://github.com/yegor256/qulice/issues/1703">#1703</a>.</p>
  *
  * @since 0.24
  */

--- a/src/main/java/com/qulice/maven/CheckerExcludes.java
+++ b/src/main/java/com/qulice/maven/CheckerExcludes.java
@@ -10,7 +10,7 @@ import javax.annotation.Nullable;
 /**
  * Converts a checker exclude into exclude param.
  *
- * <p>E.g. "checkstyle:.*" will become ".*".
+ * <p>E.g. "checkstyle:.*" will become ".*".</p>
  *
  * @since 0.1
  */

--- a/src/main/java/com/qulice/maven/PomXpathValidator.java
+++ b/src/main/java/com/qulice/maven/PomXpathValidator.java
@@ -16,7 +16,7 @@ import org.apache.commons.io.FileUtils;
 /**
  * Check pom.xml with XPath validation queries.
  *
- * <p>Restrictions:
+ * <p>Restrictions:</p>
  *
  * <ol>
  * <li>Each xpath component should contains namespace prefix pom:</li>

--- a/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UseStringIsEmptyRule.java
@@ -22,7 +22,7 @@ import net.sourceforge.pmd.lang.java.types.JTypeMirror;
  * the same six are recognised when the operands are swapped. Comparisons
  * against {@code 1} such as {@code length() == 1} or {@code length() > 1}
  * describe single-character strings and have no {@code isEmpty()}
- * counterpart, so they are left alone.
+ * counterpart, so they are left alone.</p>
  *
  * @since 0.18
  */

--- a/src/main/java/com/qulice/spi/Environment.java
+++ b/src/main/java/com/qulice/spi/Environment.java
@@ -86,7 +86,7 @@ public interface Environment {
      *
      * <p>The pattern matching scheme used is wildcard matching. The characters
      * '?' and '*' represents single or multiple wildcard characters,
-     * respectively. Pattern matching is case sensitive.
+     * respectively. Pattern matching is case sensitive.</p>
      *
      * @param pattern File name pattern
      * @return Collection of files, matching the specified pattern

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -497,6 +497,12 @@
     See https://github.com/yegor256/qulice/issues/1783
     -->
     <module name="com.qulice.checkstyle.JavadocStrayAsteriskCheck"/>
+    <!--
+    This one makes sure that every &lt;p&gt; in a Javadoc block is closed
+    with a matching &lt;/p&gt;.
+    See https://github.com/yegor256/qulice/issues/1783
+    -->
+    <module name="com.qulice.checkstyle.JavadocUnclosedParagraphCheck"/>
     <module name="com.qulice.checkstyle.JavadocFirstLineCheck"/>
     <module name="com.qulice.checkstyle.JavadocNoIndentCheck"/>
     <module name="com.qulice.checkstyle.DiamondOperatorCheck"/>

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -196,6 +196,7 @@ final class ChecksTest {
             "JavadocEmptyLineBeforeTagCheck",
             "JavadocCompactParagraphCheck",
             "JavadocStrayAsteriskCheck",
+            "JavadocUnclosedParagraphCheck",
             "JavadocFirstLineCheck",
             "JavadocNoIndentCheck",
             "JavadocTagsCheck",

--- a/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
@@ -26,7 +26,7 @@ final class PmdAssertionsTest {
      * import static org.junit.Assert.assert* import static
      * junit.framework.Assert.assert*.
      *
-     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}</p>
      *
      * @throws Exception If something wrong happens inside.
      */
@@ -45,7 +45,7 @@ final class PmdAssertionsTest {
      * PmdValidator can prohibit plain JUnit assertion in test methods like
      * Assert.assertEquals.
      *
-     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}</p>
      *
      * @throws Exception If something wrong happens inside.
      */
@@ -63,7 +63,7 @@ final class PmdAssertionsTest {
     /**
      * PmdValidator can allow Assert.fail().
      *
-     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}
+     * <p>Custom Rule {@link ProhibitPlainJunitAssertionsRule}</p>
      *
      * @throws Exception If something wrong happens inside.
      */

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/Invalid.java
@@ -1,0 +1,58 @@
+/*
+ * Hello.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is not a real Java class. It won't be compiled ever.
+ *
+ * <p>The first paragraph is still open when the second one starts.
+ *
+ * <p>And the second one is still open when the comment ends.
+ */
+public final class Invalid {
+
+    /**
+     * A field.
+     *
+     * <p>A single paragraph that nobody ever closes.
+     */
+    private int number;
+
+    /**
+     * A method.
+     *
+     * <p>This one is closed properly.</p>
+     *
+     * <p>This one is not, and the block tags below do not close it.
+     *
+     * @return Nothing
+     */
+    public int method() {
+        return this.number;
+    }
+
+    /**
+     * An annotated method.
+     *
+     * <p>Left open, behind an annotation.
+     *
+     * @return Nothing
+     */
+    @SuppressWarnings("unchecked")
+    public int annotated() {
+        return this.number;
+    }
+
+    /**
+     * A method whose inline code must not count as a tag.
+     *
+     * <p>The text mentions {@code <p>} and {@code </p>}, yet the paragraph
+     * itself is never closed.
+     *
+     * @return Nothing
+     */
+    public int inline() {
+        return this.number;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/Valid.java
@@ -1,0 +1,73 @@
+/*
+ * Hello.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is not a real Java class. It won't be compiled ever.
+ *
+ * <p>Every paragraph here is closed where it ends.</p>
+ *
+ * <p>Including this one, which spans more than a single line before
+ * it finally closes.</p>
+ */
+public final class Valid {
+
+    /**
+     * A field, described without any paragraph at all.
+     */
+    private int number;
+
+    /**
+     * A method whose paragraph closes before the block tags.
+     *
+     * <p>Closed right here.</p>
+     *
+     * @return Nothing
+     */
+    public int first() {
+        return this.number;
+    }
+
+    /**
+     * A method that writes the tags as inline code.
+     *
+     * <p>A paragraph opens with {@code <p>} and closes with {@code </p>},
+     * and neither of those counts as a real tag here.</p>
+     *
+     * @return Nothing
+     */
+    public int inline() {
+        return this.number;
+    }
+
+    /**
+     * A method with a pre block that shows literal tags.
+     *
+     * <p>Example configuration:</p>
+     * <pre>
+     * &lt;p&gt;
+     * some example
+     * </pre>
+     *
+     * @return Nothing
+     */
+    public int second() {
+        return this.number;
+    }
+
+    /**
+     * A method with a snippet that shows literal tags.
+     *
+     * <p>Here is a snippet:</p>
+     * {@snippet :
+     * <p>
+     * text
+     * }
+     *
+     * @return Nothing
+     */
+    public int third() {
+        return this.number;
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.JavadocUnclosedParagraphCheck"/>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/violations.txt
@@ -1,0 +1,6 @@
+9:Opening paragraph tag <p> must be closed with </p>
+11:Opening paragraph tag <p> must be closed with </p>
+18:Opening paragraph tag <p> must be closed with </p>
+27:Opening paragraph tag <p> must be closed with </p>
+38:Opening paragraph tag <p> must be closed with </p>
+50:Opening paragraph tag <p> must be closed with </p>


### PR DESCRIPTION
Follow-up to #1785, implementing the other half of #1783.

## What

Adds `JavadocUnclosedParagraphCheck`. A `<p>` opened in a Javadoc comment
was free to stay open forever: `JavadocParagraph` (#1692) only governs the
blank lines around it, `JavadocCompactParagraph` (#1709) only governs where
the tags sit on their lines, and `JavadocStrayAsteriskCheck` (#1785) only
catches the specific bad habit of "closing" a paragraph with a bare `*`.
Nothing noticed a paragraph that was simply never closed.

The check reports a `<p>` that has no matching `</p>` before the next `<p>`
or before the comment ends, and points at the line that opens the dangling
paragraph — that is the tag left hanging.

```java
/**
 * <p>The first paragraph.     <-- reported: still open when the next one starts
 *
 * <p>The second one.          <-- reported: still open when the comment ends
 */
```

## What is exempt

A `<p>` that is example content rather than a real tag is skipped:

- lines inside a `<pre>...</pre>` block
- lines inside a `{@snippet ...}` block
- the text of an inline `{@code ...}` or `{@literal ...}` tag

That last one is not theoretical. Three classes in this repo document these
very tags and write `{@code <p>}` / `{@code </p>}` in their prose; without
masking inline code, the check reads those as live tags and reports (and,
worse, a mechanical fixer "closes" the wrong lines). Inline-code spans are
masked across the whole comment before any tag scanning, so a span that
wraps onto a second line is handled too.

## Closing Qulice's own paragraphs

The check is registered in `checks.xml`, so it is on by default — which
means this repo had to comply. 99 paragraphs across 47 files now carry a
`</p>`, placed at the end of the paragraph's last text line so that
`JavadocCompactParagraph` stays happy (it wants `</p>` glued to the text it
closes, not starting its own line).

Every one of those edits is a pure in-place append: `git diff --numstat`
shows 1:1 line counts for all 48 touched Java files, no re-wrapping was
needed, and no line crossed the 100-character `LineLength` limit.

Where a paragraph is followed by a block element, the `</p>` lands on the
intro sentence, before the block — which is also what HTML requires, since
`<pre>`, `<ul>` and `<ol>` cannot nest inside `<p>`:

```java
 * <p>This is how a correct bracket structure should look like:</p>
 *
 * <pre>
```

`JavadocCompactParagraphCheck`'s own Javadoc said `</p>` was used "at all"
only optionally; that sentence is now stale, so it is reworded to point at
the new check as the one that insists on the closing tag.

## Testing

`ChecksTest` resources under
`src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocUnclosedParagraphCheck/`:

- `Invalid.java` — six violations: a paragraph left open when the next one
  starts, one left open at the end of the comment, one where block tags
  follow but do not close it, one behind an annotation (guarding
  `getJavadocBefore` resolving past it), and one whose prose mentions
  `{@code <p>}` and `{@code </p>}` while the real paragraph stays open.
- `Valid.java` — closed paragraphs (single- and multi-line), a comment with
  no paragraph at all, a paragraph closed before its block tags, `<pre>` and
  `{@snippet}` blocks holding literal tags, and prose that writes both tags
  as inline code.

Verified locally:

- `mvn test` — 520 tests, 0 failures (up from 518; the two new ones are this
  check's Valid/Invalid pair).
- `mvn verify -Pqulice -DskipTests -DskipITs` — clean, i.e. Qulice's own
  sources satisfy the new check and nothing else regressed.
- `src/it` has no `<p>` in any Java file, so the invoker ITs are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZHWBsA9YazG1LZRmQbqXF)_