### PR TITLE
feat(checkstyle): #1787 prohibit a constant that is used only once

### DIFF
--- a/src/it/checkstyle-violations/verify.groovy
+++ b/src/it/checkstyle-violations/verify.groovy
@@ -19,3 +19,5 @@ assert log.text.contains('Violations.java[49]: Lists.newArrayList should be init
 assert !log.text.contains('Got an exception - java.lang.NullPointerException')
 assert log.text.findAll('SomeTest.java .+ (JavadocMethodCheck)').isEmpty()
 assert !log.text.contains('IndentationChecks.java[49]: method call rparen at indentation level 12')
+assert log.text.contains('Constants.java[12]: Private constant "ONCE" is used only once, inline it (SingleUseConstantCheck)')
+assert !log.text.contains('Private constant "TWICE" is used only once')

--- a/src/it/dependency-imported-in-source/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/dependency-imported-in-source/src/main/java/com/qulice/foo/Sample.java
@@ -19,7 +19,7 @@ public final class Sample {
 
     /**
      * Return the "not found" constant.
-     * @return Inlined constant value
+     * @return The {@value #NOT_FOUND} index
      * @checkstyle NonStaticMethod (2 lines)
      */
     public int missing() {

--- a/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
@@ -28,11 +28,6 @@ import org.cactoos.text.Joined;
 public final class CascadeIndentationCheck extends AbstractFileSetCheck {
 
     /**
-     * Exact indentation increase difference.
-     */
-    private static final int LINE_INDENT_DIFF = 4;
-
-    /**
      * Default constructor.
      */
     public CascadeIndentationCheck() {
@@ -65,8 +60,7 @@ public final class CascadeIndentationCheck extends AbstractFileSetCheck {
         final int previous, final boolean closer) {
         final String message;
         if (current > previous
-            && current != previous
-            + CascadeIndentationCheck.LINE_INDENT_DIFF) {
+            && current != previous + 4) {
             message = String.format(
                 new Joined(
                     "",

--- a/src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocCompactParagraphCheck.java
@@ -48,18 +48,6 @@ import java.util.Locale;
 public final class JavadocCompactParagraphCheck extends AbstractCheck {
 
     /**
-     * Message about an opening tag that ends a line.
-     */
-    private static final String MSG_OPEN =
-        "Opening paragraph tag <p> must be followed by text on the same line";
-
-    /**
-     * Message about a closing tag that starts a line.
-     */
-    private static final String MSG_CLOSE =
-        "Closing paragraph tag </p> must be preceded by text on the same line";
-
-    /**
      * Default constructor.
      */
     public JavadocCompactParagraphCheck() {
@@ -129,10 +117,16 @@ public final class JavadocCompactParagraphCheck extends AbstractCheck {
 
     private void report(final int pos, final String body) {
         if (body.endsWith("<p>")) {
-            this.log(pos + 1, JavadocCompactParagraphCheck.MSG_OPEN);
+            this.log(
+                pos + 1,
+                "Opening paragraph tag <p> must be followed by text on the same line"
+            );
         }
         if (body.startsWith("</p>")) {
-            this.log(pos + 1, JavadocCompactParagraphCheck.MSG_CLOSE);
+            this.log(
+                pos + 1,
+                "Closing paragraph tag </p> must be preceded by text on the same line"
+            );
         }
     }
 

--- a/src/main/java/com/qulice/checkstyle/JavadocNoIndentCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocNoIndentCheck.java
@@ -33,12 +33,6 @@ import java.util.Locale;
 public final class JavadocNoIndentCheck extends AbstractCheck {
 
     /**
-     * Message about the extra indentation.
-     */
-    private static final String MESSAGE =
-        "Extra indentation is not allowed in Javadoc";
-
-    /**
      * Default constructor.
      */
     public JavadocNoIndentCheck() {
@@ -99,7 +93,10 @@ public final class JavadocNoIndentCheck extends AbstractCheck {
             }
             if (!region && !tagged
                 && JavadocNoIndentCheck.overIndented(body)) {
-                this.log(pos + 1, JavadocNoIndentCheck.MESSAGE);
+                this.log(
+                    pos + 1,
+                    "Extra indentation is not allowed in Javadoc"
+                );
             }
             pre = JavadocNoIndentCheck.nextPre(pre, line);
             depth = JavadocNoIndentCheck.nextDepth(depth, line);

--- a/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -48,16 +48,6 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
         Pattern.compile("(\\*/|@|[^\\s\\*])");
 
     /**
-     * Multiline finished at end of comment.
-     */
-    private static final String END_JAVADOC = "*/";
-
-    /**
-     * Multiline finished at next Javadoc.
-     */
-    private static final String NEXT_TAG = "@";
-
-    /**
      * Default constructor.
      */
     public JavadocParameterOrderCheck() {
@@ -163,8 +153,7 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
             if (multiline.find()) {
                 remindex = lines.length;
                 final String lfin = multiline.group(1);
-                if (!JavadocParameterOrderCheck.NEXT_TAG.equals(lfin)
-                    && !JavadocParameterOrderCheck.END_JAVADOC.equals(lfin)) {
+                if (!"@".equals(lfin) && !"*/".equals(lfin)) {
                     tags.add(new JavadocTag(line, column, paramone, paramtwo));
                 }
             }

--- a/src/main/java/com/qulice/checkstyle/JavadocStrayAsteriskCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocStrayAsteriskCheck.java
@@ -47,12 +47,6 @@ import java.util.Locale;
 public final class JavadocStrayAsteriskCheck extends AbstractCheck {
 
     /**
-     * Message about a line ending with a stray asterisk.
-     */
-    private static final String MSG =
-        "Javadoc line must not end with a stray asterisk";
-
-    /**
      * Default constructor.
      */
     public JavadocStrayAsteriskCheck() {
@@ -113,7 +107,7 @@ public final class JavadocStrayAsteriskCheck extends AbstractCheck {
             } else if (body.endsWith("*")) {
                 this.log(
                     doc.getStartLineNo() + pos,
-                    JavadocStrayAsteriskCheck.MSG
+                    "Javadoc line must not end with a stray asterisk"
                 );
             }
         }

--- a/src/main/java/com/qulice/checkstyle/JavadocTagsDotCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocTagsDotCheck.java
@@ -38,12 +38,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 public final class JavadocTagsDotCheck extends AbstractCheck {
 
     /**
-     * Message reported when a tag description ends with a dot.
-     */
-    private static final String MESSAGE =
-        "No dot allowed at the end of a '@param' or '@return' Javadoc tag";
-
-    /**
      * Default constructor.
      */
     public JavadocTagsDotCheck() {
@@ -103,7 +97,10 @@ public final class JavadocTagsDotCheck extends AbstractCheck {
             final String content = JavadocTagsDotCheck.stripMarker(lines[pos]);
             if (!content.isEmpty()) {
                 if (content.endsWith(".")) {
-                    this.log(pos + 1, JavadocTagsDotCheck.MESSAGE);
+                    this.log(
+                        pos + 1,
+                        "No dot allowed at the end of a '@param' or '@return' Javadoc tag"
+                    );
                 }
                 break;
             }

--- a/src/main/java/com/qulice/checkstyle/JavadocUnclosedParagraphCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocUnclosedParagraphCheck.java
@@ -59,16 +59,6 @@ public final class JavadocUnclosedParagraphCheck extends AbstractCheck {
         "Opening paragraph tag <p> must be closed with </p>";
 
     /**
-     * Opening tag.
-     */
-    private static final String OPEN = "<p>";
-
-    /**
-     * Closing tag.
-     */
-    private static final String CLOSE = "</p>";
-
-    /**
      * Default constructor.
      */
     public JavadocUnclosedParagraphCheck() {
@@ -144,7 +134,7 @@ public final class JavadocUnclosedParagraphCheck extends AbstractCheck {
         final int start) {
         int open = start;
         for (int idx = 0; idx < low.length(); idx += 1) {
-            if (low.startsWith(JavadocUnclosedParagraphCheck.OPEN, idx)) {
+            if (low.startsWith("<p>", idx)) {
                 if (open >= 0) {
                     this.log(
                         doc.getStartLineNo() + open,
@@ -152,7 +142,7 @@ public final class JavadocUnclosedParagraphCheck extends AbstractCheck {
                     );
                 }
                 open = pos;
-            } else if (low.startsWith(JavadocUnclosedParagraphCheck.CLOSE, idx)) {
+            } else if (low.startsWith("</p>", idx)) {
                 open = -1;
             }
         }

--- a/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
+++ b/src/main/java/com/qulice/checkstyle/SimpleStringSplitCheck.java
@@ -48,11 +48,6 @@ import java.util.Optional;
 public final class SimpleStringSplitCheck extends AbstractCheck {
 
     /**
-     * Regex meta characters the JDK fastpath refuses for a one-char pattern.
-     */
-    private static final String META = ".$|()[{^?*+\\";
-
-    /**
      * Default constructor.
      */
     public SimpleStringSplitCheck() {
@@ -137,7 +132,7 @@ public final class SimpleStringSplitCheck extends AbstractCheck {
         final boolean result;
         final int len = regex.length();
         if (len == 1) {
-            result = SimpleStringSplitCheck.META.indexOf(regex.charAt(0)) < 0;
+            result = ".$|()[{^?*+\\".indexOf(regex.charAt(0)) < 0;
         } else if (len == 2 && regex.charAt(0) == '\\') {
             result = !SimpleStringSplitCheck.isAsciiAlphanumeric(regex.charAt(1));
         } else {

--- a/src/main/java/com/qulice/checkstyle/SingleUseConstantCheck.java
+++ b/src/main/java/com/qulice/checkstyle/SingleUseConstantCheck.java
@@ -1,0 +1,187 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Checks that a private static constant is mentioned more than once.
+ *
+ * <p>A {@code private static final} field that the file mentions only
+ * once is an indirection that pays for nothing: the reader has to jump
+ * to the top of the class in order to learn what the single expression
+ * below really says. Such a constant belongs inside its only usage,
+ * since a constant starts to pay for itself at the second usage, where
+ * it removes a duplicate.</p>
+ *
+ * <p>Usages are counted as identifiers of the very same text anywhere
+ * in the file, the declaration of the constant included, which is why a
+ * constant used exactly once is mentioned exactly twice. A name that
+ * some other declaration happens to reuse is counted too, which only
+ * makes the check more forgiving.</p>
+ *
+ * <p>Only a constant with a literal initializer is inspected. A
+ * constant built by a method call or by {@code new}, like a compiled
+ * {@link java.util.regex.Pattern}, stays where it is, since inlining it
+ * would move a computation into a method body and could turn a
+ * once-per-class cost into a per-call one. The same goes for an array,
+ * which is a mutable object no matter how final its field is.</p>
+ *
+ * <p>A constant that a Javadoc comment refers to, the way {@code {@value
+ * #NAME}} and {@code {@link #NAME}} do, is left alone as well, since
+ * the documentation is a usage of its own and inlining the constant
+ * would break it. So is {@code serialVersionUID}, which belongs to Java
+ * serialization rather than to the class that declares it.</p>
+ *
+ * <p>A constant that is not mentioned anywhere at all belongs to
+ * {@link ConstantUsageCheck}, which reports it as unused.</p>
+ *
+ * @since 0.73.4
+ */
+public final class SingleUseConstantCheck extends AbstractCheck {
+
+    /**
+     * Token types an inlineable initializer may be made of.
+     */
+    private static final Set<Integer> LITERALS = Set.of(
+        TokenTypes.EXPR,
+        TokenTypes.NUM_INT,
+        TokenTypes.NUM_LONG,
+        TokenTypes.NUM_FLOAT,
+        TokenTypes.NUM_DOUBLE,
+        TokenTypes.STRING_LITERAL,
+        TokenTypes.CHAR_LITERAL,
+        TokenTypes.TEXT_BLOCK_LITERAL_BEGIN,
+        TokenTypes.TEXT_BLOCK_CONTENT,
+        TokenTypes.TEXT_BLOCK_LITERAL_END,
+        TokenTypes.LITERAL_TRUE,
+        TokenTypes.LITERAL_FALSE,
+        TokenTypes.LITERAL_NULL,
+        TokenTypes.IDENT,
+        TokenTypes.DOT,
+        TokenTypes.LPAREN,
+        TokenTypes.RPAREN,
+        TokenTypes.UNARY_MINUS,
+        TokenTypes.UNARY_PLUS,
+        TokenTypes.PLUS,
+        TokenTypes.MINUS,
+        TokenTypes.STAR,
+        TokenTypes.DIV,
+        TokenTypes.MOD
+    );
+
+    /**
+     * Default constructor.
+     */
+    public SingleUseConstantCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[]{TokenTypes.VARIABLE_DEF};
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        final DetailAST name = ast.findFirstToken(TokenTypes.IDENT);
+        if (SingleUseConstantCheck.isInlineable(ast)
+            && !this.documented(name.getText())
+            && SingleUseConstantCheck.mentions(
+                SingleUseConstantCheck.root(ast), name.getText()
+            ) == 2) {
+            this.log(
+                name.getLineNo(),
+                String.format(
+                    "Private constant \"%s\" is used only once, inline it",
+                    name.getText()
+                )
+            );
+        }
+    }
+
+    private boolean documented(final String name) {
+        final Pattern ref = Pattern.compile(
+            String.format("#%s\\b", Pattern.quote(name))
+        );
+        boolean found = false;
+        for (final String line : this.getLines()) {
+            if (ref.matcher(line).find()) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+
+    private static boolean isInlineable(final DetailAST node) {
+        final DetailAST assign = node.findFirstToken(TokenTypes.ASSIGN);
+        return SingleUseConstantCheck.isConstant(node)
+            && assign != null
+            && SingleUseConstantCheck.isLiteral(assign.getFirstChild());
+    }
+
+    private static boolean isConstant(final DetailAST node) {
+        return node.getParent().getType() == TokenTypes.OBJBLOCK
+            && !"serialVersionUID".equals(
+                node.findFirstToken(TokenTypes.IDENT).getText()
+            )
+            && SingleUseConstantCheck.isShared(node);
+    }
+
+    private static boolean isShared(final DetailAST node) {
+        final DetailAST mods = node.findFirstToken(TokenTypes.MODIFIERS);
+        return mods.findFirstToken(TokenTypes.LITERAL_PRIVATE) != null
+            && mods.findFirstToken(TokenTypes.LITERAL_STATIC) != null
+            && mods.findFirstToken(TokenTypes.FINAL) != null;
+    }
+
+    private static boolean isLiteral(final DetailAST node) {
+        boolean literal =
+            SingleUseConstantCheck.LITERALS.contains(node.getType());
+        DetailAST child = node.getFirstChild();
+        while (literal && child != null) {
+            literal = SingleUseConstantCheck.isLiteral(child);
+            child = child.getNextSibling();
+        }
+        return literal;
+    }
+
+    private static int mentions(final DetailAST node, final String name) {
+        int found = 0;
+        if (node.getType() == TokenTypes.IDENT
+            && node.getText().equals(name)) {
+            found = 1;
+        }
+        DetailAST child = node.getFirstChild();
+        while (child != null) {
+            found += SingleUseConstantCheck.mentions(child, name);
+            child = child.getNextSibling();
+        }
+        return found;
+    }
+
+    private static DetailAST root(final DetailAST node) {
+        DetailAST top = node;
+        while (top.getParent() != null) {
+            top = top.getParent();
+        }
+        return top;
+    }
+}

--- a/src/main/java/com/qulice/checkstyle/UnnecessaryJavaLangCheck.java
+++ b/src/main/java/com/qulice/checkstyle/UnnecessaryJavaLangCheck.java
@@ -38,11 +38,6 @@ public final class UnnecessaryJavaLangCheck extends AbstractCheck {
         Pattern.compile("\\bjava\\.lang\\.[A-Z]");
 
     /**
-     * Line-separator character embedded in the text of a text-block node.
-     */
-    private static final char EOL = '\n';
-
-    /**
      * Mutable copy of the file lines, with the contents of string literals
      * and text blocks blanked out so the pattern cannot match inside them.
      */
@@ -113,7 +108,7 @@ public final class UnnecessaryJavaLangCheck extends AbstractCheck {
         final String text = ast.getText();
         int span = 0;
         for (int pos = 0; pos < text.length(); ++pos) {
-            if (text.charAt(pos) == UnnecessaryJavaLangCheck.EOL) {
+            if (text.charAt(pos) == '\n') {
                 ++span;
             }
         }

--- a/src/main/java/com/qulice/errorprone/Diagnostics.java
+++ b/src/main/java/com/qulice/errorprone/Diagnostics.java
@@ -45,11 +45,6 @@ final class Diagnostics {
     );
 
     /**
-     * Check name for a diagnostic that carries no bracketed name of its own.
-     */
-    private static final String JAVAC = "javac";
-
-    /**
      * Name of the validator to attribute the violations to.
      */
     private final String validator;
@@ -114,6 +109,6 @@ final class Diagnostics {
     }
 
     private static String check(final String name) {
-        return Optional.ofNullable(name).orElse(Diagnostics.JAVAC);
+        return Optional.ofNullable(name).orElse("javac");
     }
 }

--- a/src/main/java/com/qulice/maven/CheckerExcludes.java
+++ b/src/main/java/com/qulice/maven/CheckerExcludes.java
@@ -17,11 +17,6 @@ import javax.annotation.Nullable;
 final class CheckerExcludes implements Function<String, String> {
 
     /**
-     * All checkers.
-     */
-    private static final String ALL = "*";
-
-    /**
      * Name of checker.
      */
     private final String checker;
@@ -41,7 +36,7 @@ final class CheckerExcludes implements Function<String, String> {
         if (input != null) {
             final String[] exclude = input.split(":", 2);
             final String check = exclude[0];
-            final boolean appropriate = CheckerExcludes.ALL.equals(check)
+            final boolean appropriate = "*".equals(check)
                 || this.checker.equals(check);
             if (appropriate && exclude.length > 1) {
                 result = exclude[1];

--- a/src/main/java/com/qulice/pmd/rules/TooManyFieldsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyFieldsRule.java
@@ -13,8 +13,9 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * Rule to check that a class does not declare too many fields. Like the PMD
  * built-in {@code TooManyFields} rule, this implementation counts the
  * fields declared in the body of the class, skipping the static and the
- * final ones, since those are constants rather than state. Unlike the
- * built-in rule, it skips a class that extends
+ * final ones, since those are constants rather than state, and reports a
+ * class that declares more than fifteen of them. Unlike the built-in
+ * rule, it skips a class that extends
  * {@code org.apache.maven.plugin.AbstractMojo}: a Maven Mojo declares one
  * field per {@code @Parameter} it exposes to users of the plugin goal,
  * because the Maven Plugin API requires each configurable parameter as a
@@ -28,11 +29,6 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * @since 1.0
  */
 public final class TooManyFieldsRule extends AbstractJavaRulechainRule {
-
-    /**
-     * The largest number of non-static non-final fields a class may declare.
-     */
-    private static final int MAX = 15;
 
     /**
      * The base class of every Maven Mojo.
@@ -51,7 +47,7 @@ public final class TooManyFieldsRule extends AbstractJavaRulechainRule {
     @Override
     public Object visit(final ASTClassDeclaration type, final Object data) {
         if (!TooManyFieldsRule.MOJO.matches(type.getSuperClassTypeNode())
-            && TooManyFieldsRule.state(type) > TooManyFieldsRule.MAX) {
+            && TooManyFieldsRule.state(type) > 15) {
             this.asCtx(data).addViolation(type);
         }
         return data;

--- a/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
@@ -20,9 +20,10 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * PMD built-in {@code TooManyMethods} rule, this implementation counts
  * only public and protected methods, because private and package-private
  * ones are implementation detail and say nothing about how large the
- * contract of the class is. Methods annotated with {@code @Override} are
- * skipped too, since a supertype dictates them and the class has no say
- * in how many of them there are. Test classes are skipped altogether, since
+ * contract of the class is, and reports a class that exposes more than
+ * ten of them. Methods annotated with {@code @Override} are skipped too,
+ * since a supertype dictates them and the class has no say in how many
+ * of them there are. Test classes are skipped altogether, since
  * one assertion per test method inflates their method count beyond any
  * useful threshold. JNA bindings are skipped too: a type that extends
  * {@code com.sun.jna.Library}, or its Windows flavour
@@ -37,11 +38,6 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * @since 1.0
  */
 public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
-
-    /**
-     * The largest number of public and protected methods a class may have.
-     */
-    private static final int MAX = 10;
 
     /**
      * The JNA interfaces that mark a type as a native binding.
@@ -86,7 +82,7 @@ public final class TooManyMethodsRule extends AbstractJavaRulechainRule {
     public Object visit(final ASTClassDeclaration type, final Object data) {
         if (!TooManyMethodsRule.tested(type)
             && !TooManyMethodsRule.binding(type)
-            && TooManyMethodsRule.exposed(type) > TooManyMethodsRule.MAX) {
+            && TooManyMethodsRule.exposed(type) > 10) {
             this.asCtx(data).addViolation(type);
         }
         return data;

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -472,6 +472,12 @@
     <module name="com.qulice.checkstyle.SimpleStringSplitCheck"/>
     <module name="com.qulice.checkstyle.JavadocLocationCheck"/>
     <module name="com.qulice.checkstyle.ConstantUsageCheck"/>
+    <!--
+    A private constant that is mentioned only once is an indirection
+    that pays for nothing, it belongs inside its only usage.
+    See https://github.com/yegor256/qulice/issues/1787
+    -->
+    <module name="com.qulice.checkstyle.SingleUseConstantCheck"/>
     <module name="com.qulice.checkstyle.NonStaticMethodCheck">
       <property name="excludeFileNamePattern" value=".*(Test|IT|ITCase)\.java"/>
     </module>

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -192,6 +192,7 @@ final class ChecksTest {
             "NoJavadocForOverriddenMethodsCheck",
             "NonStaticMethodCheck",
             "ConstantUsageCheck",
+            "SingleUseConstantCheck",
             "JavadocEmptyLineCheck",
             "JavadocEmptyLineBeforeTagCheck",
             "JavadocCompactParagraphCheck",

--- a/src/test/java/com/qulice/checkstyle/CheckstyleTextFileTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleTextFileTest.java
@@ -23,21 +23,6 @@ import org.junit.jupiter.api.Test;
 final class CheckstyleTextFileTest {
 
     /**
-     * Name of property to set to change location of the license.
-     */
-    private static final String LICENSE_PROP = "license";
-
-    /**
-     * Directory with classes.
-     */
-    private static final String DIRECTORY = "src/main/java/foo";
-
-    /**
-     * License text.
-     */
-    private static final String LICENSE = "Hello.";
-
-    /**
      * CheckstyleValidator reports a tab character in a non-Java text file
      * such as JavaScript. See https://github.com/yegor256/qulice/issues/521.
      * @throws Exception when error.
@@ -158,12 +143,12 @@ final class CheckstyleTextFileTest {
         final String content) throws IOException {
         final Environment.Mock mock = new Environment.Mock();
         final Environment env = mock.withParam(
-            CheckstyleTextFileTest.LICENSE_PROP,
+            "license",
             String.format(
                 "file:%s",
                 new License().savePackageInfo(
-                    new File(mock.basedir(), CheckstyleTextFileTest.DIRECTORY)
-                ).withLines(CheckstyleTextFileTest.LICENSE)
+                    new File(mock.basedir(), "src/main/java/foo")
+                ).withLines("Hello.")
                     .withEol(String.valueOf('\n')).file()
             )
         ).withFile(String.format("src/main/resources/%s", file), content);

--- a/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -39,11 +39,6 @@ final class DependenciesValidatorTest {
         ProjectDependencyAnalyzer.class.getName();
 
     /**
-     * Plexus hint.
-     */
-    private static final String HINT = "default";
-
-    /**
      * Compile scope.
      */
     private static final String SCOPE = "compile";
@@ -320,7 +315,7 @@ final class DependenciesValidatorTest {
     ) throws Exception {
         return new MavenEnvironmentMocker().inPlexus(
             DependenciesValidatorTest.ROLE,
-            DependenciesValidatorTest.HINT,
+            "default",
             new FakeProjectDependencyAnalyzer(analysis)
         ).mock();
     }

--- a/src/test/java/com/qulice/maven/ValidationExclusionTest.java
+++ b/src/test/java/com/qulice/maven/ValidationExclusionTest.java
@@ -35,11 +35,6 @@ final class ValidationExclusionTest {
     private static final String TEMP_SUB = "excl";
 
     /**
-     * Java files extension.
-     */
-    private static final String JAVA_EXT = ".java";
-
-    /**
      * DefaultMavenEnvironment can exclude a path from PMD validation.
      * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
@@ -150,9 +145,7 @@ final class ValidationExclusionTest {
     }
 
     private static File java(final Path dir, final String resource) throws Exception {
-        final File file = File.createTempFile(
-            "Test", ValidationExclusionTest.JAVA_EXT, dir.toFile()
-        );
+        final File file = File.createTempFile("Test", ".java", dir.toFile());
         FileUtils.writeStringToFile(
             file,
             new TextOf(

--- a/src/test/java/com/qulice/pmd/UseCollectionsSingletonListRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UseCollectionsSingletonListRuleTest.java
@@ -15,19 +15,13 @@ import org.junit.jupiter.api.Test;
  */
 final class UseCollectionsSingletonListRuleTest {
 
-    /**
-     * Error message produced by the rule.
-     */
-    private static final String MESSAGE =
-        "Use Collections.singletonList instead of Arrays.asList with a single non-array argument";
-
     @Test
     void detectsArraysAsListWithSingleScalar() throws Exception {
         new PmdAssert(
             "ArraysAsListSingleScalar.java",
             new IsEqual<>(false),
             Matchers.containsString(
-                UseCollectionsSingletonListRuleTest.MESSAGE
+                "Use Collections.singletonList instead of Arrays.asList with a single non-array argument"
             )
         ).assertOk();
     }

--- a/src/test/resources/com/qulice/checkstyle/AnnotationConstant.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationConstant.java
@@ -81,4 +81,17 @@ public final class AnnotationConstant {
     public String other() {
         return String.valueOf(this.dat);
     }
+
+    /**
+     * All texts together, so that no constant is used only once.
+     * @return All of them
+     */
+    public static String all() {
+        return String.format(
+            "%s%s%s%s%s%s",
+            AnnotationConstant.TEXT1, AnnotationConstant.TEXT2,
+            AnnotationConstant.TEXT3, AnnotationConstant.TEXT4,
+            AnnotationConstant.TEXT5, AnnotationConstant.TEXT6
+        );
+    }
 }

--- a/src/test/resources/com/qulice/checkstyle/AnnotationConstantField.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationConstantField.java
@@ -51,6 +51,18 @@ public final class AnnotationConstantField {
     }
 
     /**
+     * All texts together, so that no constant is used only once.
+     * @return All of them
+     */
+    public static String all() {
+        return String.format(
+            "%s%s%s%s",
+            AnnotationConstantField.TEXT1, AnnotationConstantField.TEXT2,
+            AnnotationConstantField.TEXT3, AnnotationConstantField.TEXT4
+        );
+    }
+
+    /**
      * Some inner class.
      * @since 1.0
      */

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/SingleUseConstantCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/SingleUseConstantCheck/Invalid.java
@@ -1,0 +1,26 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public final class Invalid {
+    private static final String GREETING = "Hello, world!";
+    private static final int LIMIT = 42;
+    private static final char SEPARATOR = ',';
+    private static final String PREFIX = "a" + "b";
+    private static final Charset ENCODING = StandardCharsets.UTF_8;
+    public void print() {
+        System.out.println(Invalid.GREETING);
+    }
+    public int limit(int y) {
+        return y * LIMIT;
+    }
+    public String[] split(String text) {
+        return text.split(String.valueOf(SEPARATOR));
+    }
+    public String name() {
+        return PREFIX.trim();
+    }
+    public byte[] bytes(String text) {
+        return text.getBytes(Invalid.ENCODING);
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/SingleUseConstantCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/SingleUseConstantCheck/Valid.java
@@ -1,0 +1,51 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public final class Valid {
+    private static final long serialVersionUID = 1L;
+    private static final String GREETING = "Hello, world!";
+    private static final Pattern SPACE = Pattern.compile(" ");
+    private static final int[] SIZES = {1, 2, 3};
+    private static final Valid INSTANCE = new Valid();
+    private static final String UNUSED = "never mentioned again";
+    private static final String TWICE = "x";
+    protected static final String PROTECTED = "y";
+    private final String instance = "z";
+    private static String mutable = "w";
+    public void print() {
+        System.out.println(Valid.GREETING);
+        System.out.println(Valid.GREETING.length());
+    }
+    public String trim(String text) {
+        return SPACE.matcher(text).replaceAll("");
+    }
+    public int size() {
+        return SIZES[0];
+    }
+    public Valid self() {
+        return Valid.INSTANCE;
+    }
+    public String twice() {
+        return TWICE + Valid.TWICE;
+    }
+    public String others() {
+        return Valid.PROTECTED + this.instance + Valid.mutable;
+    }
+    /**
+     * Mentioned once by the code, and once by {@value #DOCUMENTED}.
+     */
+    private static final int DOCUMENTED = 7;
+    public int documented() {
+        return DOCUMENTED;
+    }
+    private static final class Inner {
+        private static final String NESTED = "nested";
+        public String first() {
+            return Inner.NESTED;
+        }
+        public String second() {
+            return NESTED;
+        }
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/SingleUseConstantCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/SingleUseConstantCheck/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.SingleUseConstantCheck"/>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/SingleUseConstantCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/SingleUseConstantCheck/violations.txt
@@ -1,0 +1,5 @@
+6:Private constant "GREETING" is used only once, inline it
+7:Private constant "LIMIT" is used only once, inline it
+8:Private constant "SEPARATOR" is used only once, inline it
+9:Private constant "PREFIX" is used only once, inline it
+10:Private constant "ENCODING" is used only once, inline it

--- a/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
@@ -16,6 +16,14 @@ public class ValidAbbreviationAsWordInName extends SomeClass {
      */
     private static final String CONST_VALUE = "foo";
 
+    /**
+     * The constant, so that it is not used only once.
+     * @return The constant
+     */
+    public static String constant() {
+        return ValidAbbreviationAsWordInName.CONST_VALUE;
+    }
+
     @Override
     public final String UPPERCASE() {
         return ValidAbbreviationAsWordInName.CONST_VALUE;


### PR DESCRIPTION
Closes #1787

A `private static final` field that the class mentions exactly once is an
  indirection that pays for nothing: the name sits at the top of the file, far
  from the only expression that reads it, so the reader has to jump up to learn
  what that expression really says.
A constant starts to pay for itself at the second usage, where it removes a
  duplicate, so a one-usage constant belongs inside its only usage.

Neither Checkstyle nor PMD ships a rule for this, and `ConstantUsageCheck`
  only covers the zero-usage case, so this needed a custom check.
`SingleUseConstantCheck` counts identifiers of the same text across the whole
  file, the declaration included, and reports the field when that count is
  exactly two.
Counting a name that some other declaration happens to reuse only makes the
  check more forgiving, never noisier.

To stay away from false positives it leaves alone:

  * `serialVersionUID`, the way `ConstantUsageCheck` does;
  * a constant whose initializer is not a literal expression — a compiled
    `Pattern`, a `new` object, an array — since inlining it would move a
    computation into a method body and could turn a once-per-class cost into a
    per-call one;
  * a constant that a Javadoc comment refers to as `{@value #NAME}` or
    `{@link #NAME}`, since the documentation is a usage of its own and inlining
    would break it.

The check is on by default in `checks.xml`, which required inlining the
  twenty-four such constants in Qulice's own sources — mostly one-off message
  strings in the checks themselves and one-off literals in tests.

Tests: `ChecksTest` gains `Invalid.java` (five reported constants),
  `Valid.java` (a twice-used constant, `serialVersionUID`, a `Pattern`, an
  array, a `new` object, an unused constant, a non-private and a non-static
  field, a Javadoc-referenced constant and a nested class), and the
  `checkstyle-violations` integration test now asserts the message end to end.

`mvn install` (522 tests) and `mvn verify -Pqulice` both pass, as do the
  `checkstyle-violations` and `dependency-imported-in-source` integration
  tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh9tAkJzNu2aTJi29tWPUB)_