### PR TITLE
chore(deps): update PMD to 7.27.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
         <version>9.10.1</version>
       </dependency>
       <dependency>
+        <groupId>net.sf.saxon</groupId>
+        <artifactId>Saxon-HE</artifactId>
+        <version>12.10</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>2.50.0</version>
@@ -278,7 +283,7 @@
     <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd-core</artifactId>
-      <version>7.26.0</version>
+      <version>7.27.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.ow2.asm</groupId>
@@ -297,7 +302,7 @@
     <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd-java</artifactId>
-      <version>7.26.0</version>
+      <version>7.27.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.checkerframework</groupId>


### PR DESCRIPTION
Bumps `net.sourceforge.pmd:pmd-core` and `net.sourceforge.pmd:pmd-java` from 7.26.0 to 7.27.0.

PMD 7.27.0 depends on Saxon-HE 12.10, while Checkstyle 14.0.0 still brings 12.9. That version split makes the `RequireUpperBoundDeps` enforcer rule fail the build, so Saxon-HE 12.10 is pinned in `dependencyManagement` — the same approach already used for `asm`, `gson` and `checker-qual`.

Verification (all locally, on this branch):

- `mvn -B test -DskipITs` — 522 tests, 0 failures.
- `mvn -B verify -Pqulice -DskipTests -DskipITs` — passes; Qulice checked 608 `.java` files against 1016 rules (242 Checkstyle, 281 PMD, 493 ErrorProne).
- `mvn -B verify -DskipTests -Dinvoker.test=pmd-violations,...` — the PMD integration test passes.

No rule set or source changes were needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011YvF2QWeQVf27dHr9j9uuV)_