### PR TITLE
feat(checkstyle): prohibit an implicit constructor in a documented class

### DIFF
--- a/src/it/checkstyle-violations/verify.groovy
+++ b/src/it/checkstyle-violations/verify.groovy
@@ -23,3 +23,4 @@ assert log.text.contains('Constants.java[12]: Private constant "ONCE" is used on
 assert !log.text.contains('Private constant "TWICE" is used only once')
 assert log.text.contains('Violations.java[39]: Fully qualified "java.util.ArrayList" is redundant, import it and use "ArrayList" (FullyQualifiedTypeCheck)')
 assert log.text.contains('Violations.java[49]: Fully qualified "com.google.common.collect.Lists" is redundant, import it and use "Lists" (FullyQualifiedTypeCheck)')
+assert log.text.contains('Violations.java[10]: Implicit constructor of "Violations" gets no Javadoc, declare it explicitly (ImplicitConstructorCheck)')

--- a/src/it/dependency-imported-in-source/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/dependency-imported-in-source/src/main/java/com/qulice/foo/Sample.java
@@ -18,6 +18,13 @@ public final class Sample {
     private static final int NOT_FOUND = StringUtils.INDEX_NOT_FOUND;
 
     /**
+     * Ctor.
+     */
+    public Sample() {
+        // nothing to initialize
+    }
+
+    /**
      * Return the "not found" constant.
      * @return The {@value #NOT_FOUND} index
      * @checkstyle NonStaticMethod (2 lines)

--- a/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/Sample.java
@@ -15,6 +15,13 @@ import org.apache.commons.io.IOUtils;
 public final class Sample {
 
     /**
+     * Ctor.
+     */
+    public Sample() {
+        // nothing to initialize
+    }
+
+    /**
      * Test method.
      * @return Stream
      * @checkstyle NonStaticMethod (2 lines)

--- a/src/it/dependency-violations/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/dependency-violations/src/main/java/com/qulice/foo/Sample.java
@@ -15,6 +15,13 @@ import org.apache.commons.io.IOUtils;
 public final class Sample {
 
     /**
+     * Ctor.
+     */
+    public Sample() {
+        // nothing to initialize
+    }
+
+    /**
      * Test method.
      * @return Stream
      * @checkstyle NonStaticMethod (2 lines)

--- a/src/it/hibernate-validator-check/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/hibernate-validator-check/src/main/java/com/qulice/foo/Sample.java
@@ -11,6 +11,13 @@ package com.qulice.foo;
 public final class Sample {
 
     /**
+     * Ctor.
+     */
+    public Sample() {
+        // nothing to initialize
+    }
+
+    /**
      * Test method.
      * @return Stream
      * @checkstyle NonStaticMethod (2 lines)

--- a/src/main/java/com/qulice/checkstyle/ImplicitConstructorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ImplicitConstructorCheck.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.Set;
+
+/**
+ * Prohibits an implicit constructor in a class that Javadoc documents.
+ *
+ * <p>A class that declares no constructor gets one from the compiler,
+ * with the access of the class itself. Javadoc puts that constructor
+ * into the generated page, finds no comment on it, and says "use of
+ * default constructor, which does not provide a comment". A build that
+ * turns Javadoc warnings into errors, which the {@code maven-javadoc-plugin}
+ * does through {@code failOnWarnings}, breaks over it, and the mistake
+ * surfaces at site time rather than at the moment the class is written.</p>
+ *
+ * <p>The fix is an explicit constructor with a Javadoc block above it,
+ * and this check asks for it before Javadoc does.</p>
+ *
+ * <p>Only the classes Javadoc documents are reported, because only they
+ * carry the warning. A class is documented when it is public or
+ * protected, and so is every class around it, since a nested class of a
+ * package-private one never reaches the page. A member of an interface
+ * or of an annotation counts as public without saying so.</p>
+ *
+ * <p>The other type declarations stay out. An interface and an
+ * annotation have no constructor to document. An enum gets a private
+ * one, which Javadoc leaves out of the page. A record gets a canonical
+ * one, which Javadoc documents from the {@code @param} tags of the
+ * record itself. A local class and a member of an anonymous one are not
+ * documented either, whatever their modifiers say.</p>
+ *
+ * @since 0.73.4
+ */
+public final class ImplicitConstructorCheck extends AbstractCheck {
+
+    /**
+     * Types that may hold a class, and whose own visibility therefore
+     * decides whether the class inside them reaches the Javadoc page.
+     */
+    private static final Set<Integer> TYPES = Set.of(
+        TokenTypes.CLASS_DEF,
+        TokenTypes.INTERFACE_DEF,
+        TokenTypes.ENUM_DEF,
+        TokenTypes.RECORD_DEF,
+        TokenTypes.ANNOTATION_DEF
+    );
+
+    /**
+     * Default constructor.
+     */
+    public ImplicitConstructorCheck() {
+        // nothing to initialize
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[]{TokenTypes.CLASS_DEF};
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return this.getDefaultTokens();
+    }
+
+    @Override
+    public void visitToken(final DetailAST ast) {
+        if (ImplicitConstructorCheck.documented(ast)
+            && ast.findFirstToken(TokenTypes.OBJBLOCK)
+                .findFirstToken(TokenTypes.CTOR_DEF) == null) {
+            this.log(
+                ast.getLineNo(),
+                String.format(
+                    "Implicit constructor of \"%s\" gets no Javadoc, declare it explicitly",
+                    ast.findFirstToken(TokenTypes.IDENT).getText()
+                )
+            );
+        }
+    }
+
+    private static boolean documented(final DetailAST ast) {
+        boolean docs = true;
+        DetailAST node = ast;
+        while (node != null && node.getType() != TokenTypes.COMPILATION_UNIT) {
+            final int type = node.getType();
+            if (ImplicitConstructorCheck.TYPES.contains(type)) {
+                if (!ImplicitConstructorCheck.visible(node)) {
+                    docs = false;
+                    break;
+                }
+            } else if (type != TokenTypes.OBJBLOCK) {
+                docs = false;
+                break;
+            }
+            node = node.getParent();
+        }
+        return docs;
+    }
+
+    private static boolean visible(final DetailAST type) {
+        final DetailAST mods = type.findFirstToken(TokenTypes.MODIFIERS);
+        return mods.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
+            || mods.findFirstToken(TokenTypes.LITERAL_PROTECTED) != null
+            || ImplicitConstructorCheck.implied(type);
+    }
+
+    private static boolean implied(final DetailAST type) {
+        final DetailAST block = type.getParent();
+        boolean implied = false;
+        if (block != null && block.getType() == TokenTypes.OBJBLOCK) {
+            final int owner = block.getParent().getType();
+            implied = owner == TokenTypes.INTERFACE_DEF
+                || owner == TokenTypes.ANNOTATION_DEF;
+        }
+        return implied;
+    }
+}

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -468,6 +468,15 @@
     See https://github.com/yegor256/qulice/issues/1789
     -->
     <module name="com.qulice.checkstyle.FullyQualifiedTypeCheck"/>
+    <!--
+    A class that declares no constructor gets one from the compiler, and
+    Javadoc puts it into the page with no comment on it, saying "use of
+    default constructor, which does not provide a comment". A build with
+    'failOnWarnings' breaks over it at site time. Only the classes
+    Javadoc documents are reported, since only they carry the warning.
+    See https://github.com/objectionary/eo/pull/8002
+    -->
+    <module name="com.qulice.checkstyle.ImplicitConstructorCheck"/>
     <module name="com.qulice.checkstyle.MultilineJavadocTagsCheck"/>
     <module name="com.qulice.checkstyle.NoJavadocForOverriddenMethodsCheck"/>
     <module name="com.qulice.checkstyle.NoJavadocForPrivateMethodsCheck"/>

--- a/src/main/resources/com/qulice/checkstyle/suppressions.xml
+++ b/src/main/resources/com/qulice/checkstyle/suppressions.xml
@@ -6,5 +6,6 @@
 <!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN" "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
   <suppress checks="JavadocMethod" files=".+(Test|ITCase|IT).java"/>
+  <suppress checks="ImplicitConstructorCheck" files=".+(Test|ITCase|IT).java"/>
   <suppress checks="TypeName" files=".+(Test|ITCase|IT).java"/>
 </suppressions>

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -194,6 +194,7 @@ final class ChecksTest {
             "ConstantUsageCheck",
             "SingleUseConstantCheck",
             "FullyQualifiedTypeCheck",
+            "ImplicitConstructorCheck",
             "JavadocEmptyLineCheck",
             "JavadocEmptyLineBeforeTagCheck",
             "JavadocCompactParagraphCheck",

--- a/src/test/java/com/qulice/checkstyle/CheckstyleBannedApiTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleBannedApiTest.java
@@ -59,14 +59,14 @@ final class CheckstyleBannedApiTest {
                     new ViolationMatcher(message, file, "7", name),
                     new ViolationMatcher(message, file, "8", name),
                     new ViolationMatcher(message, file, "9", name),
-                    new ViolationMatcher(message, file, "23", name),
-                    new ViolationMatcher(message, file, "24", name),
-                    new ViolationMatcher(message, file, "25", name),
+                    new ViolationMatcher(message, file, "30", name),
+                    new ViolationMatcher(message, file, "31", name),
+                    new ViolationMatcher(message, file, "32", name),
                     new ViolationMatcher(
                         "is redundant, import it and use",
-                        file, "26", "FullyQualifiedTypeCheck"
+                        file, "33", "FullyQualifiedTypeCheck"
                     ),
-                    new ViolationMatcher(message, file, "26", name)
+                    new ViolationMatcher(message, file, "33", name)
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleCatchParameterNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleCatchParameterNameTest.java
@@ -36,16 +36,16 @@ final class CheckstyleCatchParameterNameTest {
                 Matchers.iterableWithSize(4),
                 Matchers.hasItems(
                     new ViolationMatcher(
-                        "Name 'ex_invalid_1' must match pattern", file, "26", name
+                        "Name 'ex_invalid_1' must match pattern", file, "33", name
                     ),
                     new ViolationMatcher(
-                        "Name '$xxx' must match pattern", file, "28", name
+                        "Name '$xxx' must match pattern", file, "35", name
                     ),
                     new ViolationMatcher(
-                        "Name '_exp' must match pattern", file, "30", name
+                        "Name '_exp' must match pattern", file, "37", name
                     ),
                     new ViolationMatcher(
-                        "Name '$xxx' must match pattern", file, "28",
+                        "Name '$xxx' must match pattern", file, "35",
                         "IllegalIdentifierNameCheck"
                     )
                 )

--- a/src/test/java/com/qulice/checkstyle/License.java
+++ b/src/test/java/com/qulice/checkstyle/License.java
@@ -30,12 +30,19 @@ public final class License {
     /**
      * Package name.
      */
-    private String pkg = "foo";
+    private String pkg;
 
     /**
      * Directory for package-info.java.
      */
     private File directory;
+
+    /**
+     * Ctor.
+     */
+    public License() {
+        this.pkg = "foo";
+    }
 
     /**
      * Use this EOL.

--- a/src/test/java/com/qulice/maven/MavenProjectMocker.java
+++ b/src/test/java/com/qulice/maven/MavenProjectMocker.java
@@ -17,7 +17,14 @@ public final class MavenProjectMocker {
     /**
      * Mock of project.
      */
-    private final MavenProject project = new MavenProject();
+    private final MavenProject project;
+
+    /**
+     * Ctor.
+     */
+    public MavenProjectMocker() {
+        this.project = new MavenProject();
+    }
 
     /**
      * In this basedir.

--- a/src/test/resources/com/qulice/checkstyle/AnnotationConstant.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationConstant.java
@@ -45,6 +45,13 @@ public final class AnnotationConstant {
     private int dat = 1;
 
     /**
+     * Ctor.
+     */
+    public AnnotationConstant() {
+        // nothing
+    }
+
+    /**
      * Some data.
      * @return Some data
      */

--- a/src/test/resources/com/qulice/checkstyle/AnnotationConstantField.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationConstantField.java
@@ -45,6 +45,13 @@ public final class AnnotationConstantField {
     private int other = 2;
 
     /**
+     * Ctor.
+     */
+    public AnnotationConstantField() {
+        // nothing
+    }
+
+    /**
      * Some data.
      * @return Some data
      */

--- a/src/test/resources/com/qulice/checkstyle/AnnotationIndentation.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationIndentation.java
@@ -13,4 +13,11 @@ package foo;
     "PMD.AvoidDuplicateLiterals"
 })
 public final class AnnotationIndentation {
+
+    /**
+     * Ctor.
+     */
+    public AnnotationIndentation() {
+        // nothing
+    }
 }

--- a/src/test/resources/com/qulice/checkstyle/BlankLinesOutsideMethodsPass.java
+++ b/src/test/resources/com/qulice/checkstyle/BlankLinesOutsideMethodsPass.java
@@ -10,6 +10,13 @@ package foo;
 public final class BlankLinesOutsideMethodsPass {
 
     /**
+     * Ctor.
+     */
+    public BlankLinesOutsideMethodsPass() {
+        // nothing
+    }
+
+    /**
      * Method with space between anonymous innter class methods.
      */
     public void methodwithAnonymousInnerClass() {

--- a/src/test/resources/com/qulice/checkstyle/CatchParameterNames.java
+++ b/src/test/resources/com/qulice/checkstyle/CatchParameterNames.java
@@ -18,6 +18,13 @@ public final class CatchParameterNames {
     private int counter;
 
     /**
+     * Ctor.
+     */
+    public CatchParameterNames() {
+        // nothing
+    }
+
+    /**
      * Invalid exception parameter name.
      */
     void invalidOne() {

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/Invalid-Abstract.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/Invalid-Abstract.java
@@ -1,0 +1,12 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public abstract class InvalidAbstract {
+    public abstract int one();
+    public interface Face {
+        class Inner {
+            int two();
+        }
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/Invalid.java
@@ -1,0 +1,23 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class Invalid {
+    public static class Nested {
+        public int one() {
+            return 1;
+        }
+    }
+    protected static class Guarded {
+        public int two() {
+            return 2;
+        }
+    }
+    private static class Hidden {
+        Hidden() {
+        }
+    }
+    public Object make() {
+        return new Invalid.Hidden();
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/Valid-Types.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/Valid-Types.java
@@ -1,0 +1,14 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public interface ValidTypes {
+    int one();
+    enum Kind {
+        FIRST, SECOND
+    }
+    record Pair(String left, String right) {
+    }
+    @interface Marker {
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/Valid.java
@@ -1,0 +1,45 @@
+/*
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public class Valid {
+    public Valid() {
+    }
+    public static class Nested {
+        private Nested() {
+        }
+        public static int one() {
+            return 1;
+        }
+    }
+    private static class Hidden {
+        public int two() {
+            return 2;
+        }
+    }
+    static class Neighbour {
+        public int three() {
+            return 3;
+        }
+        public static class Deep {
+            public int five() {
+                return 5;
+            }
+        }
+    }
+    public void run() {
+        class Local {
+            int four() {
+                return 4;
+            }
+        }
+        new Local();
+    }
+    public Object anonymous() {
+        return new Object() {
+            public String toString() {
+                return "";
+            }
+        };
+    }
+}

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/config.xml
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.qulice.checkstyle.ImplicitConstructorCheck"/>
+  </module>
+</module>

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/violations-Abstract.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/violations-Abstract.txt
@@ -1,0 +1,2 @@
+5:Implicit constructor of "InvalidAbstract" gets no Javadoc, declare it explicitly
+8:Implicit constructor of "Inner" gets no Javadoc, declare it explicitly

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/ImplicitConstructorCheck/violations.txt
@@ -1,0 +1,3 @@
+5:Implicit constructor of "Invalid" gets no Javadoc, declare it explicitly
+6:Implicit constructor of "Nested" gets no Javadoc, declare it explicitly
+11:Implicit constructor of "Guarded" gets no Javadoc, declare it explicitly

--- a/src/test/resources/com/qulice/checkstyle/DiamondUsageNotNeeded.java
+++ b/src/test/resources/com/qulice/checkstyle/DiamondUsageNotNeeded.java
@@ -12,6 +12,13 @@ import java.util.List;
  */
 public final class DiamondUsageNotNeeded {
 
+    /**
+     * Ctor.
+     */
+    public DiamondUsageNotNeeded() {
+        // nothing
+    }
+
     @Override
     public List<String> firstTen(final String... args) {
         return new ArrayList<String>(2);

--- a/src/test/resources/com/qulice/checkstyle/DoNotUseCharEncoding.java
+++ b/src/test/resources/com/qulice/checkstyle/DoNotUseCharEncoding.java
@@ -15,6 +15,13 @@ import org.apache.commons.lang3.CharEncoding;
 public final class DoNotUseCharEncoding {
 
     /**
+     * Ctor.
+     */
+    public DoNotUseCharEncoding() {
+        // nothing
+    }
+
+    /**
      * Act.
      */
     public void act() {

--- a/src/test/resources/com/qulice/checkstyle/FileLengthCheck.java
+++ b/src/test/resources/com/qulice/checkstyle/FileLengthCheck.java
@@ -13,6 +13,13 @@ package foo;
  */
 public final class FileLengthCheck {
 
+    /**
+     * Ctor.
+     */
+    public FileLengthCheck() {
+        // nothing
+    }
+
     void method1() {
         // Intentionally empty
     }

--- a/src/test/resources/com/qulice/checkstyle/InstanceMethodRef.java
+++ b/src/test/resources/com/qulice/checkstyle/InstanceMethodRef.java
@@ -8,6 +8,13 @@ package foo;
  */
 public final class InstanceMethodRef {
 
+    /**
+     * Ctor.
+     */
+    public InstanceMethodRef() {
+        // nothing
+    }
+
     private void start() {
         Collections.singletonList("1")
             .forEach(this::doSomething);

--- a/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
+++ b/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
@@ -21,6 +21,13 @@ public final class LocalVariableNames {
     private transient int id;
 
     /**
+     * Ctor.
+     */
+    public LocalVariableNames() {
+        // nothing
+    }
+
+    /**
      * Just a valid method.
      * @param id
      *  A valid parameter with name 'id'

--- a/src/test/resources/com/qulice/checkstyle/NonAsciiLineLength.java
+++ b/src/test/resources/com/qulice/checkstyle/NonAsciiLineLength.java
@@ -9,6 +9,13 @@ package foo;
  */
 public final class NonAsciiLineLength {
 
+    /**
+     * Ctor.
+     */
+    public NonAsciiLineLength() {
+        // nothing
+    }
+
     @Override
     public String toString() {
         final String input = "Hello, товарищ output äÄ üÜ öÖ and ßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßßß";

--- a/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
@@ -17,6 +17,13 @@ public class ValidAbbreviationAsWordInName extends SomeClass {
     private static final String CONST_VALUE = "foo";
 
     /**
+     * Ctor.
+     */
+    public ValidAbbreviationAsWordInName() {
+        // nothing
+    }
+
+    /**
      * The constant, so that it is not used only once.
      * @return The constant
      */
@@ -34,5 +41,12 @@ public class ValidAbbreviationAsWordInName extends SomeClass {
      * @since 1.0
      */
     public class ValidInnerHtml {
+
+        /**
+         * Ctor.
+         */
+        public ValidInnerHtml() {
+            // nothing
+        }
     }
 }

--- a/src/test/resources/com/qulice/checkstyle/ValidDiamondsUsage.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidDiamondsUsage.java
@@ -20,6 +20,13 @@ public final class ValidDiamondsUsage {
      */
     public static final int TEN = 10;
 
+    /**
+     * Ctor.
+     */
+    public ValidDiamondsUsage() {
+        // nothing
+    }
+
     @Override
     public List<String> firstTen(final String... args) {
         final List<String> list = new ArrayList<>(args.length + 1);

--- a/src/test/resources/com/qulice/checkstyle/ValidLambdaAndGenericsAtEndOfLine.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidLambdaAndGenericsAtEndOfLine.java
@@ -15,6 +15,13 @@ public final class ValidLambdaAndGenericsAtEndOfLine {
     private final int zero = 0;
 
     /**
+     * Ctor.
+     */
+    public ValidLambdaAndGenericsAtEndOfLine() {
+        // nothing
+    }
+
+    /**
      * Main method.
      */
     public void main() {

--- a/src/test/resources/com/qulice/checkstyle/ValidRecord.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidRecord.java
@@ -10,6 +10,13 @@ package foo;
 public final class ValidRecord {
 
     /**
+     * Ctor.
+     */
+    public ValidRecord() {
+        // nothing
+    }
+
+    /**
      * Just a record type which should be successfully parsed.
      * @param hello Some field
      * @param world Another field

--- a/src/test/resources/com/qulice/checkstyle/ValidSemicolon.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidSemicolon.java
@@ -15,6 +15,13 @@ public final class ValidSemicolon {
     private int dat = 1;
 
     /**
+     * Ctor.
+     */
+    public ValidSemicolon() {
+        // nothing
+    }
+
+    /**
      * Method without extra semicolon in the end
      * of try-with-resources head.
      */


### PR DESCRIPTION
A class that declares no constructor gets one from the compiler, with the access of the class itself. Javadoc puts that constructor into the generated page, finds no comment on it, and says `use of default constructor, which does not provide a comment`. A build that turns Javadoc warnings into errors, which `maven-javadoc-plugin` does through `failOnWarnings`, breaks over it, so the mistake surfaces at site time rather than at the moment the class is written. It cost the EO project a red site build in objectionary/eo#8002, where one mojo relied on the implicit constructor while every other one declared it.

`ImplicitConstructorCheck` reports it. It takes every `CLASS_DEF`, asks whether Javadoc documents it, and demands a `CTOR_DEF` inside if it does.

## Scope

Only the classes Javadoc documents are reported, because only they carry the warning. Every row below was checked against `javadoc -Xdoclint:all` before the check was written, rather than guessed:

| Shape | doclint | This check |
| --- | --- | --- |
| `public class` with no constructor | warns | reports |
| `public abstract class` with no constructor | warns | reports |
| `public` or `protected` nested class | warns | reports |
| class inside a public interface (implicitly public) | warns | reports |
| package-private class | silent | ignores |
| `public` class nested in a package-private one | silent | ignores |
| enum (implicit constructor is private) | silent | ignores |
| record (canonical constructor documented from `@param`) | silent | ignores |
| interface, annotation (no constructor at all) | silent | ignores |
| local class, member of an anonymous class | silent | ignores |

Checkstyle's own `MissingCtor` does not fit and stays switched off, since it demands a constructor of every class, the package-private ones included, and skips the abstract ones that Javadoc does report.

Test classes are suppressed in `suppressions.xml`, next to the `JavadocMethod` suppression that sits there already, because Javadoc does not run over test sources and Qulice does not ask for Javadoc on a test method either.

## Changes

- `ImplicitConstructorCheck`, registered in `checks.xml`
- `ImplicitConstructorCheck` suppressed for `*Test`, `*IT`, `*ITCase` in `suppressions.xml`
- `ChecksTest` fixtures covering every row of the table above, in `Invalid.java`, `Invalid-Abstract.java`, `Valid.java` and `Valid-Types.java`
- an assertion in the `checkstyle-violations` integration test
- an explicit constructor in 16 Checkstyle fixtures, 3 integration-test samples and 2 test helpers, which enabling the check against Qulice's own sources required

## Verification

- `mvn test`: 528 tests, 0 failures
- `mvn verify -Pqulice`: the self-check reported nothing once the two test helpers moved their inline field initialization into the new constructor. That pairing is worth knowing about: adding an explicit constructor makes PMD's `ConstructorShouldDoInitialization` apply, so a class with inline field initializers has to move them into the constructor as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjqrWpWLWJeBQtDsVgD3rK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjqrWpWLWJeBQtDsVgD3rK)_