### PR TITLE
fix(deps): pin PMD back to 7.26.0, closes #1800

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
     <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd-core</artifactId>
-      <version>7.27.0</version>
+      <version>7.26.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.ow2.asm</groupId>
@@ -302,7 +302,7 @@
     <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd-java</artifactId>
-      <version>7.27.0</version>
+      <version>7.26.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.checkerframework</groupId>

--- a/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -8,6 +8,7 @@ import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
 import java.util.Collections;
+import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,21 @@ final class PmdValidatorTest {
             "PMD cannot stay silent about how many rules it applies",
             new PmdValidator(new Environment.Mock()).rules(),
             Matchers.greaterThan(100)
+        );
+    }
+
+    @Test
+    void doesNotCrashOnNonAsciiIdentifier() throws Exception {
+        final String file = "src/main/java/Main.java";
+        final Environment env = new Environment.Mock().withFile(
+            file, "final class Main { private final Phi.Φ obj = null; }"
+        );
+        MatcherAssert.assertThat(
+            "PMD must not choke on a non-ASCII Java identifier",
+            new PmdValidator(env).validate(
+                Collections.singletonList(new File(env.basedir(), file))
+            ).stream().map(Violation::name).collect(Collectors.toList()),
+            Matchers.not(Matchers.hasItem("ProcessingError"))
         );
     }
 


### PR DESCRIPTION
## Summary

- Since 0.34.0, qulice bundles PMD 7.27.0, whose ASM-based symbol resolver crashes with `IllegalArgumentException: Not a Java binary name '...'` while disambiguating a qualified name whose leading segment can't be resolved to a known type and whose trailing segment contains a non-ASCII Java identifier character (e.g. `Φ`, U+03A6). This happened to `objectionary/eo`, which had to disable PMD entirely (`pmd:.*`) for ~17 files that reference a field named `Phi.Φ` (objectionary/eo#8139).
- `pmd-core`/`pmd-java` are pinned back to `7.26.0` (`pom.xml`), which does not exhibit the crash. PMD's own binary-name regex is still ASCII-only on their `main` branch as of this writing, so there's no fixed release to move to yet.
- Added a regression test (`PmdValidatorTest#doesNotCrashOnNonAsciiIdentifier`) reproducing the exact crash condition, confirmed to fail against PMD 7.27.0 and pass against 7.26.0.

## Test plan

- [x] `mvn test` — full unit test suite passes
- [x] New test verified to fail with `IllegalArgumentException: Not a Java binary name 'Phi.Φ'` when pmd-core/pmd-java are temporarily bumped back to 7.27.0
- [x] New test passes with pmd-core/pmd-java pinned to 7.26.0
- [x] `mvn -Pqulice verify` — qulice's own self-check (checkstyle/PMD/error-prone) passes on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7Qpm1Fufi3SocazwfbyAf

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7Qpm1Fufi3SocazwfbyAf)_