### PR TITLE
#1810 always demand empty Javadoc line before at-clauses

### DIFF
--- a/src/it/binary-files/src/main/java/com/qulice/plugin/binary/Thing.java
+++ b/src/it/binary-files/src/main/java/com/qulice/plugin/binary/Thing.java
@@ -8,6 +8,7 @@ package com.qulice.plugin.binary;
  * A clean class that lives next to binary resources. Used only to prove
  * that qulice still validates real sources while silently ignoring the
  * binary blobs in {@code src/main/resources}.
+ *
  * @since 0.24
  */
 public final class Thing {
@@ -19,6 +20,7 @@ public final class Thing {
 
     /**
      * Ctor.
+     *
      * @param name Label to use
      */
     public Thing(final String name) {
@@ -27,6 +29,7 @@ public final class Thing {
 
     /**
      * Print the label.
+     *
      * @return Human-readable label
      */
     public String name() {

--- a/src/it/binary-files/src/main/java/com/qulice/plugin/binary/package-info.java
+++ b/src/it/binary-files/src/main/java/com/qulice/plugin/binary/package-info.java
@@ -8,6 +8,7 @@
  * issue #1264</a>: binary resources (PNG, GIF, etc.) sitting in
  * {@code src/main/resources} must not be inspected by text-based checks
  * such as {@code RegexpSinglelineCheck}.
+ *
  * @since 0.24
  */
 package com.qulice.plugin.binary;

--- a/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Brackets.java
+++ b/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/Brackets.java
@@ -39,6 +39,7 @@ public final class Brackets {
 
         /**
          * Constructor.
+         *
          * @param start First param
          * @param list Second param
          * @param rest Last param

--- a/src/it/dependency-imported-in-source/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/dependency-imported-in-source/src/main/java/com/qulice/foo/Sample.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * Test class using a compile-time constant.
+ *
  * @since 1.0
  */
 public final class Sample {
@@ -26,6 +27,7 @@ public final class Sample {
 
     /**
      * Return the "not found" constant.
+     *
      * @return The {@value #NOT_FOUND} index
      * @checkstyle NonStaticMethod (2 lines)
      */

--- a/src/it/dependency-imported-in-source/src/main/java/com/qulice/foo/package-info.java
+++ b/src/it/dependency-imported-in-source/src/main/java/com/qulice/foo/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Sample package.
+ *
  * @since 1.0
  */
 package com.qulice.foo;

--- a/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/model/package-info.java
+++ b/src/it/dependency-not-matches-exclude/src/main/java/com/qulice/entity/model/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Package docs.
+ *
  * @since 0.1
  */
 package com.qulice.entity.model;

--- a/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/Sample.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.IOUtils;
 
 /**
  * Test class.
+ *
  * @since 1.0
  */
 public final class Sample {
@@ -23,6 +24,7 @@ public final class Sample {
 
     /**
      * Test method.
+     *
      * @return Stream
      * @checkstyle NonStaticMethod (2 lines)
      */

--- a/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/package-info.java
+++ b/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Package docs.
+ *
  * @since 0.1
  */
 package com.qulice.foo;

--- a/src/it/dependency-violations/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/dependency-violations/src/main/java/com/qulice/foo/Sample.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.IOUtils;
 
 /**
  * Test class.
+ *
  * @since 1.0
  */
 public final class Sample {
@@ -23,6 +24,7 @@ public final class Sample {
 
     /**
      * Test method.
+     *
      * @return Stream
      * @checkstyle NonStaticMethod (2 lines)
      */

--- a/src/it/dependency-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/src/it/dependency-violations/src/main/java/com/qulice/foo/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Package docs.
+ *
  * @since 0.1
  */
 package com.qulice.foo;

--- a/src/it/errorprone-violations/src/main/java/com/qulice/foo/Bad.java
+++ b/src/it/errorprone-violations/src/main/java/com/qulice/foo/Bad.java
@@ -6,6 +6,7 @@ package com.qulice.foo;
 
 /**
  * Sample class that contains an ErrorProne SelfAssignment violation.
+ *
  * @since 1.0
  */
 public final class Bad {
@@ -17,6 +18,7 @@ public final class Bad {
 
     /**
      * Setter that assigns the field to itself.
+     *
      * @param val New value
      */
     public void set(final int val) {
@@ -25,6 +27,7 @@ public final class Bad {
 
     /**
      * Getter for the stored value.
+     *
      * @return The value
      */
     public int value() {

--- a/src/it/errorprone-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/src/it/errorprone-violations/src/main/java/com/qulice/foo/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Sample package containing ErrorProne violations.
+ *
  * @since 1.0
  */
 package com.qulice.foo;

--- a/src/it/hibernate-validator-check/src/main/java/com/qulice/foo/Sample.java
+++ b/src/it/hibernate-validator-check/src/main/java/com/qulice/foo/Sample.java
@@ -6,6 +6,7 @@ package com.qulice.foo;
 
 /**
  * Test class.
+ *
  * @since 1.0
  */
 public final class Sample {
@@ -19,6 +20,7 @@ public final class Sample {
 
     /**
      * Test method.
+     *
      * @return Stream
      * @checkstyle NonStaticMethod (2 lines)
      */

--- a/src/it/hibernate-validator-check/src/main/java/com/qulice/foo/package-info.java
+++ b/src/it/hibernate-validator-check/src/main/java/com/qulice/foo/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Package docs.
+ *
  * @since 0.1
  */
 package com.qulice.foo;

--- a/src/it/ignored-dirs/src/main/java/com/qulice/plugin/ignored/Thing.java
+++ b/src/it/ignored-dirs/src/main/java/com/qulice/plugin/ignored/Thing.java
@@ -8,6 +8,7 @@ package com.qulice.plugin.ignored;
  * A clean class that lives next to the ignored directories. It is here
  * to prove that Qulice still validates real sources, while leaving the
  * Java files in {@code src/site} and {@code src/it} alone.
+ *
  * @since 1.0
  */
 public final class Thing {
@@ -19,6 +20,7 @@ public final class Thing {
 
     /**
      * Ctor.
+     *
      * @param name Label to use
      */
     public Thing(final String name) {
@@ -27,6 +29,7 @@ public final class Thing {
 
     /**
      * Print the label.
+     *
      * @return Human-readable label
      */
     public String name() {

--- a/src/it/ignored-dirs/src/main/java/com/qulice/plugin/ignored/package-info.java
+++ b/src/it/ignored-dirs/src/main/java/com/qulice/plugin/ignored/package-info.java
@@ -9,6 +9,7 @@
  * directories in the POM, so that Qulice walks them, and both hold a
  * Java file that breaks plenty of rules. The build must stay green
  * anyway, with no {@code <exclude>} in the POM.
+ *
  * @since 1.0
  */
 package com.qulice.plugin.ignored;

--- a/src/it/javac-warnings/src/main/java/com/qulice/foo/Caller.java
+++ b/src/it/javac-warnings/src/main/java/com/qulice/foo/Caller.java
@@ -7,12 +7,14 @@ package com.qulice.foo;
 /**
  * Sample class whose only defect is a plain {@code javac} warning, with no
  * ErrorProne bug pattern anywhere in sight.
+ *
  * @since 1.0
  */
 public final class Caller {
 
     /**
      * Call the stale method and earn the {@code [removal]} warning.
+     *
      * @return Whatever {@link Stale#old()} returns
      */
     public int call() {

--- a/src/it/javac-warnings/src/main/java/com/qulice/foo/Stale.java
+++ b/src/it/javac-warnings/src/main/java/com/qulice/foo/Stale.java
@@ -6,12 +6,14 @@ package com.qulice.foo;
 
 /**
  * Sample class holding a method nobody should call any more.
+ *
  * @since 1.0
  */
 public final class Stale {
 
     /**
      * Method scheduled for removal.
+     *
      * @return Always one
      */
     @Deprecated(forRemoval = true)

--- a/src/it/javac-warnings/src/main/java/com/qulice/foo/package-info.java
+++ b/src/it/javac-warnings/src/main/java/com/qulice/foo/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Sample package containing a plain compiler warning.
+ *
  * @since 1.0
  */
 package com.qulice.foo;

--- a/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/Main.java
+++ b/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/Main.java
@@ -6,6 +6,7 @@ package com.qulice.plugin.alpha;
 
 /**
  * Sample class.
+ *
  * @since 1.0
  */
 @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
@@ -20,6 +21,7 @@ public final class Main {
 
     /**
      * Calculate square of a number.
+     *
      * @param num The number
      * @return The square
      */

--- a/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/package-info.java
+++ b/src/it/multi-module/mod-alpha/src/main/java/com/qulice/plugin/alpha/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Package docs.
+ *
  * @since 0.1
  */
 package com.qulice.plugin.alpha;

--- a/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/MainTest.java
+++ b/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/MainTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Simple test of the Main class.
+ *
  * @since 1.0
  */
 final class MainTest {

--- a/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/package-info.java
+++ b/src/it/multi-module/mod-alpha/src/test/java/com/qulice/plugin/alpha/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Package docs.
+ *
  * @since 0.1
  */
 package com.qulice.plugin.alpha;

--- a/src/it/pmd-violations/src/main/java/com/qulice/foo/Violations.java
+++ b/src/it/pmd-violations/src/main/java/com/qulice/foo/Violations.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 /**
  * Sample class.
+ *
  * @since 1.0
  */
 public final class Violations {
@@ -19,6 +20,7 @@ public final class Violations {
 
     /**
      * Calculate square of a number.
+     *
      * @param num The number
      * @return The square
      * @checkstyle NonStaticMethod (2 lines)
@@ -29,6 +31,7 @@ public final class Violations {
 
     /**
      * Returns Foo.
+     *
      * @return Foo
      * @checkstyle NonStaticMethod (2 lines)
      */
@@ -39,6 +42,7 @@ public final class Violations {
 
     /**
      * Returns Foo again.
+     *
      * @return Foo
      * @checkstyle NonStaticMethod (2 lines)
      */
@@ -50,6 +54,7 @@ public final class Violations {
 
     /**
      * Prints something.
+     *
      * @checkstyle NonStaticMethod (2 lines)
      */
     public void print() {
@@ -68,6 +73,7 @@ public final class Violations {
 
         /**
          * Constructor.
+         *
          * @param name Name
          */
         Foo(final String name) {

--- a/src/it/pmd-violations/src/main/java/com/qulice/foo/package-info.java
+++ b/src/it/pmd-violations/src/main/java/com/qulice/foo/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Package docs.
+ *
  * @since 0.1
  */
 package com.qulice.foo;

--- a/src/it/test-resources-excluded/src/main/java/com/qulice/plugin/resources/Thing.java
+++ b/src/it/test-resources-excluded/src/main/java/com/qulice/plugin/resources/Thing.java
@@ -8,6 +8,7 @@ package com.qulice.plugin.resources;
  * A clean class that lives next to a broken test resource. It is here to
  * prove that qulice still validates real sources, while leaving the Java
  * fixtures in {@code src/test/resources} alone.
+ *
  * @since 1.0
  */
 public final class Thing {
@@ -19,6 +20,7 @@ public final class Thing {
 
     /**
      * Ctor.
+     *
      * @param name Label to use
      */
     public Thing(final String name) {
@@ -27,6 +29,7 @@ public final class Thing {
 
     /**
      * Print the label.
+     *
      * @return Human-readable label
      */
     public String name() {

--- a/src/it/test-resources-excluded/src/main/java/com/qulice/plugin/resources/package-info.java
+++ b/src/it/test-resources-excluded/src/main/java/com/qulice/plugin/resources/package-info.java
@@ -9,6 +9,7 @@
  * the tests, not sources of the product, and neither Checkstyle, PMD nor
  * ErrorProne may complain about them, even though the project says
  * nothing about them in its {@code <excludes>}.
+ *
  * @since 1.0
  */
 package com.qulice.plugin.resources;

--- a/src/main/java/com/qulice/checkstyle/BranchContains.java
+++ b/src/main/java/com/qulice/checkstyle/BranchContains.java
@@ -28,6 +28,7 @@ class BranchContains {
 
     /**
      * Creates a decorator which is able to search in the node's subtree.
+     *
      * @param node Node which will be represented by the new BranchContains instance
      */
     BranchContains(final DetailAST node) {
@@ -38,6 +39,7 @@ class BranchContains {
      * Checks if there is a node of type `type` in this node subtree.
      * The root node itself may also match, i.e.
      * `new BranchContains(node).contains(node.getType())` is always true
+     *
      * @param type Desired type
      * @return Whether node of given type exists somewhere in the subtree
      */

--- a/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
+++ b/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
@@ -23,6 +23,7 @@ import org.cactoos.text.Joined;
  * since every one of them closes exactly one more nesting level and thus
  * must be shallower than the one above it.
  * All other cases must cause a failure.
+ *
  * @since 0.3
  */
 public final class CascadeIndentationCheck extends AbstractFileSetCheck {

--- a/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 /**
  * Listener of Checkstyle events.
+ *
  * @since 0.3
  */
 final class CheckstyleListener implements AuditListener {
@@ -37,6 +38,7 @@ final class CheckstyleListener implements AuditListener {
 
     /**
      * Public ctor.
+     *
      * @param environ The environment
      */
     CheckstyleListener(final Environment environ) {
@@ -95,6 +97,7 @@ final class CheckstyleListener implements AuditListener {
 
     /**
      * Get all events.
+     *
      * @return List of events
      */
     List<AuditEvent> events() {
@@ -104,6 +107,7 @@ final class CheckstyleListener implements AuditListener {
     /**
      * Files that Checkstyle processed, leaving out those it took from
      * its cache and never collected events for.
+     *
      * @return List of files
      */
     List<File> processed() {

--- a/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -30,6 +30,7 @@ import org.xml.sax.InputSource;
 
 /**
  * Validator with Checkstyle.
+ *
  * @since 0.3
  */
 public final class CheckstyleValidator implements ResourceValidator {
@@ -78,6 +79,7 @@ public final class CheckstyleValidator implements ResourceValidator {
 
     /**
      * Constructor.
+     *
      * @param env Environment to use
      */
     public CheckstyleValidator(final Environment env) {
@@ -143,6 +145,7 @@ public final class CheckstyleValidator implements ResourceValidator {
 
     /**
      * Filters out excluded files from further validation.
+     *
      * @param files Files to validate
      * @return List of relevant files
      */

--- a/src/main/java/com/qulice/checkstyle/ChildStream.java
+++ b/src/main/java/com/qulice/checkstyle/ChildStream.java
@@ -26,6 +26,7 @@ class ChildStream {
 
     /**
      * Creates a new child stream factory.
+     *
      * @param node Node which will used by this object
      */
     ChildStream(final DetailAST node) {

--- a/src/main/java/com/qulice/checkstyle/ClassDesc.java
+++ b/src/main/java/com/qulice/checkstyle/ClassDesc.java
@@ -6,6 +6,7 @@ package com.qulice.checkstyle;
 
 /**
  * Maintains information about class' ctors.
+ *
  * @since 0.1
  */
 final class ClassDesc {
@@ -27,6 +28,7 @@ final class ClassDesc {
 
     /**
      * Create a new ClassDesc instance.
+     *
      * @param qualified Qualified class name(with package)
      * @param asfinal Indicates if the class declared as final
      * @param asabstract Indicates if the class declared as
@@ -42,6 +44,7 @@ final class ClassDesc {
 
     /**
      * Get qualified class name.
+     *
      * @return Qualified class name
      */
     String getQualified() {
@@ -50,6 +53,7 @@ final class ClassDesc {
 
     /**
      * Is class declared as final.
+     *
      * @return True if class is declared as final
      */
     boolean isAsfinal() {
@@ -58,6 +62,7 @@ final class ClassDesc {
 
     /**
      * Is class declared as abstract.
+     *
      * @return True if class is declared as final
      */
     boolean isDeclaredAsAbstract() {

--- a/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 /**
  * Performs multiline regexp match only if a regexp condition passes.
+ *
  * @since 0.5
  */
 public final class ConditionalRegexpMultilineCheck extends
@@ -49,6 +50,7 @@ public final class ConditionalRegexpMultilineCheck extends
 
     /**
      * Condition regexp that has to match before checking the core one.
+     *
      * @param cond Regexp that has to match in file
      */
     public void setCondition(final String cond) {

--- a/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
@@ -11,6 +11,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * Checks that constant, declared as private field of class is used more than
  * once.
+ *
  * @since 0.3
  */
 public final class ConstantUsageCheck extends AbstractCheck {

--- a/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
@@ -12,6 +12,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Checks that try-with-resources does not end with a semicolon. Implementation
  * relies on existence of semicolon inside of RESOURCE_SPECIFICATION token
  * as interpreted by Checkstyle.
+ *
  * @since 0.15
  */
 public final class FinalSemicolonInTryWithResourcesCheck extends AbstractCheck {

--- a/src/main/java/com/qulice/checkstyle/JavadocEmptyLineBeforeTagCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocEmptyLineBeforeTagCheck.java
@@ -11,34 +11,35 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * Check for the empty Javadoc line before the group of at-clauses.
  *
- * <p>If the Javadoc body before at-clauses consists of a single paragraph,
- * there must be no empty line between the body and the first at-clause.
- * If the body contains more than one paragraph (separated by empty Javadoc
- * lines), then an empty Javadoc line is required right before the first
- * at-clause. See
- * <a href="https://github.com/yegor256/qulice/issues/708">#708</a>.</p>
+ * <p>The group of at-clauses ({@code @param}, {@code @return},
+ * {@code @since}, {@code @throws} and the rest) must always be separated
+ * from the description above it by an empty Javadoc line, no matter how
+ * many paragraphs that description has. This holds for every Javadoc
+ * block: packages, classes, interfaces, enums, enum constants,
+ * annotations, annotation fields, records, fields, constructors and
+ * methods. See
+ * <a href="https://github.com/yegor256/qulice/issues/1810">#1810</a>.</p>
  *
- * <p>The following Javadoc will be reported as a violation, since its body
- * is a single paragraph and yet it is separated from the at-clauses by an
- * empty line:</p>
+ * <p>The following Javadoc will be reported as a violation, since its
+ * description touches the first at-clause:</p>
  * <pre>
  * &#47;**
  *  * Just one line here.
- *  <span style="color:red" >*</span>
+ *  <span style="color:red" >* &#64;since 0.1</span>
+ *  *&#47;
+ * </pre>
+ *
+ * <p>And this is how it should be written instead:</p>
+ * <pre>
+ * &#47;**
+ *  * Just one line here.
+ *  *
  *  * &#64;since 0.1
  *  *&#47;
  * </pre>
  *
- * <p>And this one will be reported too, since its body has more than one
- * paragraph but there is no empty line before the at-clauses:</p>
- * <pre>
- * &#47;**
- *  * First line.
- *  *
- *  * Second par.
- *  <span style="color:red" >* &#64;since 0.1</span>
- *  *&#47;
- * </pre>
+ * <p>A Javadoc block with no at-clauses at all, and a block whose very
+ * first line already is an at-clause, are both left alone.</p>
  *
  * @since 0.27.0
  */
@@ -61,8 +62,10 @@ public final class JavadocEmptyLineBeforeTagCheck extends AbstractCheck {
             TokenTypes.ANNOTATION_FIELD_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.RECORD_DEF,
             TokenTypes.VARIABLE_DEF,
             TokenTypes.CTOR_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
             TokenTypes.METHOD_DEF,
         };
     }
@@ -89,37 +92,11 @@ public final class JavadocEmptyLineBeforeTagCheck extends AbstractCheck {
             && start < lines.length && end >= start) {
             final int tag =
                 JavadocEmptyLineBeforeTagCheck.findFirstTag(lines, start, end);
-            if (tag > start) {
-                this.inspect(lines, start, tag);
-            }
-        }
-    }
-
-    private void inspect(final String[] lines, final int start, final int tag) {
-        int body = tag - 1;
-        while (body >= start
-            && JavadocEmptyLineBeforeTagCheck.isJavadocLineEmpty(lines[body])) {
-            body -= 1;
-        }
-        if (body >= start) {
-            boolean multi = false;
-            for (int pos = start; pos <= body; pos += 1) {
-                if (JavadocEmptyLineBeforeTagCheck.isJavadocLineEmpty(lines[pos])) {
-                    multi = true;
-                    break;
-                }
-            }
-            final boolean empty =
-                JavadocEmptyLineBeforeTagCheck.isJavadocLineEmpty(lines[tag - 1]);
-            if (multi && !empty) {
+            if (tag > start
+                && !JavadocEmptyLineBeforeTagCheck.isJavadocLineEmpty(lines[tag - 1])) {
                 this.log(
                     tag + 1,
-                    "Empty Javadoc line required before at-clauses, since the description has multiple paragraphs"
-                );
-            } else if (!multi && empty) {
-                this.log(
-                    tag,
-                    "Empty Javadoc line before at-clauses is not allowed, since the description is a single paragraph"
+                    "Empty Javadoc line required before the block of at-clauses"
                 );
             }
         }

--- a/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 /**
  * Checks method parameters order to comply with what is defined in method
  * javadoc.
+ *
  * @since 0.18.10
  */
 @SuppressWarnings("PMD.LongVariable")

--- a/src/main/java/com/qulice/checkstyle/JnaBinding.java
+++ b/src/main/java/com/qulice/checkstyle/JnaBinding.java
@@ -44,6 +44,7 @@ final class JnaBinding {
 
     /**
      * Ctor.
+     *
      * @param method The METHOD_DEF node
      */
     JnaBinding(final DetailAST method) {
@@ -52,6 +53,7 @@ final class JnaBinding {
 
     /**
      * Is this method a part of a JNA binding?
+     *
      * @return TRUE if the type that declares it maps a native library
      */
     boolean is() {

--- a/src/main/java/com/qulice/checkstyle/LineRange.java
+++ b/src/main/java/com/qulice/checkstyle/LineRange.java
@@ -8,6 +8,7 @@ package com.qulice.checkstyle;
  * Represent a line range. For example, a Java method can be described by an
  * instance of this class. The alpha line could be the method definition and
  * the omega line could be the end closing bracket.
+ *
  * @since 0.16
  */
 public final class LineRange {
@@ -24,6 +25,7 @@ public final class LineRange {
 
     /**
      * Default constructor.
+     *
      * @param first The alpha line number
      * @param last The omega line number
      */
@@ -34,6 +36,7 @@ public final class LineRange {
 
     /**
      * Is the given line number within range.
+     *
      * @param line The given line number to check
      * @return True if the given line number is within this range
      */
@@ -45,6 +48,7 @@ public final class LineRange {
      * Is the given range entirely within the LineRange. Example, given a
      * LineRange of [10, 50], the given range of [12,48] should be within
      * side that. And the method should return true.
+     *
      * @param range The given LineRange to check
      * @return True if the given is entirely within this LineRange
      */
@@ -55,6 +59,7 @@ public final class LineRange {
 
     /**
      * Get the alpha line number.
+     *
      * @return The alpha line number
      */
     public int first() {
@@ -63,6 +68,7 @@ public final class LineRange {
 
     /**
      * Get the omega line number.
+     *
      * @return The omega line number
      */
     public int last() {

--- a/src/main/java/com/qulice/checkstyle/LineRanges.java
+++ b/src/main/java/com/qulice/checkstyle/LineRanges.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
  * Represents a set of LineRange objects. For example, an instance of this class
  * could represent all the line ranges for methods in a given Java source code
  * file.
+ *
  * @since 0.16
  */
 public final class LineRanges {
@@ -31,6 +32,7 @@ public final class LineRanges {
 
     /**
      * Adds a line range to the collection.
+     *
      * @param line The line range to add to the collection
      */
     public void add(final LineRange line) {
@@ -39,6 +41,7 @@ public final class LineRanges {
 
     /**
      * Returns an iterator for this collection.
+     *
      * @return Iterator pointing to the internal collections elements
      */
     public Iterator<LineRange> iterator() {
@@ -47,6 +50,7 @@ public final class LineRanges {
 
     /**
      * Detects if the given line number is within any of the line ranges.
+     *
      * @param line The given line number to check
      * @return True if the given line number is within any line range
      */
@@ -59,6 +63,7 @@ public final class LineRanges {
     /**
      * Gets the subset of LineRanges that are within all given ranges. Does
      * not return null; instead, returns empty range if there are no matches.
+     *
      * @param ranges The ranges to filter on
      * @return Returns all LineRange elements that are within range
      */

--- a/src/main/java/com/qulice/checkstyle/LineWithAny.java
+++ b/src/main/java/com/qulice/checkstyle/LineWithAny.java
@@ -9,6 +9,7 @@ import com.google.common.base.Predicate;
 /**
  * Predicate to determine if a given line is within range of any of
  * the line ranges.
+ *
  * @since 0.1
  */
 final class LineWithAny implements Predicate<LineRange> {
@@ -20,6 +21,7 @@ final class LineWithAny implements Predicate<LineRange> {
 
     /**
      * Default constructor.
+     *
      * @param line The given line to check against all the line ranges
      */
     LineWithAny(final int line) {

--- a/src/main/java/com/qulice/checkstyle/MethodDeclarationLengthCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodDeclarationLengthCheck.java
@@ -53,6 +53,7 @@ public final class MethodDeclarationLengthCheck extends AbstractCheck {
 
     /**
      * Configure the maximum allowed length.
+     *
      * @param value New value
      */
     public void setMax(final int value) {

--- a/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
@@ -182,6 +182,7 @@ public final class MethodsOrderCheck extends AbstractCheck {
 
         /**
          * Constructor.
+         *
          * @param type TokenType of DetailAST which represents modifier
          * @param ord Order of the modifier in class definition
          */
@@ -192,6 +193,7 @@ public final class MethodsOrderCheck extends AbstractCheck {
 
         /**
          * TokenType.
+         *
          * @return TokenType
          */
         int getType() {
@@ -200,6 +202,7 @@ public final class MethodsOrderCheck extends AbstractCheck {
 
         /**
          * Order of modifier.
+         *
          * @return Order number
          */
         int getOrder() {

--- a/src/main/java/com/qulice/checkstyle/MultiLineCommentCheck.java
+++ b/src/main/java/com/qulice/checkstyle/MultiLineCommentCheck.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 /**
  * Multi line comment checker.
  * Used by the checkstyle process multiple times as a singleton.
+ *
  * @since 0.23.1
  */
 public final class MultiLineCommentCheck extends AbstractCheck {
@@ -96,6 +97,7 @@ public final class MultiLineCommentCheck extends AbstractCheck {
      * The parameter is set from the checks.xml file
      * {@code <module name="com.qulice.checkstyle.MultiLineCommentCheck"/>} and
      * {@code <property name="format" value=" this regexp "/>} property
+     *
      * @param fmt Validatig regexp
      */
     public void setFormat(final String fmt) {
@@ -108,6 +110,7 @@ public final class MultiLineCommentCheck extends AbstractCheck {
      * {@code <module name="com.qulice.checkstyle.MultiLineCommentCheck"/>} and
      * {@code <property name="message" value="First sentence in a comment ..."/>}
      * property
+     *
      * @param msg Error message
      */
     public void setMessage(final String msg) {

--- a/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
+++ b/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
@@ -16,6 +16,7 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  * Users may have a different understanding of your method
  * based on whether they examine the method in the supertype
  * or the subtype and it may cause confusion.
+ *
  * @since 0.16
  */
 public final class NoJavadocForOverriddenMethodsCheck extends AbstractCheck {

--- a/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -50,6 +50,7 @@ public final class NonStaticMethodCheck extends AbstractCheck {
 
     /**
      * Exclude files matching given pattern.
+     *
      * @param excl Regexp of classes to exclude
      */
     public void setExcludeFileNamePattern(final String excl) {

--- a/src/main/java/com/qulice/checkstyle/ProhibitFieldsInTestClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitFieldsInTestClassesCheck.java
@@ -52,6 +52,7 @@ public final class ProhibitFieldsInTestClassesCheck extends AbstractCheck {
 
     /**
      * Restrict the check to files matching the given pattern.
+     *
      * @param regex Regex of file names to include
      */
     public void setIncludeFileNamePattern(final String regex) {

--- a/src/main/java/com/qulice/checkstyle/ProhibitStaticNestedClassesCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitStaticNestedClassesCheck.java
@@ -46,6 +46,7 @@ public final class ProhibitStaticNestedClassesCheck extends AbstractCheck {
 
     /**
      * Do not apply this check to files matching the given pattern.
+     *
      * @param regex Regex of file names to exclude
      */
     public void setExcludeFileNamePattern(final String regex) {

--- a/src/main/java/com/qulice/checkstyle/ProhibitUnusedPrivateConstructorCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProhibitUnusedPrivateConstructorCheck.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 /**
  * Checks that constructor, declared as private class is used more than once.
+ *
  * @since 0.3
  */
 public final class ProhibitUnusedPrivateConstructorCheck extends AbstractCheck {

--- a/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
+++ b/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
@@ -14,6 +14,7 @@ import java.util.List;
 /**
  * Checks that final class doesn't contain protected methods unless they are
  * overriding protected methods from superclass.
+ *
  * @since 0.6
  */
 public final class ProtectedMethodInFinalClassCheck extends AbstractCheck {

--- a/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
+++ b/src/main/java/com/qulice/checkstyle/QualifyInnerClassCheck.java
@@ -13,6 +13,7 @@ import java.util.Set;
 /**
  * Checks if inner classes are properly accessed using their qualified name
  * with the outer class.
+ *
  * @since 0.18
  */
 public final class QualifyInnerClassCheck extends AbstractCheck {

--- a/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
+++ b/src/main/java/com/qulice/checkstyle/RequiredJavaDocTag.java
@@ -56,6 +56,7 @@ final class RequiredJavaDocTag {
 
     /**
      * Ctor.
+     *
      * @param cname Tag name
      * @param ptag Pattern for searching a tag in a string
      * @param patt Pattern for checking the contents of a tag in a string
@@ -75,6 +76,7 @@ final class RequiredJavaDocTag {
 
     /**
      * Check if the tag text matches the format from pattern.
+     *
      * @param lines List of all lines
      * @param start Line number where comment starts
      * @param end Line number where comment ends
@@ -148,6 +150,7 @@ final class RequiredJavaDocTag {
 
     /**
      * Logger.
+     *
      * @see com.puppycrawl.tools.checkstyle.api.AbstractCheck#log(int, String, Object...)
      * @since 0.23.1
      */
@@ -156,6 +159,7 @@ final class RequiredJavaDocTag {
 
         /**
          * Log a message that has no column information.
+         *
          * @param line The line number where the audit event was found
          * @param msg The message that describes the audit event
          * @param args The details of the message

--- a/src/main/java/com/qulice/checkstyle/SingleLineCommentCheck.java
+++ b/src/main/java/com/qulice/checkstyle/SingleLineCommentCheck.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 /**
  * C++ style inline comment is not allowed.
  * Use //-style comment instead.
+ *
  * @since 0.18
  */
 public final class SingleLineCommentCheck extends AbstractCheck {
@@ -102,6 +103,7 @@ public final class SingleLineCommentCheck extends AbstractCheck {
      * The parameter is set from the checks.xml file
      * {@code <module name="com.qulice.checkstyle.SingleLineCommentCheck"/>} and
      * {@code <property name="format" value=" this regexp "/>} property
+     *
      * @param fmt Validatig regexp
      */
     public void setFormat(final String fmt) {
@@ -114,6 +116,7 @@ public final class SingleLineCommentCheck extends AbstractCheck {
      * {@code <module name="com.qulice.checkstyle.SingleLineCommentCheck"/>} and
      * {@code <property name="message" value="This comment is not allowed."/>}
      * property
+     *
      * @param msg Error message
      */
     public void setMessage(final String msg) {

--- a/src/main/java/com/qulice/checkstyle/SuppressionTag.java
+++ b/src/main/java/com/qulice/checkstyle/SuppressionTag.java
@@ -41,6 +41,7 @@ final class SuppressionTag {
 
     /**
      * Constructor.
+     *
      * @param check Name of the suppressed check
      * @param first First line of the influence range, and of the comment
      * @param last Last line of the influence range
@@ -53,6 +54,7 @@ final class SuppressionTag {
 
     /**
      * Name of the suppressed check.
+     *
      * @return The name
      */
     String check() {
@@ -61,6 +63,7 @@ final class SuppressionTag {
 
     /**
      * Line of the comment, where a violation about it belongs.
+     *
      * @return Line number
      */
     int line() {

--- a/src/main/java/com/qulice/checkstyle/Suppressions.java
+++ b/src/main/java/com/qulice/checkstyle/Suppressions.java
@@ -64,6 +64,7 @@ final class Suppressions implements Iterable<SuppressionTag> {
 
     /**
      * Constructor.
+     *
      * @param text Text of the source file
      */
     Suppressions(final String text) {

--- a/src/main/java/com/qulice/checkstyle/UnusedSuppressions.java
+++ b/src/main/java/com/qulice/checkstyle/UnusedSuppressions.java
@@ -62,6 +62,7 @@ final class UnusedSuppressions {
 
     /**
      * Constructor.
+     *
      * @param env Environment to use
      */
     UnusedSuppressions(final Environment env) {
@@ -70,6 +71,7 @@ final class UnusedSuppressions {
 
     /**
      * Find the suppressions that cover no violation.
+     *
      * @param files Files the primary run processed, cache aside
      * @return Violations, one per dead suppression
      */

--- a/src/main/java/com/qulice/checkstyle/package-info.java
+++ b/src/main/java/com/qulice/checkstyle/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Checkstyle checks.
+ *
  * @since 0.3
  */
 package com.qulice.checkstyle;

--- a/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
+++ b/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
@@ -13,6 +13,7 @@ import java.util.function.Consumer;
 
 /**
  * Method or constructor arguments.
+ *
  * @since 0.18.18
  */
 public class Arguments {
@@ -24,6 +25,7 @@ public class Arguments {
 
     /**
      * Secondary ctor.
+     *
      * @param node Constructor or method definition node
      */
     public Arguments(final DetailAST node) {
@@ -36,6 +38,7 @@ public class Arguments {
 
     /**
      * Primary ctor.
+     *
      * @param parameters Parameters
      */
     public Arguments(final Parameters parameters) {
@@ -44,6 +47,7 @@ public class Arguments {
 
     /**
      * Return number of arguments.
+     *
      * @return Number of arguments
      */
     public final int count() {
@@ -53,6 +57,7 @@ public class Arguments {
     /**
      * Checks for consistency the order of arguments and their Javadoc
      * parameters.
+     *
      * @param tags Javadoc parameter tags
      * @param consumer Consumer accepts JavadocTag which is located out of
      *  order

--- a/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
+++ b/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
@@ -12,6 +12,7 @@ import java.util.List;
 /**
  * Abstract parameters. Is used for Generic type parameters or
  * method(constructor) arguments.
+ *
  * @since 0.18.18
  */
 public class Parameters {
@@ -23,18 +24,21 @@ public class Parameters {
 
     /**
      * Parent TokenType (TYPE_PARAMETERS or PARAMETERS).
+     *
      * @see com.puppycrawl.tools.checkstyle.api.TokenTypes
      */
     private final int parent;
 
     /**
      * Children TokenType (TYPE_PARAMETER or PARAMETER_DEF).
+     *
      * @see com.puppycrawl.tools.checkstyle.api.TokenTypes
      */
     private final int children;
 
     /**
      * Primary ctor.
+     *
      * @param node Class, interface, constructor or method definition node
      * @param parent Parent TokenType (TYPE_PARAMETERS or PARAMETERS)
      * @param children Children TokenType (TYPE_PARAMETER or PARAMETER_DEF)
@@ -49,6 +53,7 @@ public class Parameters {
 
     /**
      * Return number of arguments.
+     *
      * @return Number of parameters
      */
     public final int count() {
@@ -64,6 +69,7 @@ public class Parameters {
 
     /**
      * Return parameters for this node.
+     *
      * @return Parameters for this node
      */
     public final List<DetailAST> parameters() {

--- a/src/main/java/com/qulice/checkstyle/parameters/TypeParameters.java
+++ b/src/main/java/com/qulice/checkstyle/parameters/TypeParameters.java
@@ -13,6 +13,7 @@ import java.util.function.Consumer;
 
 /**
  * Class, interface, constructor or method generic type parameters.
+ *
  * @since 0.18.18
  */
 public class TypeParameters {
@@ -24,6 +25,7 @@ public class TypeParameters {
 
     /**
      * Secondary ctor.
+     *
      * @param node Class, interface, constructor or method definition node
      */
     public TypeParameters(final DetailAST node) {
@@ -36,6 +38,7 @@ public class TypeParameters {
 
     /**
      * Primary ctor.
+     *
      * @param parameters Parameters
      */
     public TypeParameters(final Parameters parameters) {
@@ -44,6 +47,7 @@ public class TypeParameters {
 
     /**
      * Return number of arguments.
+     *
      * @return Number of arguments
      */
     public final int count() {
@@ -53,6 +57,7 @@ public class TypeParameters {
     /**
      * Checks for consistency the order of generic type parameters and
      * their Javadoc parameters.
+     *
      * @param tags Javadoc parameter tags
      * @param consumer Consumer accepts JavadocTag which is located out of
      *  order

--- a/src/main/java/com/qulice/checkstyle/parameters/package-info.java
+++ b/src/main/java/com/qulice/checkstyle/parameters/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Argument and generic type parameters.
+ *
  * @since 0.18.18
  */
 package com.qulice.checkstyle.parameters;

--- a/src/main/java/com/qulice/errorprone/Argfile.java
+++ b/src/main/java/com/qulice/errorprone/Argfile.java
@@ -38,6 +38,7 @@ public final class Argfile {
 
     /**
      * Constructor.
+     *
      * @param place Target file path
      * @param args Tokens to write
      */
@@ -48,6 +49,7 @@ public final class Argfile {
 
     /**
      * Write the argfile and return its path.
+     *
      * @return The path of the just-written argfile
      */
     public File save() {

--- a/src/main/java/com/qulice/errorprone/Batches.java
+++ b/src/main/java/com/qulice/errorprone/Batches.java
@@ -77,6 +77,7 @@ public final class Batches {
 
     /**
      * Constructor.
+     *
      * @param env Environment that knows the source roots
      * @param sources Java source files to split
      */
@@ -87,6 +88,7 @@ public final class Batches {
 
     /**
      * Split the sources, one batch per source root.
+     *
      * @return Batches by name, in compilation order, none of them empty
      */
     public Map<String, List<File>> split() {

--- a/src/main/java/com/qulice/errorprone/Diagnostics.java
+++ b/src/main/java/com/qulice/errorprone/Diagnostics.java
@@ -56,6 +56,7 @@ final class Diagnostics {
 
     /**
      * Constructor.
+     *
      * @param validator Name of the validator reporting these diagnostics
      * @param fallback File to blame when a diagnostic names no position
      */
@@ -66,6 +67,7 @@ final class Diagnostics {
 
     /**
      * Read the diagnostics out of the compiler's output.
+     *
      * @param output Combined stdout/stderr of the forked process
      * @return Violations, one per diagnostic line
      */

--- a/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
+++ b/src/main/java/com/qulice/errorprone/ErrorProneValidator.java
@@ -98,6 +98,7 @@ public final class ErrorProneValidator implements ResourceValidator {
 
     /**
      * Constructor.
+     *
      * @param env Environment to use
      */
     public ErrorProneValidator(final Environment env) {

--- a/src/main/java/com/qulice/errorprone/Release.java
+++ b/src/main/java/com/qulice/errorprone/Release.java
@@ -61,6 +61,7 @@ final class Release {
 
     /**
      * Constructor.
+     *
      * @param env Environment to read the Maven properties from
      * @param batch Name of the batch being compiled
      */
@@ -71,6 +72,7 @@ final class Release {
 
     /**
      * The source-level flags to append to the {@code javac} command line.
+     *
      * @return Source-level flags, possibly empty
      */
     List<String> flags() {

--- a/src/main/java/com/qulice/errorprone/Unencoded.java
+++ b/src/main/java/com/qulice/errorprone/Unencoded.java
@@ -32,6 +32,7 @@ final class Unencoded {
 
     /**
      * Constructor.
+     *
      * @param url URL of a classpath entry
      */
     Unencoded(final URL url) {
@@ -40,6 +41,7 @@ final class Unencoded {
 
     /**
      * Absolute path of the file this URL points at.
+     *
      * @return The path, or empty if the URL is not a local file
      */
     Optional<String> path() {

--- a/src/main/java/com/qulice/errorprone/Xplugin.java
+++ b/src/main/java/com/qulice/errorprone/Xplugin.java
@@ -68,6 +68,7 @@ public final class Xplugin {
 
     /**
      * Constructor.
+     *
      * @param flags ErrorProne flags of the project, if any, separated by
      *  whitespace or commas
      */

--- a/src/main/java/com/qulice/errorprone/package-info.java
+++ b/src/main/java/com/qulice/errorprone/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * ErrorProne validator.
+ *
  * @since 1.0
  */
 package com.qulice.errorprone;

--- a/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -20,6 +20,7 @@ import org.slf4j.impl.StaticLoggerBinder;
 
 /**
  * Abstract mojo.
+ *
  * @since 0.3
  */
 public abstract class AbstractQuliceMojo extends AbstractMojo
@@ -88,6 +89,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * The source encoding.
+     *
      * @parameter expression="${project.build.sourceEncoding}" required="true"
      */
     @Parameter(property = "encoding", defaultValue = "${project.build.sourceEncoding}")
@@ -105,6 +107,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Set Maven Project (used mostly for unit testing).
+     *
      * @param proj The project to set
      */
     public final void setProject(final MavenProject proj) {
@@ -113,6 +116,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Set skip option (mostly for unit testing).
+     *
      * @param skp The "skip" option
      */
     public final void setSkip(final boolean skp) {
@@ -121,6 +125,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Set asserts option.
+     *
      * @param val Asserts to use
      */
     public final void setAsserts(final Collection<String> val) {
@@ -130,6 +135,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Set excludes.
+     *
      * @param exprs Expressions
      */
     public final void setExcludes(final Collection<String> exprs) {
@@ -139,6 +145,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Set extra ErrorProne flags.
+     *
      * @param flags Flags, e.g. {@code -Xep:UnicodeInCode:OFF}
      */
     public final void setErrorprone(final Collection<String> flags) {
@@ -148,6 +155,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Set source code encoding.
+     *
      * @param encoding Source code encoding
      */
     public void setEncoding(final String encoding) {
@@ -190,6 +198,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Current maven session.
+     *
      * @return Current maven session
      */
     public final MavenSession session() {
@@ -198,6 +207,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Do the real execution.
+     *
      * @return What was done, as the middle of the final log line, e.g.
      *  {@code "checked 42 .java files against 385 rules"}
      * @throws MojoFailureException If some failure inside
@@ -206,6 +216,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * Get the environment.
+     *
      * @return The environment
      */
     protected final MavenEnvironment env() {

--- a/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/src/main/java/com/qulice/maven/CheckMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Check the project and find all possible violations.
+ *
  * @since 0.3
  */
 @Mojo(
@@ -69,6 +70,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
 
     /**
      * Primary constructor.
+     *
      * @param svc Executors to run resource validators in
      */
     private CheckMojo(final ExecutorService svc) {
@@ -90,6 +92,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
 
     /**
      * Set provider of validators.
+     *
      * @param prov The provider
      */
     public void setValidatorsProvider(final ValidatorsProvider prov) {
@@ -98,6 +101,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
 
     /**
      * Set timeout for checks.
+     *
      * @param time Timeout value
      */
     public void setTimeout(final String time) {
@@ -106,6 +110,7 @@ public final class CheckMojo extends AbstractQuliceMojo {
 
     /**
      * Filter files based on excludes.
+     *
      * @param env Maven environment
      * @param files Files to exclude
      * @param validator Validator to use

--- a/src/main/java/com/qulice/maven/CheckerExcludes.java
+++ b/src/main/java/com/qulice/maven/CheckerExcludes.java
@@ -23,6 +23,7 @@ final class CheckerExcludes implements Function<String, String> {
 
     /**
      * Constructor.
+     *
      * @param checker Name of checker
      */
     CheckerExcludes(final String checker) {

--- a/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -33,6 +33,7 @@ import org.codehaus.plexus.context.Context;
 
 /**
  * Environment, passed from MOJO to validators.
+ *
  * @since 0.3
  */
 @SuppressWarnings("PMD.GodClass")
@@ -246,6 +247,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     /**
      * Set Maven Project (used mostly for unit testing).
+     *
      * @param proj The project to set
      */
     public void setProject(final MavenProject proj) {
@@ -254,6 +256,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     /**
      * Set context.
+     *
      * @param ctx The context to set
      */
     public void setContext(final Context ctx) {
@@ -262,6 +265,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     /**
      * Set executor.
+     *
      * @param exec The executor
      */
     public void setMojoExecutor(final MojoExecutor exec) {
@@ -270,6 +274,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     /**
      * Set property.
+     *
      * @param name Its name
      * @param value Its value
      */
@@ -279,6 +284,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     /**
      * Set list of regular expressions to exclude.
+     *
      * @param exprs Expressions
      */
     public void setExcludes(final Collection<String> exprs) {
@@ -288,6 +294,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     /**
      * Set list of Xpath queries for pom.xml validation.
+     *
      * @param ass Xpath queries
      */
     public void setAssertion(final Collection<String> ass) {
@@ -297,6 +304,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     /**
      * Set the encoding of source files.
+     *
      * @param encoding The encoding to use
      */
     public void setEncoding(final String encoding) {

--- a/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
+++ b/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 /**
  * Provider of validators.
+ *
  * @since 0.3
  */
 final class DefaultValidatorsProvider implements ValidatorsProvider {
@@ -28,6 +29,7 @@ final class DefaultValidatorsProvider implements ValidatorsProvider {
 
     /**
      * Constructor.
+     *
      * @param env Environment to use for validation
      */
     DefaultValidatorsProvider(final Environment env) {

--- a/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -34,6 +34,7 @@ import org.codehaus.plexus.context.ContextException;
 
 /**
  * Validator of dependencies.
+ *
  * @since 0.3
  * @checkstyle ReturnCountCheck (100 line)
  */

--- a/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
+++ b/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
@@ -14,6 +14,7 @@ import org.apache.commons.collections.CollectionUtils;
 
 /**
  * Validate with maven-duplicate-finder-plugin.
+ *
  * @since 0.5
  * @todo #1118 ignored dependencies and resources should be placed in different parameters,
  *  and current implementation use ':' symbol as a flag if it is resource or dependency.

--- a/src/main/java/com/qulice/maven/EnforcerValidator.java
+++ b/src/main/java/com/qulice/maven/EnforcerValidator.java
@@ -9,6 +9,7 @@ import java.util.Properties;
 
 /**
  * Validate with maven-enforcer-plugin.
+ *
  * @since 0.3
  */
 public final class EnforcerValidator implements MavenValidator {

--- a/src/main/java/com/qulice/maven/ExcludePredicate.java
+++ b/src/main/java/com/qulice/maven/ExcludePredicate.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 
 /**
  * Predicate for excluded dependencies.
+ *
  * @since 0.1
  */
 final class ExcludePredicate implements Predicate<String> {
@@ -20,6 +21,7 @@ final class ExcludePredicate implements Predicate<String> {
 
     /**
      * Constructor.
+     *
      * @param excludes List of excludes
      */
     ExcludePredicate(final Collection<String> excludes) {

--- a/src/main/java/com/qulice/maven/MavenEnvironment.java
+++ b/src/main/java/com/qulice/maven/MavenEnvironment.java
@@ -14,48 +14,56 @@ import org.codehaus.plexus.context.Context;
 
 /**
  * Environment, passed from MOJO to validators.
+ *
  * @since 0.3
  */
 interface MavenEnvironment extends Environment {
 
     /**
      * Get project.
+     *
      * @return The project
      */
     MavenProject project();
 
     /**
      * Get properties.
+     *
      * @return The properties
      */
     Properties properties();
 
     /**
      * Get context.
+     *
      * @return The context
      */
     Context context();
 
     /**
      * Get plugin configuration properties.
+     *
      * @return The props
      */
     Properties config();
 
     /**
      * Get MOJO executor.
+     *
      * @return The executor
      */
     MojoExecutor executor();
 
     /**
      * Get xpath queries for pom.xml validation.
+     *
      * @return The asserts
      */
     Collection<String> asserts();
 
     /**
      * Wrapper of maven environment.
+     *
      * @since 0.1
      */
     final class Wrap implements MavenEnvironment {
@@ -72,6 +80,7 @@ interface MavenEnvironment extends Environment {
 
         /**
          * Public ctor.
+         *
          * @param penv Parent env
          * @param pmenv Parent maven env
          */

--- a/src/main/java/com/qulice/maven/MavenValidator.java
+++ b/src/main/java/com/qulice/maven/MavenValidator.java
@@ -8,6 +8,7 @@ import com.qulice.spi.ValidationException;
 
 /**
  * Validator inside Maven.
+ *
  * @since 0.3
  */
 @FunctionalInterface
@@ -15,6 +16,7 @@ interface MavenValidator {
 
     /**
      * Validate this environment.
+     *
      * @param env The environment
      * @throws ValidationException In case of violations
      */

--- a/src/main/java/com/qulice/maven/MojoExecutor.java
+++ b/src/main/java/com/qulice/maven/MojoExecutor.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 /**
  * Executor of plugins.
+ *
  * @since 0.3
  */
 public final class MojoExecutor {
@@ -45,6 +46,7 @@ public final class MojoExecutor {
 
     /**
      * Public ctor.
+     *
      * @param mngr The manager
      * @param sesn Maven session
      */
@@ -56,6 +58,7 @@ public final class MojoExecutor {
 
     /**
      * Find and configure a mojo.
+     *
      * @param coords Maven coordinates,
      *  e.g. "com.qulice:maven-qulice-plugin:1.0"
      * @param goal Maven plugin goal to execute
@@ -105,6 +108,7 @@ public final class MojoExecutor {
 
     /**
      * Recursively convert Properties to Xpp3Dom.
+     *
      * @param config The config to convert
      * @param name High-level name of it
      * @return The Xpp3Dom document

--- a/src/main/java/com/qulice/maven/PathPredicate.java
+++ b/src/main/java/com/qulice/maven/PathPredicate.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.FilenameUtils;
 
 /**
  * Checks if two paths are equal.
+ *
  * @since 0.1
  */
 final class PathPredicate implements Predicate<String> {
@@ -21,6 +22,7 @@ final class PathPredicate implements Predicate<String> {
 
     /**
      * Constructor.
+     *
      * @param name Path to match
      */
     PathPredicate(final String name) {

--- a/src/main/java/com/qulice/maven/PrivilegedClassLoader.java
+++ b/src/main/java/com/qulice/maven/PrivilegedClassLoader.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 /**
  * Creates URL ClassLoader in privileged block.
+ *
  * @since 0.1
  */
 final class PrivilegedClassLoader implements PrivilegedAction<URLClassLoader> {
@@ -22,6 +23,7 @@ final class PrivilegedClassLoader implements PrivilegedAction<URLClassLoader> {
 
     /**
      * Constructor.
+     *
      * @param urls URLs for class loading
      */
     PrivilegedClassLoader(final List<URL> urls) {

--- a/src/main/java/com/qulice/maven/SnapshotsValidator.java
+++ b/src/main/java/com/qulice/maven/SnapshotsValidator.java
@@ -13,6 +13,7 @@ import org.apache.maven.model.Plugin;
 /**
  * Check that the project has not SNAPSHOT dependencies if its own
  * status is stable.
+ *
  * @since 0.3
  */
 public final class SnapshotsValidator implements MavenValidator {

--- a/src/main/java/com/qulice/maven/Summary.java
+++ b/src/main/java/com/qulice/maven/Summary.java
@@ -37,6 +37,7 @@ final class Summary {
 
     /**
      * Constructor.
+     *
      * @param files Files handed to the validators
      * @param validators Validators that read them
      */

--- a/src/main/java/com/qulice/maven/ValidatorCallable.java
+++ b/src/main/java/com/qulice/maven/ValidatorCallable.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Callable;
 
 /**
  * Callable for validators.
+ *
  * @since 0.1
  */
 final class ValidatorCallable implements Callable<Collection<Violation>> {
@@ -33,6 +34,7 @@ final class ValidatorCallable implements Callable<Collection<Violation>> {
 
     /**
      * Constructor.
+     *
      * @param validator Validator to use
      * @param env Maven environment
      * @param files List of files to validate

--- a/src/main/java/com/qulice/maven/ValidatorsProvider.java
+++ b/src/main/java/com/qulice/maven/ValidatorsProvider.java
@@ -11,12 +11,14 @@ import java.util.Set;
 
 /**
  * Provider of validators.
+ *
  * @since 0.3
  */
 interface ValidatorsProvider {
 
     /**
      * Get a collection of internal validators.
+     *
      * @return List of them
      * @see CheckMojo#execute()
      */
@@ -24,6 +26,7 @@ interface ValidatorsProvider {
 
     /**
      * Get a collection of external validators.
+     *
      * @return List of them
      * @see CheckMojo#execute()
      */
@@ -31,6 +34,7 @@ interface ValidatorsProvider {
 
     /**
      * Get a collection of external validators.
+     *
      * @return List of them
      * @see CheckMojo#execute()
      */

--- a/src/main/java/com/qulice/maven/package-info.java
+++ b/src/main/java/com/qulice/maven/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Maven plugin.
+ *
  * @since 0.3
  */
 package com.qulice.maven;

--- a/src/main/java/com/qulice/pmd/PmdError.java
+++ b/src/main/java/com/qulice/pmd/PmdError.java
@@ -11,6 +11,7 @@ import org.cactoos.text.UncheckedText;
 
 /**
  * Represents one PMD error (usually it will be violation).
+ *
  * @since 1.0
  */
 public interface PmdError {
@@ -18,6 +19,7 @@ public interface PmdError {
     /**
      * Returns error name which is short, fixed, human-readable category of
      * the error.
+     *
      * @return Error name
      */
     String name();
@@ -25,6 +27,7 @@ public interface PmdError {
     /**
      * Returns file name which caused this error.
      * May return sentinel value if file information is not available.
+     *
      * @return File name
      */
     String fileName();
@@ -32,18 +35,21 @@ public interface PmdError {
     /**
      * Returns formatted line range which cause this error.
      * May return sentinel value if line information is not available.
+     *
      * @return Formatted line range
      */
     String lines();
 
     /**
      * Returns error description.
+     *
      * @return Description
      */
     String description();
 
     /**
      * PmdError backed by a RuleViolation.
+     *
      * @since 1.0
      */
     final class OfRuleViolation implements PmdError {
@@ -55,6 +61,7 @@ public interface PmdError {
 
         /**
          * Creates a new PmdError, representing given RuleViolation.
+         *
          * @param violation Internal RuleViolation
          */
         public OfRuleViolation(final RuleViolation violation) {
@@ -87,6 +94,7 @@ public interface PmdError {
 
     /**
      * PmdError backed by a ProcessingError.
+     *
      * @since 1.0
      */
     final class OfProcessingError implements PmdError {
@@ -98,6 +106,7 @@ public interface PmdError {
 
         /**
          * Creates a new PmdError, representing given ProcessingError.
+         *
          * @param error Internal ProcessingError
          */
         public OfProcessingError(final Report.ProcessingError error) {
@@ -133,6 +142,7 @@ public interface PmdError {
 
     /**
      * PmdError backed by a ConfigError.
+     *
      * @since 1.0
      */
     final class OfConfigError implements PmdError {
@@ -144,6 +154,7 @@ public interface PmdError {
 
         /**
          * Creates a new PmdError, representing given ConfigurationError.
+         *
          * @param error Internal ConfigurationError
          */
         public OfConfigError(final Report.ConfigurationError error) {

--- a/src/main/java/com/qulice/pmd/PmdValidator.java
+++ b/src/main/java/com/qulice/pmd/PmdValidator.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 
 /**
  * Validates source code with PMD.
+ *
  * @since 0.3
  */
 public final class PmdValidator implements ResourceValidator {
@@ -28,6 +29,7 @@ public final class PmdValidator implements ResourceValidator {
 
     /**
      * Constructor.
+     *
      * @param env Environment to use
      */
     public PmdValidator(final Environment env) {
@@ -76,6 +78,7 @@ public final class PmdValidator implements ResourceValidator {
 
     /**
      * Filters out excluded files from further validation.
+     *
      * @param files Files to validate
      * @return Relevant source files
      */

--- a/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -23,6 +23,7 @@ import org.cactoos.list.ListOf;
 
 /**
  * Validates source files via <code>PmdValidator</code>.
+ *
  * @since 0.3
  */
 final class SourceValidator {
@@ -39,6 +40,7 @@ final class SourceValidator {
 
     /**
      * Creates new instance of <code>SourceValidator</code>.
+     *
      * @param charset Source files encoding
      */
     SourceValidator(final Charset charset) {
@@ -48,6 +50,7 @@ final class SourceValidator {
 
     /**
      * Performs validation of the input source files.
+     *
      * @param sources Input source files
      * @param path Base path
      * @return Collection of violations
@@ -81,6 +84,7 @@ final class SourceValidator {
     /**
      * How many rules the ruleset holds, once PMD has resolved the
      * categories it refers to and taken the exclusions out.
+     *
      * @return The number of rules
      */
     int rules() {

--- a/src/main/java/com/qulice/pmd/package-info.java
+++ b/src/main/java/com/qulice/pmd/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * PMD validator.
+ *
  * @since 0.3
  */
 package com.qulice.pmd;

--- a/src/main/java/com/qulice/pmd/rules/CloseInlineResourceRule.java
+++ b/src/main/java/com/qulice/pmd/rules/CloseInlineResourceRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 /**
  * Rule to flag {@code AutoCloseable} expressions that are created inline and
  * then consumed by another expression instead of a resource boundary.
+ *
  * @since 0.27.7
  */
 public final class CloseInlineResourceRule extends AbstractJavaRulechainRule {

--- a/src/main/java/com/qulice/pmd/rules/CloseInlineResourceRule.java
+++ b/src/main/java/com/qulice/pmd/rules/CloseInlineResourceRule.java
@@ -37,6 +37,9 @@ public final class CloseInlineResourceRule extends AbstractJavaRulechainRule {
         "java.util.stream.DoubleStream"
     );
 
+    /**
+     * Default constructor.
+     */
     public CloseInlineResourceRule() {
         super(ASTConstructorCall.class, ASTMethodCall.class);
     }
@@ -95,8 +98,7 @@ public final class CloseInlineResourceRule extends AbstractJavaRulechainRule {
     private static boolean closedDirectly(final ASTExpression expr) {
         boolean found = false;
         final Node parent = expr.getParent();
-        if (parent instanceof ASTMethodCall) {
-            final ASTMethodCall call = (ASTMethodCall) parent;
+        if (parent instanceof ASTMethodCall call) {
             found = "close".equals(call.getMethodName())
                 && expr.equals(call.getQualifier());
         }

--- a/src/main/java/com/qulice/pmd/rules/ExcessiveParameterListRule.java
+++ b/src/main/java/com/qulice/pmd/rules/ExcessiveParameterListRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * {@code @SuppressWarnings("PMD.ExcessiveParameterList")} visible to
  * {@code UnnecessaryWarningSuppression}, which PMD credits to the
  * annotation whenever the annotation suppressor runs first.
+ *
  * @since 1.0
  */
 public final class ExcessiveParameterListRule

--- a/src/main/java/com/qulice/pmd/rules/NamedSupertype.java
+++ b/src/main/java/com/qulice/pmd/rules/NamedSupertype.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
  * never resolves to a type and only the name written in the clause is
  * available. That name is trusted when it is fully qualified, or when the
  * file imports the type, either directly or on demand from its package.
+ *
  * @since 1.0
  */
 final class NamedSupertype {
@@ -26,6 +27,7 @@ final class NamedSupertype {
 
     /**
      * Constructor.
+     *
      * @param name Canonical name of the type
      */
     NamedSupertype(final String name) {
@@ -34,6 +36,7 @@ final class NamedSupertype {
 
     /**
      * Does the given clause name this very type?
+     *
      * @param clause Type named in an extends or implements clause,
      *  may be NULL when the clause is absent
      * @return TRUE if the clause names this type

--- a/src/main/java/com/qulice/pmd/rules/ProhibitFormatInLoggerRule.java
+++ b/src/main/java/com/qulice/pmd/rules/ProhibitFormatInLoggerRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * supports printf-style format strings as the message argument, so
  * pre-formatting with {@code String.format} is unnecessary and should be
  * inlined into the Logger call.
+ *
  * @since 0.26.0
  */
 public final class ProhibitFormatInLoggerRule

--- a/src/main/java/com/qulice/pmd/rules/ProhibitPlainJunitAssertionsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/ProhibitPlainJunitAssertionsRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 
 /**
  * Rule to check plain assertions in JUnit tests.
+ *
  * @since 0.17
  */
 public final class ProhibitPlainJunitAssertionsRule

--- a/src/main/java/com/qulice/pmd/rules/TooManyFieldsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyFieldsRule.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * {@code @SuppressWarnings("PMD.TooManyFields")} visible to
  * {@code UnnecessaryWarningSuppression}, which PMD credits to the
  * annotation whenever the annotation suppressor runs first.
+ *
  * @since 1.0
  */
 public final class TooManyFieldsRule extends AbstractJavaRulechainRule {

--- a/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/TooManyMethodsRule.java
@@ -35,6 +35,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  * {@code @SuppressWarnings("PMD.TooManyMethods")} visible to
  * {@code UnnecessaryWarningSuppression}, which PMD credits to the
  * annotation whenever the annotation suppressor runs first.
+ *
  * @since 1.0
  */
 public final class TooManyMethodsRule extends AbstractJavaRulechainRule {

--- a/src/main/java/com/qulice/pmd/rules/UnitTestContainsTooManyAssertsRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UnitTestContainsTooManyAssertsRule.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
  * idiom wraps {@code assertThrows(...).getMessage()} inside an
  * {@code assertThat} to verify the thrown exception's message in a
  * single logical check.
+ *
  * @since 0.26.0
  */
 public final class UnitTestContainsTooManyAssertsRule

--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 
 /**
  * Rule to check unnecessary local variables.
+ *
  * @since 0.4
  */
 public final class UnnecessaryLocalRule extends AbstractJavaRulechainRule {

--- a/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
+++ b/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalSkips.java
@@ -23,6 +23,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
  * Heuristics that veto an {@link UnnecessaryLocalRule} report when the local
  * is semantically required (closure capture, clock snapshot, or capture
  * before a destructive call). See issue #1607.
+ *
  * @since 0.27.7
  */
 final class UnnecessaryLocalSkips {
@@ -54,6 +55,7 @@ final class UnnecessaryLocalSkips {
      * The single use of the local is reachable only by crossing a lambda or
      * anonymous-class boundary, so the local exists to carry the value into
      * a different exception scope.
+     *
      * @param block The block enclosing the declaration
      * @param name The variable name
      * @param crossings Number of usages found when crossing find boundaries
@@ -74,6 +76,7 @@ final class UnnecessaryLocalSkips {
      * The initialiser snapshots mutable global state - a clock, a randomness
      * source, or {@code new Date()} - so inlining would change <em>when</em>
      * the value is taken.
+     *
      * @param init The initialiser expression
      * @return True if the initialiser captures fresh state
      */
@@ -100,6 +103,7 @@ final class UnnecessaryLocalSkips {
      * qualifier (e.g. {@code System.setOut(...)}) counts, since such a call may
      * reassign the field before it is read; an unrelated statement leaves the
      * read inlinable. See issues #1607, #1699, #1700 and #1710.
+     *
      * @param variable The variable declarator
      * @param use The single use of the variable
      * @return True if a statement intervenes between init and its use

--- a/src/main/java/com/qulice/pmd/rules/UseCollectionsSingletonListRule.java
+++ b/src/main/java/com/qulice/pmd/rules/UseCollectionsSingletonListRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
  * either spreads the array's elements (for reference arrays) or wraps the
  * array itself in a one-element list (for primitive arrays), and either
  * behaviour may be intentional.
+ *
  * @since 0.26.0
  */
 public final class UseCollectionsSingletonListRule

--- a/src/main/java/com/qulice/pmd/rules/package-info.java
+++ b/src/main/java/com/qulice/pmd/rules/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * PMD custom rules.
+ *
  * @since 0.4
  */
 package com.qulice.pmd.rules;

--- a/src/main/java/com/qulice/spi/Binary.java
+++ b/src/main/java/com/qulice/spi/Binary.java
@@ -41,6 +41,7 @@ public final class Binary {
 
     /**
      * Ctor.
+     *
      * @param src File to inspect
      */
     public Binary(final File src) {
@@ -49,6 +50,7 @@ public final class Binary {
 
     /**
      * Is the file binary?
+     *
      * @return TRUE if the first {@value #SNIFF} bytes contain a NULL byte
      */
     public boolean yes() {

--- a/src/main/java/com/qulice/spi/Environment.java
+++ b/src/main/java/com/qulice/spi/Environment.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.filefilter.WildcardFileFilter;
 
 /**
  * Environment.
+ *
  * @since 0.3
  */
 @SuppressWarnings("PMD.TooManyMethods")
@@ -31,18 +32,21 @@ public interface Environment {
 
     /**
      * Get project's basedir.
+     *
      * @return The directory
      */
     File basedir();
 
     /**
      * Get directory to keep temporary files in.
+     *
      * @return The directory
      */
     File tempdir();
 
     /**
      * Get directory where {@code .class} files are stored.
+     *
      * @return The directory
      */
     File outdir();
@@ -63,6 +67,7 @@ public interface Environment {
 
     /**
      * Get parameter by name, and return default if it's not set.
+     *
      * @param name The name of parameter
      * @param value Default value to return as default
      * @return The value
@@ -71,12 +76,14 @@ public interface Environment {
 
     /**
      * Get classloader for this project.
+     *
      * @return The classloader
      */
     ClassLoader classloader();
 
     /**
      * Get list of paths in classpath.
+     *
      * @return The collection of paths
      */
     Collection<String> classpath();
@@ -95,6 +102,7 @@ public interface Environment {
 
     /**
      * Shall this item be excluded from report?
+     *
      * @param check Name of the check that is asking
      * @param name File or any other item, which is subject of validation
      * @return TRUE if it should be ignored
@@ -106,6 +114,7 @@ public interface Environment {
      * Each list element will contain exactly one exclude pattern which,
      * depending on the plugin that uses the excludes might be either wildcard
      * (CodeNarc) pattern or regex pattern (FindBugs).
+     *
      * @param checker Name of the checker that is asking (pmd, codenarc ...)
      * @return Exclude patterns
      */
@@ -113,12 +122,14 @@ public interface Environment {
 
     /**
      * Encoding for the files.
+     *
      * @return Source files charset
      */
     Charset encoding();
 
     /**
      * Mock of {@link Environment}.
+     *
      * @since 0.1
      */
     final class Mock implements Environment {
@@ -157,6 +168,7 @@ public interface Environment {
 
         /**
          * Constructor with a ready basedir.
+         *
          * @param base The basedir
          */
         private Mock(final File base) {
@@ -165,6 +177,7 @@ public interface Environment {
 
         /**
          * Primary constructor.
+         *
          * @param base The basedir
          * @param dirs Directories to put on the classpath
          */
@@ -178,6 +191,7 @@ public interface Environment {
         /**
          * With this extra test source root, the way
          * {@code build-helper-maven-plugin} would add one.
+         *
          * @param path Directory name, related to basedir
          * @return This object
          */
@@ -188,6 +202,7 @@ public interface Environment {
 
         /**
          * With this param and its value.
+         *
          * @param name Param name
          * @param value Param value
          * @return This object
@@ -200,6 +215,7 @@ public interface Environment {
 
         /**
          * With this file on board.
+         *
          * @param name File name related to basedir
          * @param content File content to write
          * @return This object
@@ -217,6 +233,7 @@ public interface Environment {
 
         /**
          * With this file on board.
+         *
          * @param name File name related to basedir
          * @param bytes File content to write
          * @return This object
@@ -230,6 +247,7 @@ public interface Environment {
 
         /**
          * With exclude patterns.
+         *
          * @param excludes Exclude patterns
          * @return This object
          */
@@ -240,6 +258,7 @@ public interface Environment {
 
         /**
          * With default classpath.
+         *
          * @return This object
          */
         public Environment.Mock withDefaultClasspath() {

--- a/src/main/java/com/qulice/spi/Ignored.java
+++ b/src/main/java/com/qulice/spi/Ignored.java
@@ -56,6 +56,7 @@ public final class Ignored {
 
     /**
      * Ctor.
+     *
      * @param file Path of the file, the way {@link Relative} makes it
      */
     public Ignored(final String file) {
@@ -64,6 +65,7 @@ public final class Ignored {
 
     /**
      * Is this file ignored?
+     *
      * @return TRUE if the file is inside one of the ignored directories
      */
     public boolean yes() {

--- a/src/main/java/com/qulice/spi/Relative.java
+++ b/src/main/java/com/qulice/spi/Relative.java
@@ -35,6 +35,7 @@ public final class Relative {
 
     /**
      * Ctor.
+     *
      * @param base Base directory
      * @param target Target file
      */
@@ -45,6 +46,7 @@ public final class Relative {
 
     /**
      * Path of the target file relative to the base directory.
+     *
      * @return Relative path starting with a forward slash, or the
      *  absolute path of the file if it is not under the base directory
      */

--- a/src/main/java/com/qulice/spi/ResourceValidator.java
+++ b/src/main/java/com/qulice/spi/ResourceValidator.java
@@ -9,12 +9,14 @@ import java.util.Collection;
 
 /**
  * Validator.
+ *
  * @since 0.17
  */
 public interface ResourceValidator {
 
     /**
      * Validate and throws exception if there are any problems.
+     *
      * @param files Files to validate
      * @return Validation results
      */
@@ -22,12 +24,14 @@ public interface ResourceValidator {
 
     /**
      * Name of this validator.
+     *
      * @return Name of this validator
      */
     String name();
 
     /**
      * How many rules this validator applies to every file it reads.
+     *
      * @return Number of rules, or zero when the validator cannot tell
      */
     int rules();

--- a/src/main/java/com/qulice/spi/ValidationException.java
+++ b/src/main/java/com/qulice/spi/ValidationException.java
@@ -6,6 +6,7 @@ package com.qulice.spi;
 
 /**
  * Exception thrown by a validator, if it fails.
+ *
  * @since 0.3
  */
 public final class ValidationException extends Exception {
@@ -17,6 +18,7 @@ public final class ValidationException extends Exception {
 
     /**
      * Public ctor.
+     *
      * @param cause The cause of exception
      */
     public ValidationException(final Throwable cause) {
@@ -25,6 +27,7 @@ public final class ValidationException extends Exception {
 
     /**
      * Public ctor.
+     *
      * @param text The text of the exception
      */
     public ValidationException(final String text) {
@@ -33,6 +36,7 @@ public final class ValidationException extends Exception {
 
     /**
      * Primary ctor.
+     *
      * @param text The text of the exception
      * @param cause The cause of exception
      */

--- a/src/main/java/com/qulice/spi/Validator.java
+++ b/src/main/java/com/qulice/spi/Validator.java
@@ -6,12 +6,14 @@ package com.qulice.spi;
 
 /**
  * Validator.
+ *
  * @since 0.3
  */
 public interface Validator {
 
     /**
      * Validate and throws exception if there are any problems.
+     *
      * @param env The environment to work with
      * @throws ValidationException In case of any violations found
      */
@@ -19,6 +21,7 @@ public interface Validator {
 
     /**
      * Name of this validator.
+     *
      * @return Name of this validator
      */
     String name();

--- a/src/main/java/com/qulice/spi/Violation.java
+++ b/src/main/java/com/qulice/spi/Violation.java
@@ -10,42 +10,49 @@ import lombok.ToString;
 
 /**
  * Validation result.
+ *
  * @since 0.17
  */
 public interface Violation extends Comparable<Violation> {
 
     /**
      * Name of the validator that generated this violation information.
+     *
      * @return Name of the validator
      */
     String validator();
 
     /**
      * Name of the failed check.
+     *
      * @return Name of the failed check
      */
     String name();
 
     /**
      * Validated file.
+     *
      * @return Validated file
      */
     String file();
 
     /**
      * Lines with the problem.
+     *
      * @return Lines with the problem
      */
     String lines();
 
     /**
      * Validation message.
+     *
      * @return Validation message
      */
     String message();
 
     /**
      * Default validation result.
+     *
      * @since 0.1
      */
     @EqualsAndHashCode
@@ -91,6 +98,7 @@ public interface Violation extends Comparable<Violation> {
 
         /**
          * Constructor.
+         *
          * @param vldtr Name of the validator
          * @param name Name of the failed check
          * @param file Validated file

--- a/src/main/java/com/qulice/spi/package-info.java
+++ b/src/main/java/com/qulice/spi/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Service provider interface.
+ *
  * @since 0.3
  */
 package com.qulice.spi;

--- a/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -699,10 +699,10 @@
       <property name="severity" value="ignore"/>
     </module>
     <!--
-    Demands an empty Javadoc line before the at-clauses in every case, while
-    our 'JavadocEmptyLineBeforeTagCheck' asks for one only when the body
-    spans more than a single paragraph, and forbids it otherwise. Inserting
-    the line to satisfy this module makes that one report 621 violations.
+    Demands an empty Javadoc line before the at-clauses, which is exactly
+    what our 'JavadocEmptyLineBeforeTagCheck' above already demands, so
+    enabling it would report every such mistake twice.
+    See https://github.com/yegor256/qulice/issues/1810
     -->
     <module name="RequireEmptyLineBeforeBlockTagGroup">
       <property name="severity" value="ignore"/>

--- a/src/test/java/com/qulice/checkstyle/AuditCollector.java
+++ b/src/test/java/com/qulice/checkstyle/AuditCollector.java
@@ -32,6 +32,7 @@ final class AuditCollector {
 
     /**
      * How many messages do we have?
+     *
      * @return Amount of messages reported
      */
     int eventCount() {
@@ -40,6 +41,7 @@ final class AuditCollector {
 
     /**
      * Do we have this message for this line?
+     *
      * @param line The number of the line
      * @param msg The message we're looking for
      * @return This message was reported for the give line?
@@ -57,6 +59,7 @@ final class AuditCollector {
 
     /**
      * Returns full summary.
+     *
      * @return The test summary of all events
      */
     String summary() {

--- a/src/test/java/com/qulice/checkstyle/CascadeIndentationCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/CascadeIndentationCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link CascadeIndentationCheck}.
+ *
  * @since 0.25.1
  */
 final class CascadeIndentationCheckTest {

--- a/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -27,12 +27,14 @@ import org.xml.sax.InputSource;
 
 /**
  * Integration test case for all checkstyle checks.
+ *
  * @since 0.3
  */
 final class ChecksTest {
 
     /**
      * Test checkstyle for true positive.
+     *
      * @param dir Directory where test scripts are located
      * @param name The name of the Invalid*.java file
      * @throws Exception If something goes wrong
@@ -83,6 +85,7 @@ final class ChecksTest {
 
     /**
      * Test checkstyle for true negative.
+     *
      * @param dir Directory where test scripts are located
      * @param name The name of the Valid*.java file
      * @throws Exception If something goes wrong

--- a/src/test/java/com/qulice/checkstyle/CheckstyleAbbreviationAsWordInNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleAbbreviationAsWordInNameTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code AbbreviationAsWordInName} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleAbbreviationAsWordInNameTest {
@@ -44,11 +45,11 @@ final class CheckstyleAbbreviationAsWordInNameTest {
                     String.format(
                         message, "InvalidAbbreviationAsWordInNameXML"
                     ),
-                    file, "10", name
+                    file, "11", name
                 ),
                 new ViolationMatcher(
                     String.format(message, "InvalidHTML"), file,
-                    "14", name
+                    "15", name
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleAtClauseOrderTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleAtClauseOrderTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code AtclauseOrder} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleAtClauseOrderTest {
@@ -36,14 +37,14 @@ final class CheckstyleAtClauseOrderTest {
                 new ViolationMatcher(
                     "Javadoc comment at column 3 has parse error.",
                     file,
-                    "12",
+                    "13",
                     name
                 ),
                 new ViolationMatcher(
-                    message, file, "21", name
+                    message, file, "23", name
                 ),
                 new ViolationMatcher(
-                    message, file, "46", name
+                    message, file, "50", name
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleBannedApiTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleBannedApiTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
  * API usages such as Guava {@code Lists.newArrayList()} with no
  * size, Apache Commons {@code CharEncoding}, and interface type
  * parameter naming.
+ *
  * @since 0.25.1
  */
 final class CheckstyleBannedApiTest {
@@ -59,14 +60,14 @@ final class CheckstyleBannedApiTest {
                     new ViolationMatcher(message, file, "7", name),
                     new ViolationMatcher(message, file, "8", name),
                     new ViolationMatcher(message, file, "9", name),
-                    new ViolationMatcher(message, file, "30", name),
                     new ViolationMatcher(message, file, "31", name),
                     new ViolationMatcher(message, file, "32", name),
+                    new ViolationMatcher(message, file, "33", name),
                     new ViolationMatcher(
                         "is redundant, import it and use",
-                        file, "33", "FullyQualifiedTypeCheck"
+                        file, "34", "FullyQualifiedTypeCheck"
                     ),
-                    new ViolationMatcher(message, file, "33", name)
+                    new ViolationMatcher(message, file, "34", name)
                 )
             )
         );
@@ -81,7 +82,7 @@ final class CheckstyleBannedApiTest {
             Matchers.hasItem(
                 new ViolationMatcher(
                     "Name 'wRoNg' must match pattern", file,
-                    "11", "InterfaceTypeParameterNameCheck"
+                    "12", "InterfaceTypeParameterNameCheck"
                 )
             )
         );
@@ -98,10 +99,10 @@ final class CheckstyleBannedApiTest {
             "cannot find all java.lang. violations",
             this.runValidation(file, false),
             Matchers.hasItems(
-                new ViolationMatcher(message, file, "10", name),
-                new ViolationMatcher(message, file, "18", name),
-                new ViolationMatcher(message, file, "23", name),
-                new ViolationMatcher(message, file, "25", name)
+                new ViolationMatcher(message, file, "11", name),
+                new ViolationMatcher(message, file, "19", name),
+                new ViolationMatcher(message, file, "25", name),
+                new ViolationMatcher(message, file, "27", name)
             )
         );
     }
@@ -118,8 +119,8 @@ final class CheckstyleBannedApiTest {
             this.runValidation(file, false),
             Matchers.not(
                 Matchers.anyOf(
-                    Matchers.hasItem(new ViolationMatcher(message, file, "43", name)),
-                    Matchers.hasItem(new ViolationMatcher(message, file, "52", name))
+                    Matchers.hasItem(new ViolationMatcher(message, file, "47", name)),
+                    Matchers.hasItem(new ViolationMatcher(message, file, "57", name))
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleCatchParameterNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleCatchParameterNameTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code CatchParameterName} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleCatchParameterNameTest {
@@ -36,16 +37,16 @@ final class CheckstyleCatchParameterNameTest {
                 Matchers.iterableWithSize(4),
                 Matchers.hasItems(
                     new ViolationMatcher(
-                        "Name 'ex_invalid_1' must match pattern", file, "33", name
+                        "Name 'ex_invalid_1' must match pattern", file, "34", name
                     ),
                     new ViolationMatcher(
-                        "Name '$xxx' must match pattern", file, "35", name
+                        "Name '$xxx' must match pattern", file, "36", name
                     ),
                     new ViolationMatcher(
-                        "Name '_exp' must match pattern", file, "37", name
+                        "Name '_exp' must match pattern", file, "38", name
                     ),
                     new ViolationMatcher(
-                        "Name '$xxx' must match pattern", file, "35",
+                        "Name '$xxx' must match pattern", file, "36",
                         "IllegalIdentifierNameCheck"
                     )
                 )

--- a/src/test/java/com/qulice/checkstyle/CheckstyleFileLengthTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleFileLengthTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code FileLength} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleFileLengthTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleFluentCallFormattingTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleFluentCallFormattingTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link CheckstyleValidator}'s enforcement that a
  * fluent call opening a multi-line block must be attached to the
  * previous line, see https://github.com/yegor256/qulice/issues/670.
+ *
  * @since 0.25.1
  */
 final class CheckstyleFluentCallFormattingTest {
@@ -35,7 +36,7 @@ final class CheckstyleFluentCallFormattingTest {
             Matchers.hasItem(
                 new ViolationMatcher(
                     "A fluent call opening a multi-line block must be attached to the previous line",
-                    file, "20", "RegexpSinglelineCheck"
+                    file, "22", "RegexpSinglelineCheck"
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleHexLiteralCaseTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleHexLiteralCaseTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code HexLiteralCase} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleHexLiteralCaseTest {
@@ -34,7 +35,7 @@ final class CheckstyleHexLiteralCaseTest {
                 new ViolationMatcher(
                     "Should use uppercase hexadecimal letters",
                     file,
-                    "18",
+                    "20",
                     "HexLiteralCaseCheck"
                 )
             )

--- a/src/test/java/com/qulice/checkstyle/CheckstyleHiddenFieldTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleHiddenFieldTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code HiddenField} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleHiddenFieldTest {
@@ -34,13 +35,13 @@ final class CheckstyleHiddenFieldTest {
             Matchers.allOf(
                 Matchers.hasItem(
                     new ViolationMatcher(
-                        "'number' hides a field.", file, "29", name
+                        "'number' hides a field.", file, "32", name
                     )
                 ),
                 Matchers.not(
                     Matchers.hasItem(
                         new ViolationMatcher(
-                            "'number' hides a field.", file, "20", name
+                            "'number' hides a field.", file, "22", name
                         )
                     )
                 )
@@ -56,7 +57,7 @@ final class CheckstyleHiddenFieldTest {
             this.runValidation(file, false),
             Matchers.hasItems(
                 new ViolationMatcher(
-                    "'test' hides a field.", file, "18", "HiddenFieldCheck"
+                    "'test' hides a field.", file, "20", "HiddenFieldCheck"
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleJavadocLeadingAsteriskAlignTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleJavadocLeadingAsteriskAlignTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code JavadocLeadingAsteriskAlign} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleJavadocLeadingAsteriskAlignTest {
@@ -34,7 +35,7 @@ final class CheckstyleJavadocLeadingAsteriskAlignTest {
                 new ViolationMatcher(
                     "Leading asterisk has incorrect indentation level 5, expected is 6",
                     file,
-                    "13",
+                    "14",
                     "JavadocLeadingAsteriskAlignCheck"
                 )
             )

--- a/src/test/java/com/qulice/checkstyle/CheckstyleJavadocPackageTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleJavadocPackageTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
  * {@code src/main/java} package already declares
  * {@code package-info.java}. See <a href=
  * "https://github.com/yegor256/qulice/issues/865">#865</a>.
+ *
  * @since 0.25.1
  */
 final class CheckstyleJavadocPackageTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleJavadocTypeTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleJavadocTypeTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code JavadocType} check, including its suppression for
  * test classes.
+ *
  * @since 0.25.1
  */
 final class CheckstyleJavadocTypeTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleLambdaBodyLengthTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleLambdaBodyLengthTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code LambdaBodyLength} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleLambdaBodyLengthTest {
@@ -33,7 +34,7 @@ final class CheckstyleLambdaBodyLengthTest {
             Matchers.hasItem(
                 new ViolationMatcher(
                     "Lambda body length is 25 lines (max allowed is 20).",
-                    file, "19", "LambdaBodyLengthCheck"
+                    file, "21", "LambdaBodyLengthCheck"
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleLineLengthTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleLineLengthTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code LineLength} check and its @checkstyle suppressions.
+ *
  * @since 0.25.1
  */
 final class CheckstyleLineLengthTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleLocalVariableNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleLocalVariableNameTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code LocalVariableName} and {@code CatchParameterName} checks.
+ *
  * @since 0.25.1
  */
 final class CheckstyleLocalVariableNameTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleMethodNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleMethodNameTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code MethodName} check.
+ *
  * @since 0.28.0
  */
 final class CheckstyleMethodNameTest {
@@ -43,7 +44,7 @@ final class CheckstyleMethodNameTest {
             CheckstyleMethodNameTest.violations(file),
             Matchers.hasItem(
                 new ViolationMatcher(
-                    "Name 'zz' must match pattern", file, "29", "MethodNameCheck"
+                    "Name 'zz' must match pattern", file, "32", "MethodNameCheck"
                 )
             )
         );
@@ -79,7 +80,7 @@ final class CheckstyleMethodNameTest {
                 new ViolationMatcher(
                     "Name 'GetLastError' must match pattern",
                     file,
-                    "16",
+                    "18",
                     "MethodNameCheck"
                 )
             )

--- a/src/test/java/com/qulice/checkstyle/CheckstyleNoWhitespaceBeforeTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleNoWhitespaceBeforeTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code NoWhitespaceBefore} check.
+ *
  * @since 0.25.1
  */
 final class CheckstyleNoWhitespaceBeforeTest {
@@ -33,7 +34,7 @@ final class CheckstyleNoWhitespaceBeforeTest {
             Matchers.hasItem(
                 new ViolationMatcher(
                     "',' is preceded with whitespace",
-                    file, "21", "NoWhitespaceBeforeCheck"
+                    file, "23", "NoWhitespaceBeforeCheck"
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleOperatorWrapTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleOperatorWrapTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code OperatorWrap} check in {@code nl} mode, see
  * https://github.com/yegor256/qulice/issues/790.
+ *
  * @since 0.25.1
  */
 final class CheckstyleOperatorWrapTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstylePackageDeclarationTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstylePackageDeclarationTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code PackageDeclaration}/line-wrap check.
+ *
  * @since 0.25.1
  */
 final class CheckstylePackageDeclarationTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleParameterNumberTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * {@code ParameterNumber} check.
+ *
  * @since 1.0
  */
 final class CheckstyleParameterNumberTest {
@@ -54,7 +55,7 @@ final class CheckstyleParameterNumberTest {
                 new ViolationMatcher(
                     "More than 3 parameters (found 4)",
                     file,
-                    "20",
+                    "22",
                     "ParameterNumberCheck"
                 )
             )
@@ -84,6 +85,7 @@ final class CheckstyleParameterNumberTest {
      * A JNA binding is recognized by the fully qualified name of the
      * interface it implements too, even though FullyQualifiedTypeCheck
      * asks for that name to be imported and reports the file for it.
+     *
      * @throws Exception If something goes wrong
      */
     @Test

--- a/src/test/java/com/qulice/checkstyle/CheckstyleReturnCountTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleReturnCountTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code ReturnCount} check, including a regression guard
  * against cross-test violation leakage (issue #547).
+ *
  * @since 0.25.1
  */
 final class CheckstyleReturnCountTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleSingleSpaceSeparatorTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleSingleSpaceSeparatorTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * {@code SingleSpaceSeparatorCheck}.
+ *
  * @since 0.24.2
  */
 final class CheckstyleSingleSpaceSeparatorTest {
@@ -50,7 +51,7 @@ final class CheckstyleSingleSpaceSeparatorTest {
             Matchers.hasItem(
                 new ViolationMatcher(
                     "Use a single space to separate non-whitespace characters.",
-                    file, "17", "SingleSpaceSeparatorCheck"
+                    file, "18", "SingleSpaceSeparatorCheck"
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/CheckstyleTextFileTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleTextFileTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator} covering checks that apply to
  * non-Java text files and whitespace before closing braces.
+ *
  * @since 0.25.0
  */
 final class CheckstyleTextFileTest {
@@ -25,6 +26,7 @@ final class CheckstyleTextFileTest {
     /**
      * CheckstyleValidator reports a tab character in a non-Java text file
      * such as JavaScript. See https://github.com/yegor256/qulice/issues/521.
+     *
      * @throws Exception when error.
      */
     @Test
@@ -47,6 +49,7 @@ final class CheckstyleTextFileTest {
     /**
      * CheckstyleValidator reports missing final newline in a non-Java text
      * file such as Markdown. See https://github.com/yegor256/qulice/issues/521.
+     *
      * @throws Exception when error.
      */
     @Test
@@ -70,6 +73,7 @@ final class CheckstyleTextFileTest {
     /**
      * CheckstyleValidator rejects empty lines before closing braces.
      * See https://github.com/yegor256/qulice/issues/710.
+     *
      * @throws Exception when error.
      */
     @Test
@@ -106,6 +110,7 @@ final class CheckstyleTextFileTest {
      * CheckstyleValidator does not report a false positive when a closing
      * brace immediately follows a non-empty line.
      * See https://github.com/yegor256/qulice/issues/710.
+     *
      * @throws Exception when error.
      */
     @Test

--- a/src/test/java/com/qulice/checkstyle/CheckstyleTypeNameTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleTypeNameTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code TypeName} check.
+ *
  * @since 0.73.2
  */
 final class CheckstyleTypeNameTest {
@@ -34,7 +35,7 @@ final class CheckstyleTypeNameTest {
                 new ViolationMatcher(
                     "must match pattern",
                     file,
-                    "10",
+                    "11",
                     "TypeNameCheck"
                 )
             )

--- a/src/test/java/com/qulice/checkstyle/CheckstyleTypeParamDescriptionTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleTypeParamDescriptionTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link CheckstyleValidator}'s enforcement that
  * Javadoc {@code @param} type descriptions start with a capital
  * letter, see https://github.com/yegor256/qulice/issues/705.
+ *
  * @since 0.25.1
  */
 final class CheckstyleTypeParamDescriptionTest {
@@ -37,8 +38,8 @@ final class CheckstyleTypeParamDescriptionTest {
             "Both class and method type parameter descriptions must be reported",
             this.runValidation(file, false),
             Matchers.hasItems(
-                new ViolationMatcher(message, file, "8", name),
-                new ViolationMatcher(message, file, "15", name)
+                new ViolationMatcher(message, file, "9", name),
+                new ViolationMatcher(message, file, "17", name)
             )
         );
     }

--- a/src/test/java/com/qulice/checkstyle/CheckstyleUseEnhancedSwitchTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleUseEnhancedSwitchTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
  * stock {@code UseEnhancedSwitch} check. The check suggests arrow-switch
  * syntax, a Java 14+ feature, so it must be disabled when the project targets
  * an older Java (issue #1694).
+ *
  * @since 1.0
  */
 final class CheckstyleUseEnhancedSwitchTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
  * regression guard. Per-check coverage lives in the dedicated
  * {@code *CheckTest.java} and {@code Checkstyle*Test.java} files
  * in this package.
+ *
  * @since 0.3
  */
 final class CheckstyleValidatorTest {

--- a/src/test/java/com/qulice/checkstyle/CheckstyleVisibilityModifierTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleVisibilityModifierTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code VisibilityModifier} check.
+ *
  * @since 0.28.0
  */
 final class CheckstyleVisibilityModifierTest {
@@ -44,13 +45,13 @@ final class CheckstyleVisibilityModifierTest {
                     new ViolationMatcher(
                         "Variable 'dir' must be private and have accessor methods.",
                         CheckstyleVisibilityModifierTest.FILE,
-                        "18",
+                        "19",
                         CheckstyleVisibilityModifierTest.NAME
                     ),
                     new ViolationMatcher(
                         "Variable 'charset' must be private and have accessor methods.",
                         CheckstyleVisibilityModifierTest.FILE,
-                        "24",
+                        "25",
                         CheckstyleVisibilityModifierTest.NAME
                     )
                 )
@@ -67,7 +68,7 @@ final class CheckstyleVisibilityModifierTest {
                 new ViolationMatcher(
                     "Variable 'extra' must be private and have accessor methods.",
                     CheckstyleVisibilityModifierTest.FILE,
-                    "29",
+                    "30",
                     CheckstyleVisibilityModifierTest.NAME
                 )
             )

--- a/src/test/java/com/qulice/checkstyle/CheckstyleWhitespaceAroundTest.java
+++ b/src/test/java/com/qulice/checkstyle/CheckstyleWhitespaceAroundTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link CheckstyleValidator}'s handling of the
  * stock {@code WhitespaceAround} check for the enhanced-for colon,
  * see https://github.com/yegor256/qulice/issues/721.
+ *
  * @since 0.25.1
  */
 final class CheckstyleWhitespaceAroundTest {

--- a/src/test/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link ConditionalRegexpMultilineCheck}.
+ *
  * @since 0.25.1
  */
 final class ConditionalRegexpMultilineCheckTest {

--- a/src/test/java/com/qulice/checkstyle/ConstantUsageCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/ConstantUsageCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link ConstantUsageCheck}.
+ *
  * @since 0.25.1
  */
 final class ConstantUsageCheckTest {

--- a/src/test/java/com/qulice/checkstyle/DiamondOperatorCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/DiamondOperatorCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link DiamondOperatorCheck}.
+ *
  * @since 0.25.1
  */
 final class DiamondOperatorCheckTest {
@@ -34,8 +35,8 @@ final class DiamondOperatorCheckTest {
             "Two diamond violations should be found",
             this.runValidation(file, false),
             Matchers.hasItems(
-                new ViolationMatcher(message, file, "18", name),
-                new ViolationMatcher(message, file, "28", name)
+                new ViolationMatcher(message, file, "19", name),
+                new ViolationMatcher(message, file, "29", name)
             )
         );
     }

--- a/src/test/java/com/qulice/checkstyle/EmptyLinesCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/EmptyLinesCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link EmptyLinesCheck}.
+ *
  * @since 0.25.1
  */
 final class EmptyLinesCheckTest {
@@ -42,18 +43,18 @@ final class EmptyLinesCheckTest {
             "All empty lines should be found",
             this.runValidation(file, false),
             Matchers.hasItems(
-                new ViolationMatcher(message, file, "15", name),
-                new ViolationMatcher(message, file, "19", name),
-                new ViolationMatcher(message, file, "21", name),
-                new ViolationMatcher(message, file, "25", name),
-                new ViolationMatcher(message, file, "28", name),
-                new ViolationMatcher(message, file, "32", name),
-                new ViolationMatcher(message, file, "34", name),
-                new ViolationMatcher(message, file, "38", name),
-                new ViolationMatcher(message, file, "41", name),
-                new ViolationMatcher(message, file, "48", name),
-                new ViolationMatcher(message, file, "50", name),
-                new ViolationMatcher(message, file, "52", name)
+                new ViolationMatcher(message, file, "16", name),
+                new ViolationMatcher(message, file, "20", name),
+                new ViolationMatcher(message, file, "22", name),
+                new ViolationMatcher(message, file, "26", name),
+                new ViolationMatcher(message, file, "29", name),
+                new ViolationMatcher(message, file, "33", name),
+                new ViolationMatcher(message, file, "35", name),
+                new ViolationMatcher(message, file, "39", name),
+                new ViolationMatcher(message, file, "42", name),
+                new ViolationMatcher(message, file, "49", name),
+                new ViolationMatcher(message, file, "51", name),
+                new ViolationMatcher(message, file, "53", name)
             )
         );
     }

--- a/src/test/java/com/qulice/checkstyle/EnumValueNameCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/EnumValueNameCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link EnumValueNameCheck}.
+ *
  * @since 0.25.1
  */
 final class EnumValueNameCheckTest {
@@ -42,15 +43,15 @@ final class EnumValueNameCheckTest {
             Matchers.hasItems(
                 new ViolationMatcher(
                     "Enum value anyName must match pattern",
-                    file, "16", name
+                    file, "17", name
                 ),
                 new ViolationMatcher(
                     "Enum value MixedCase must match pattern",
-                    file, "21", name
+                    file, "22", name
                 ),
                 new ViolationMatcher(
                     "Enum value lowercase must match pattern",
-                    file, "26", name
+                    file, "27", name
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/ExcludingEnvironment.java
+++ b/src/test/java/com/qulice/checkstyle/ExcludingEnvironment.java
@@ -29,6 +29,7 @@ final class ExcludingEnvironment implements Environment {
 
     /**
      * Ctor.
+     *
      * @param env Environment to delegate to
      */
     ExcludingEnvironment(final Environment env) {

--- a/src/test/java/com/qulice/checkstyle/ExtraSemicolonCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/ExtraSemicolonCheckTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link ExtraSemicolonCheck}.
+ *
  * @since 0.25.1
  */
 final class ExtraSemicolonCheckTest {
@@ -33,9 +34,9 @@ final class ExtraSemicolonCheckTest {
             "Stray semicolons after constructor, method and class must be reported",
             this.runValidation(file, false),
             Matchers.hasItems(
-                new ViolationMatcher(message, file, "20", name),
-                new ViolationMatcher(message, file, "28", name),
-                new ViolationMatcher(message, file, "29", name)
+                new ViolationMatcher(message, file, "21", name),
+                new ViolationMatcher(message, file, "30", name),
+                new ViolationMatcher(message, file, "31", name)
             )
         );
     }

--- a/src/test/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link FinalSemicolonInTryWithResourcesCheck}.
+ *
  * @since 0.25.1
  */
 final class FinalSemicolonInTryWithResourcesCheckTest {

--- a/src/test/java/com/qulice/checkstyle/IfThenThrowElseCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/IfThenThrowElseCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link IfThenThrowElseCheck}.
+ *
  * @since 0.24
  */
 final class IfThenThrowElseCheckTest {
@@ -34,9 +35,9 @@ final class IfThenThrowElseCheckTest {
             "All three if-throw-else patterns should be flagged",
             this.runValidation(file, false),
             Matchers.hasItems(
-                new ViolationMatcher(message, file, "30", name),
-                new ViolationMatcher(message, file, "42", name),
-                new ViolationMatcher(message, file, "54", name)
+                new ViolationMatcher(message, file, "33", name),
+                new ViolationMatcher(message, file, "46", name),
+                new ViolationMatcher(message, file, "59", name)
             )
         );
     }

--- a/src/test/java/com/qulice/checkstyle/License.java
+++ b/src/test/java/com/qulice/checkstyle/License.java
@@ -13,6 +13,7 @@ import org.cactoos.text.Joined;
 
 /**
  * Builder of {@code LICENSE.txt} content.
+ *
  * @since 0.4
  */
 public final class License {
@@ -46,6 +47,7 @@ public final class License {
 
     /**
      * Use this EOL.
+     *
      * @param txt What to use as end-of-line character
      * @return This object
      */
@@ -56,6 +58,7 @@ public final class License {
 
     /**
      * Use this text (lines).
+     *
      * @param lns The lines to use
      * @return This object
      */
@@ -67,6 +70,7 @@ public final class License {
 
     /**
      * Use this package name.
+     *
      * @param name The name of package
      * @return This object
      */
@@ -77,6 +81,7 @@ public final class License {
 
     /**
      * Save package-info.java into this folder.
+     *
      * @param dir The folder to save to
      * @return This object
      */
@@ -87,6 +92,7 @@ public final class License {
 
     /**
      * Make a file.
+     *
      * @return The location of LICENSE.txt
      * @throws IOException If something wrong happens inside
      */

--- a/src/test/java/com/qulice/checkstyle/MultilineJavadocTagsCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/MultilineJavadocTagsCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link MultilineJavadocTagsCheck}.
+ *
  * @since 0.25.1
  */
 final class MultilineJavadocTagsCheckTest {

--- a/src/test/java/com/qulice/checkstyle/NonStaticMethodCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/NonStaticMethodCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link NonStaticMethodCheck}.
+ *
  * @since 0.25.1
  */
 final class NonStaticMethodCheckTest {

--- a/src/test/java/com/qulice/checkstyle/RequiredJavaDocTagTest.java
+++ b/src/test/java/com/qulice/checkstyle/RequiredJavaDocTagTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test case for {@link RequiredJavaDocTag} class.
+ *
  * @since 0.23.1
  */
 final class RequiredJavaDocTagTest {

--- a/src/test/java/com/qulice/checkstyle/SingleLineCommentCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/SingleLineCommentCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link SingleLineCommentCheck}.
+ *
  * @since 0.25.1
  */
 final class SingleLineCommentCheckTest {

--- a/src/test/java/com/qulice/checkstyle/UnknownSuppressionCheckTest.java
+++ b/src/test/java/com/qulice/checkstyle/UnknownSuppressionCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link UnknownSuppressionCheck}.
+ *
  * @since 1.0
  */
 final class UnknownSuppressionCheckTest {
@@ -35,7 +36,7 @@ final class UnknownSuppressionCheckTest {
             Matchers.hasItems(
                 new ViolationMatcher("FooBar", file, "4", name),
                 new ViolationMatcher(
-                    "ClassDataAbstractionCoupling", file, "11", name
+                    "ClassDataAbstractionCoupling", file, "12", name
                 )
             )
         );

--- a/src/test/java/com/qulice/checkstyle/UnusedSuppressionTest.java
+++ b/src/test/java/com/qulice/checkstyle/UnusedSuppressionTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link CheckstyleValidator}'s handling of
  * {@link UnusedSuppressions}.
+ *
  * @since 1.0
  */
 final class UnusedSuppressionTest {

--- a/src/test/java/com/qulice/checkstyle/ViolationMatcher.java
+++ b/src/test/java/com/qulice/checkstyle/ViolationMatcher.java
@@ -12,6 +12,7 @@ import org.hamcrest.TypeSafeMatcher;
  * Matcher for {@link Violation} produced by {@link CheckstyleValidator}
  * in unit tests. Matches by substring of the message, suffix of the file
  * path and, optionally, exact line number and check name.
+ *
  * @since 0.1
  */
 final class ViolationMatcher extends TypeSafeMatcher<Violation> {
@@ -38,6 +39,7 @@ final class ViolationMatcher extends TypeSafeMatcher<Violation> {
 
     /**
      * Constructor.
+     *
      * @param message Message to check
      * @param file File to check
      */
@@ -47,6 +49,7 @@ final class ViolationMatcher extends TypeSafeMatcher<Violation> {
 
     /**
      * Constructor.
+     *
      * @param message Message to check
      * @param file File to check
      * @param line Line to check

--- a/src/test/java/com/qulice/checkstyle/package-info.java
+++ b/src/test/java/com/qulice/checkstyle/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Tests of checkstyle checks.
+ *
  * @since 0.3
  */
 package com.qulice.checkstyle;

--- a/src/test/java/com/qulice/errorprone/ArgfileTest.java
+++ b/src/test/java/com/qulice/errorprone/ArgfileTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link Argfile}.
+ *
  * @since 1.0
  */
 final class ArgfileTest {

--- a/src/test/java/com/qulice/errorprone/BatchesTest.java
+++ b/src/test/java/com/qulice/errorprone/BatchesTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Batches}.
+ *
  * @since 1.0
  */
 final class BatchesTest {

--- a/src/test/java/com/qulice/errorprone/DiagnosticsTest.java
+++ b/src/test/java/com/qulice/errorprone/DiagnosticsTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Diagnostics}.
+ *
  * @since 1.0
  */
 final class DiagnosticsTest {

--- a/src/test/java/com/qulice/errorprone/ErrorPronePatternMatchingInstanceofTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorPronePatternMatchingInstanceofTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
  * stock {@code PatternMatchingInstanceof} check. The check suggests
  * pattern-matching {@code instanceof}, a Java 16+ feature, so it must not fire
  * when the project compiles at an older source level (issue #1716).
+ *
  * @since 1.0
  */
 final class ErrorPronePatternMatchingInstanceofTest {

--- a/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
+++ b/src/test/java/com/qulice/errorprone/ErrorProneValidatorTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link ErrorProneValidator}.
+ *
  * @since 1.0
  */
 final class ErrorProneValidatorTest {

--- a/src/test/java/com/qulice/errorprone/ReleaseTest.java
+++ b/src/test/java/com/qulice/errorprone/ReleaseTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Release}.
+ *
  * @since 1.0
  */
 final class ReleaseTest {

--- a/src/test/java/com/qulice/errorprone/UnencodedTest.java
+++ b/src/test/java/com/qulice/errorprone/UnencodedTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link Unencoded}.
+ *
  * @since 1.0
  */
 final class UnencodedTest {

--- a/src/test/java/com/qulice/errorprone/XpluginTest.java
+++ b/src/test/java/com/qulice/errorprone/XpluginTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Xplugin}.
+ *
  * @since 1.0
  */
 final class XpluginTest {

--- a/src/test/java/com/qulice/errorprone/package-info.java
+++ b/src/test/java/com/qulice/errorprone/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Test cases for ErrorProne validator.
+ *
  * @since 1.0
  */
 package com.qulice.errorprone;

--- a/src/test/java/com/qulice/maven/CheckMojoTest.java
+++ b/src/test/java/com/qulice/maven/CheckMojoTest.java
@@ -16,12 +16,14 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link CheckMojo} class.
+ *
  * @since 0.3
  */
 final class CheckMojoTest {
 
     /**
      * CheckMojo can skip execution if "skip" flag is set.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -93,6 +95,7 @@ final class CheckMojoTest {
 
     /**
      * CheckMojo can validate a project using all provided validators.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -123,6 +126,7 @@ final class CheckMojoTest {
 
     /**
      * CheckMojo can hand the ErrorProne flags of the project to validators.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test

--- a/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link DefaultMavenEnvironment} class.
+ *
  * @since 0.8
  */
 final class DefaultMavenEnvironmentTest {
@@ -89,6 +90,7 @@ final class DefaultMavenEnvironmentTest {
 
     /**
      * DefaultMavenEnvironment can work with whitespaces in classpath.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -113,6 +115,7 @@ final class DefaultMavenEnvironmentTest {
      * transitive test-scope dependencies such as {@code opentest4j}
      * (see <a href="https://github.com/yegor256/qulice/issues/1691">
      * issue #1691</a>).
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -163,6 +166,7 @@ final class DefaultMavenEnvironmentTest {
      * that validators never try to read them as text
      * (see <a href="https://github.com/yegor256/qulice/issues/1264">
      * issue #1264</a>).
+     *
      * @param basedir Temporary base directory
      * @throws Exception If something wrong happens inside
      */
@@ -210,6 +214,7 @@ final class DefaultMavenEnvironmentTest {
      * {@code <sourceDirectory>} declared in the POM
      * (see <a href="https://github.com/yegor256/qulice/issues/382">
      * issue #382</a>).
+     *
      * @param basedir Temporary base directory
      * @throws Exception If something wrong happens inside
      */
@@ -245,6 +250,7 @@ final class DefaultMavenEnvironmentTest {
      * {@code <testSourceDirectory>} declared in the POM
      * (see <a href="https://github.com/yegor256/qulice/issues/382">
      * issue #382</a>).
+     *
      * @param basedir Temporary base directory
      * @throws Exception If something wrong happens inside
      */
@@ -280,6 +286,7 @@ final class DefaultMavenEnvironmentTest {
      * {@code <resources>} blocks of the POM
      * (see <a href="https://github.com/yegor256/qulice/issues/382">
      * issue #382</a>).
+     *
      * @param basedir Temporary base directory
      * @throws Exception If something wrong happens inside
      */
@@ -326,6 +333,7 @@ final class DefaultMavenEnvironmentTest {
      * them, e.g. {@code src/mock/java}
      * (see <a href="https://github.com/yegor256/qulice/issues/1742">
      * issue #1742</a>).
+     *
      * @param basedir Temporary base directory
      */
     @Test
@@ -371,6 +379,7 @@ final class DefaultMavenEnvironmentTest {
      * outputs (e.g. target/generated-sources/...) and not user-authored code
      * (see <a href="https://github.com/yegor256/qulice/issues/1560">
      * issue #1560</a>).
+     *
      * @param basedir Temporary base directory
      * @throws Exception If something wrong happens inside
      */
@@ -433,6 +442,7 @@ final class DefaultMavenEnvironmentTest {
      * {@code jacoco:report}
      * (see <a href="https://github.com/yegor256/qulice/issues/1741">
      * issue #1741</a>).
+     *
      * @param basedir Temporary base directory
      */
     @Test

--- a/src/test/java/com/qulice/maven/DefaultValidatorsProviderTest.java
+++ b/src/test/java/com/qulice/maven/DefaultValidatorsProviderTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link ValidatorsProvider} class.
+ *
  * @since 0.3
  */
 final class DefaultValidatorsProviderTest {

--- a/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link DependenciesValidator} class.
+ *
  * @since 0.3
  */
 final class DependenciesValidatorTest {
@@ -50,6 +51,7 @@ final class DependenciesValidatorTest {
 
     /**
      * DependencyValidator can pass on when no violations are found.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -63,6 +65,7 @@ final class DependenciesValidatorTest {
 
     /**
      * DependencyValidator can catch dependency problems.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -89,6 +92,7 @@ final class DependenciesValidatorTest {
 
     /**
      * DependencyValidator can ignore runtime scope dependencies.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -114,6 +118,7 @@ final class DependenciesValidatorTest {
 
     /**
      * DependencyValidator can exclude used undeclared dependencies.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -146,6 +151,7 @@ final class DependenciesValidatorTest {
 
     /**
      * DependencyValidator can exclude unused declared dependencies.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -181,6 +187,7 @@ final class DependenciesValidatorTest {
      * dependency is actually referenced by an {@code import} in source, which
      * is the typical shape of false positives caused by annotations with
      * source retention or inlined compile-time constants (see issue #782).
+     *
      * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      */
@@ -215,6 +222,7 @@ final class DependenciesValidatorTest {
     /**
      * Static imports must also count as evidence that a dependency is used,
      * since inlined constants are referenced via {@code import static}.
+     *
      * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      */
@@ -246,6 +254,7 @@ final class DependenciesValidatorTest {
 
     /**
      * Wildcard imports must cover any class inside the imported package.
+     *
      * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      */
@@ -278,6 +287,7 @@ final class DependenciesValidatorTest {
     /**
      * Without any matching import, an "unused declared" compile-scope
      * dependency must still fail the build even when sources exist.
+     *
      * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      */

--- a/src/test/java/com/qulice/maven/EnforcerValidatorTest.java
+++ b/src/test/java/com/qulice/maven/EnforcerValidatorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link EnforcerValidator} class.
+ *
  * @since 0.70.0
  */
 final class EnforcerValidatorTest {
@@ -17,6 +18,7 @@ final class EnforcerValidatorTest {
     /**
      * EnforcerValidator can skip validation when the enforcer
      * check is excluded.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test
@@ -35,6 +37,7 @@ final class EnforcerValidatorTest {
     /**
      * EnforcerValidator attempts to execute the plugin when the check
      * is not excluded.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test

--- a/src/test/java/com/qulice/maven/FakeContext.java
+++ b/src/test/java/com/qulice/maven/FakeContext.java
@@ -13,6 +13,7 @@ import org.codehaus.plexus.context.ContextException;
 /**
  * FakeContext.
  * A mock to a context.
+ *
  * @since 0.24.1
  */
 final class FakeContext implements Context {

--- a/src/test/java/com/qulice/maven/FakeMavenEnvironment.java
+++ b/src/test/java/com/qulice/maven/FakeMavenEnvironment.java
@@ -16,6 +16,7 @@ import org.codehaus.plexus.context.Context;
 /**
  * FakeMavenEnvironment.
  * A mock to MavenEnvironment.
+ *
  * @since 0.24.1
  */
 final class FakeMavenEnvironment implements MavenEnvironment {

--- a/src/test/java/com/qulice/maven/FakeMavenValidator.java
+++ b/src/test/java/com/qulice/maven/FakeMavenValidator.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * {@code validate(MavenEnvironment)} entry point was invoked, so tests
  * can assert that {@code CheckMojo} drove every internal validator
  * exactly once.
+ *
  * @since 0.27.0
  */
 final class FakeMavenValidator implements MavenValidator {

--- a/src/test/java/com/qulice/maven/FakeResourceValidator.java
+++ b/src/test/java/com/qulice/maven/FakeResourceValidator.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * rule count through {@link #name()} and {@link #rules()}. The validate
  * call always returns an empty collection, so {@code CheckMojo} treats
  * the run as clean.
+ *
  * @since 0.27.0
  */
 final class FakeResourceValidator implements ResourceValidator {

--- a/src/test/java/com/qulice/maven/FakeValidator.java
+++ b/src/test/java/com/qulice/maven/FakeValidator.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * A test fake {@link Validator} that records how many times
  * {@link #validate(Environment)} was invoked and reports a configurable
  * name through {@link #name()}.
+ *
  * @since 0.27.0
  */
 final class FakeValidator implements Validator {

--- a/src/test/java/com/qulice/maven/FakeValidatorsProvider.java
+++ b/src/test/java/com/qulice/maven/FakeValidatorsProvider.java
@@ -12,6 +12,7 @@ import java.util.Set;
 /**
  * FakeValidatorsProvides.
  * A mock to ValidatorsProvides.
+ *
  * @since 0.24.1
  */
 final class FakeValidatorsProvider implements ValidatorsProvider {

--- a/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
+++ b/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
@@ -19,6 +19,7 @@ import org.slf4j.impl.StaticLoggerBinder;
 
 /**
  * Mocker of {@link MavenProject}.
+ *
  * @since 0.4
  */
 public final class MavenEnvironmentMocker {
@@ -45,6 +46,7 @@ public final class MavenEnvironmentMocker {
 
     /**
      * Public ctor.
+     *
      * @throws IOException If some IO problem inside
      */
     public MavenEnvironmentMocker() throws IOException {
@@ -60,6 +62,7 @@ public final class MavenEnvironmentMocker {
 
     /**
      * Inject this object into plexus container.
+     *
      * @param role The role
      * @param hint The hint
      * @param object The object to return
@@ -74,6 +77,7 @@ public final class MavenEnvironmentMocker {
 
     /**
      * With this project mocker.
+     *
      * @param mocker The project mocker
      * @return This object
      */
@@ -84,6 +88,7 @@ public final class MavenEnvironmentMocker {
 
     /**
      * With this file on board.
+     *
      * @param name File name related to basedir
      * @param content File content to write
      * @return This object
@@ -97,6 +102,7 @@ public final class MavenEnvironmentMocker {
 
     /**
      * With this file on board.
+     *
      * @param name File name related to basedir
      * @param bytes File content to write
      * @return This object
@@ -110,6 +116,7 @@ public final class MavenEnvironmentMocker {
 
     /**
      * With list of xpath queries to validate pom.xml.
+     *
      * @param asserts Collection of xpath queries
      * @return This object
      */
@@ -121,6 +128,7 @@ public final class MavenEnvironmentMocker {
 
     /**
      * Mock it.
+     *
      * @return The environment just mocked
      * @throws Exception If something wrong happens inside
      */

--- a/src/test/java/com/qulice/maven/MavenProjectMocker.java
+++ b/src/test/java/com/qulice/maven/MavenProjectMocker.java
@@ -10,6 +10,7 @@ import org.apache.maven.project.MavenProject;
 
 /**
  * Mocker of {@link MavenProject}.
+ *
  * @since 0.4
  */
 public final class MavenProjectMocker {
@@ -28,6 +29,7 @@ public final class MavenProjectMocker {
 
     /**
      * In this basedir.
+     *
      * @param dir The directory
      * @return This object
      */
@@ -42,6 +44,7 @@ public final class MavenProjectMocker {
 
     /**
      * Mock it.
+     *
      * @return The mock
      * @throws Exception If something wrong happens inside
      */

--- a/src/test/java/com/qulice/maven/MojoExecutorTest.java
+++ b/src/test/java/com/qulice/maven/MojoExecutorTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link MojoExecutor} conversion of Properties into Xpp3Dom.
+ *
  * @since 1.0
  */
 final class MojoExecutorTest {

--- a/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
+++ b/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
@@ -15,12 +15,14 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link PomXpathValidator} class.
+ *
  * @since 0.6
  */
 final class PomXpathValidatorTest {
 
     /**
      * PomXpathValidator can validate pom.xml with xpath.
+     *
      * @throws Exception If something wrong happens inside
      */
     @Test

--- a/src/test/java/com/qulice/maven/RecordingValidator.java
+++ b/src/test/java/com/qulice/maven/RecordingValidator.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * A test fake {@link Validator} that remembers the value one
  * {@link Environment} parameter had when the validator was called.
+ *
  * @since 1.0
  */
 final class RecordingValidator implements Validator {

--- a/src/test/java/com/qulice/maven/SummaryTest.java
+++ b/src/test/java/com/qulice/maven/SummaryTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Summary} class.
+ *
  * @since 1.0
  */
 final class SummaryTest {

--- a/src/test/java/com/qulice/maven/ValidationExclusionTest.java
+++ b/src/test/java/com/qulice/maven/ValidationExclusionTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Test case for {@link DefaultMavenEnvironment} class methods that
  * exclude files from validation.
+ *
  * @since 0.19
  */
 final class ValidationExclusionTest {
@@ -36,6 +37,7 @@ final class ValidationExclusionTest {
 
     /**
      * DefaultMavenEnvironment can exclude a path from PMD validation.
+     *
      * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      */
@@ -66,6 +68,7 @@ final class ValidationExclusionTest {
 
     /**
      * DefaultMavenEnvironment can exclude a path from Checkstyle validation.
+     *
      * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      */
@@ -99,6 +102,7 @@ final class ValidationExclusionTest {
 
     /**
      * DefaultMavenEnvironment can exclude a path from entire validation.
+     *
      * @param dir Temporary directory
      * @throws Exception If something wrong happens inside
      * @todo #1457:90min Add global exclusion support to qulice.

--- a/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
+++ b/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 /**
  * Mocker of ValidatorsProvider.
+ *
  * @since 0.4
  */
 final class ValidatorsProviderMocker {
@@ -32,6 +33,7 @@ final class ValidatorsProviderMocker {
 
     /**
      * With this external validator.
+     *
      * @param validator The validator
      * @return This object
      */
@@ -42,6 +44,7 @@ final class ValidatorsProviderMocker {
 
     /**
      * With this external resource validator.
+     *
      * @param validator The validator
      * @return This object
      */
@@ -52,6 +55,7 @@ final class ValidatorsProviderMocker {
 
     /**
      * With this external validator.
+     *
      * @param validator The validator
      * @return This object
      */
@@ -62,6 +66,7 @@ final class ValidatorsProviderMocker {
 
     /**
      * Mock it.
+     *
      * @return The provider
      */
     ValidatorsProvider mock() {

--- a/src/test/java/com/qulice/maven/package-info.java
+++ b/src/test/java/com/qulice/maven/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Tests of maven plugin.
+ *
  * @since 0.3
  */
 package com.qulice.maven;

--- a/src/test/java/com/qulice/pmd/CloseInlineResourceRuleTest.java
+++ b/src/test/java/com/qulice/pmd/CloseInlineResourceRuleTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link com.qulice.pmd.rules.CloseInlineResourceRule}.
+ *
  * @since 0.27.7
  */
 final class CloseInlineResourceRuleTest {

--- a/src/test/java/com/qulice/pmd/CloseInlineResourceRuleTest.java
+++ b/src/test/java/com/qulice/pmd/CloseInlineResourceRuleTest.java
@@ -27,11 +27,6 @@ final class CloseInlineResourceRuleTest {
      */
     private static final String RULE = "CloseInlineResourceRule";
 
-    /**
-     * Path template for the fixture file in the mock environment.
-     */
-    private static final String PATH = "src/main/java/foo/%s";
-
     @Test
     void detectsCloseableInsideMethodChain() throws Exception {
         MatcherAssert.assertThat(
@@ -63,7 +58,7 @@ final class CloseInlineResourceRuleTest {
     }
 
     private List<String> violations(final String file) throws Exception {
-        final String name = String.format(CloseInlineResourceRuleTest.PATH, file);
+        final String name = String.format("src/main/java/foo/%s", file);
         final Environment env = new Environment.Mock().withFile(
             name,
             new TextOf(this.getClass().getResourceAsStream(file)).asString()

--- a/src/test/java/com/qulice/pmd/EmptyCollectionRuleTest.java
+++ b/src/test/java/com/qulice/pmd/EmptyCollectionRuleTest.java
@@ -9,12 +9,14 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for ReturnEmptyCollectionRatherThanNull.
+ *
  * @since 0.19
  */
 final class EmptyCollectionRuleTest {
 
     /**
      * Makes sure that empty collections not returned as null.
+     *
      * @throws Exception when something goes wrong
      */
     @Test

--- a/src/test/java/com/qulice/pmd/ExcludingEnvironment.java
+++ b/src/test/java/com/qulice/pmd/ExcludingEnvironment.java
@@ -29,6 +29,7 @@ final class ExcludingEnvironment implements Environment {
 
     /**
      * Ctor.
+     *
      * @param env Environment to delegate to
      */
     ExcludingEnvironment(final Environment env) {

--- a/src/test/java/com/qulice/pmd/ImplicitFunctionalInterfaceRuleTest.java
+++ b/src/test/java/com/qulice/pmd/ImplicitFunctionalInterfaceRuleTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for
  * {@link com.qulice.pmd.rules.ImplicitFunctionalInterfaceRule}.
+ *
  * @since 1.0
  */
 final class ImplicitFunctionalInterfaceRuleTest {

--- a/src/test/java/com/qulice/pmd/LocalVariableCouldBeFinalRuleTest.java
+++ b/src/test/java/com/qulice/pmd/LocalVariableCouldBeFinalRuleTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for LocalVariableCouldBeFinal.
+ *
  * @since 0.18
  */
 final class LocalVariableCouldBeFinalRuleTest {
@@ -17,6 +18,7 @@ final class LocalVariableCouldBeFinalRuleTest {
     /**
      * LocalVariableCouldBeFinal can detect when variable is not
      * final and shows correct message.
+     *
      * @throws Exception If something goes wrong
      */
     @Test

--- a/src/test/java/com/qulice/pmd/PmdArrayIsStoredDirectlyTest.java
+++ b/src/test/java/com/qulice/pmd/PmdArrayIsStoredDirectlyTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
  * {@code ArrayIsStoredDirectly} rule, including the suppression
  * when a varargs/array parameter is wrapped in a method call or
  * constructor before assignment (issue #1053).
+ *
  * @since 0.25.1
  */
 final class PmdArrayIsStoredDirectlyTest {

--- a/src/test/java/com/qulice/pmd/PmdAssert.java
+++ b/src/test/java/com/qulice/pmd/PmdAssert.java
@@ -15,6 +15,7 @@ import org.hamcrest.MatcherAssert;
 
 /**
  * PMD Validator assertions.
+ *
  * @since 0.16
  */
 final class PmdAssert {
@@ -36,6 +37,7 @@ final class PmdAssert {
 
     /**
      * Constructor.
+     *
      * @param file File to validate
      * @param result Expected build status
      * @param matcher Matcher that needs to match
@@ -52,6 +54,7 @@ final class PmdAssert {
 
     /**
      * Validates given file against PMD.
+     *
      * @throws Exception In case of error.
      */
     void assertOk() throws Exception {

--- a/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdAssertionsTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link PmdValidator} covering JUnit assertion rules and
  * related test-class conventions.
+ *
  * @since 0.25.0
  */
 final class PmdAssertionsTest {
@@ -87,6 +88,7 @@ final class PmdAssertionsTest {
      * PmdValidator does not report UnitTestContainsTooManyAsserts when a test
      * wraps an Assertions.assertThrows call inside an assertThat to verify the
      * thrown exception's message.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -104,6 +106,7 @@ final class PmdAssertionsTest {
      * PmdValidator still reports UnitTestContainsTooManyAsserts when a test
      * has multiple asserts in addition to an assertThrows call, because only
      * assertThrows is excluded from the count.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -122,6 +125,7 @@ final class PmdAssertionsTest {
      * starts with 'verify' or 'check' but which are not JUnit/Hamcrest
      * assertions.
      * Regression test for https://github.com/yegor256/qulice/issues/1606
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -138,6 +142,7 @@ final class PmdAssertionsTest {
     /**
      * PmdValidator can allow only package private methods, marked with: Test,
      * RepeatedTest, TestFactory, TestTemplate or ParameterizedTest annotations.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -151,6 +156,7 @@ final class PmdAssertionsTest {
 
     /**
      * PmdValidator can allow only final JUnit3 test classes.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -164,6 +170,7 @@ final class PmdAssertionsTest {
 
     /**
      * PmdValidator can allow only final JUnit4 test classes.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -177,6 +184,7 @@ final class PmdAssertionsTest {
 
     /**
      * PmdValidator can allow only final JUnit5 test classes.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -190,6 +198,7 @@ final class PmdAssertionsTest {
 
     /**
      * PmdValidator can allow only final Junit test classes.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -209,6 +218,7 @@ final class PmdAssertionsTest {
     /**
      * PmdValidator can find assert() calls placed inside a lambda
      * body and not report UnitTestShouldIncludeAssert violation.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -227,6 +237,7 @@ final class PmdAssertionsTest {
      * no-argument {@code affirm()} call on an {@code Assertion} object as a
      * valid assertion and does not report UnitTestShouldIncludeAssert.
      * Regression test for https://github.com/yegor256/qulice/issues/1698
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -246,6 +257,7 @@ final class PmdAssertionsTest {
      * {@code public static void test()} entry point instead of
      * {@code @Test}-annotated methods.
      * Regression test for https://github.com/yegor256/qulice/issues/1064
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -273,6 +285,7 @@ final class PmdAssertionsTest {
      * {@link org.hamcrest.MatcherAssert#assertThat(String, boolean)} where
      * the first argument already is the message.
      * Regression test for https://github.com/yegor256/qulice/issues/1315
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -294,6 +307,7 @@ final class PmdAssertionsTest {
      * {@link org.hamcrest.MatcherAssert#assertThat(Object, org.hamcrest.Matcher)}
      * is used without a reason. Guards the fix for
      * https://github.com/yegor256/qulice/issues/1315 from over-suppressing.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test

--- a/src/test/java/com/qulice/pmd/PmdAvoidUsingHardCodedIpTest.java
+++ b/src/test/java/com/qulice/pmd/PmdAvoidUsingHardCodedIpTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
  * The rule is suppressed inside unit-test classes (whose simple name
  * ends with Test, IT, TestCase or ITCase) but stays active in
  * production code.
+ *
  * @since 0.26.0
  */
 final class PmdAvoidUsingHardCodedIpTest {

--- a/src/test/java/com/qulice/pmd/PmdCloneMethodTest.java
+++ b/src/test/java/com/qulice/pmd/PmdCloneMethodTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s handling of PMD's
  * clone-method rules: {@code CloneMethodMustBePublic} and
  * {@code CloneMethodReturnTypeMustMatchClassName}.
+ *
  * @since 0.25.1
  */
 final class PmdCloneMethodTest {

--- a/src/test/java/com/qulice/pmd/PmdCompareObjectsWithEqualsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdCompareObjectsWithEqualsTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link PmdValidator}'s handling of the
  * {@code CompareObjectsWithEquals} rule.
+ *
  * @since 1.0
  */
 final class PmdCompareObjectsWithEqualsTest {

--- a/src/test/java/com/qulice/pmd/PmdConstructorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdConstructorTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
  * constructor rules: fields must be initialized either outside the
  * constructor or in a single constructor, and constructors may only
  * delegate or initialize fields.
+ *
  * @since 0.25.1
  */
 final class PmdConstructorTest {

--- a/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for disabled rules.
+ *
  * @since 0.16
  */
 final class PmdDisabledRulesTest {

--- a/src/test/java/com/qulice/pmd/PmdDuplicateLiteralsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdDuplicateLiteralsTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s tolerance of repeated string
  * literals, since the {@code AvoidDuplicateLiterals} rule is not part
  * of the ruleset.
+ *
  * @since 0.25.1
  */
 final class PmdDuplicateLiteralsTest {

--- a/src/test/java/com/qulice/pmd/PmdEmptyTest.java
+++ b/src/test/java/com/qulice/pmd/PmdEmptyTest.java
@@ -9,12 +9,14 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link PmdValidator} class.
+ *
  * @since 0.15
  */
 final class PmdEmptyTest {
 
     /**
      * Makes sure that empty static initializers fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -30,6 +32,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty statement blocks fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -45,6 +48,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty initializers fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -60,6 +64,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty statement not in a loop fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -75,6 +80,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty synchronized statements fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -90,6 +96,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty switch statements fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -105,6 +112,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty finally blocks fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -118,6 +126,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty while statements fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -131,6 +140,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty if blocks fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test
@@ -144,6 +154,7 @@ final class PmdEmptyTest {
 
     /**
      * Makes sure that empty catch blocks fail with an error.
+     *
      * @throws Exception when something goes wrong
      */
     @Test

--- a/src/test/java/com/qulice/pmd/PmdEnabledRulesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdEnabledRulesTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for rules that PMD ships and Qulice enables.
+ *
  * @since 0.25.1
  */
 final class PmdEnabledRulesTest {

--- a/src/test/java/com/qulice/pmd/PmdExcessiveParameterListTest.java
+++ b/src/test/java/com/qulice/pmd/PmdExcessiveParameterListTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
  * constructor.
  * Regression test for https://github.com/yegor256/qulice/issues/1763
  * and https://github.com/yegor256/qulice/issues/1775
+ *
  * @since 1.0
  */
 final class PmdExcessiveParameterListTest {

--- a/src/test/java/com/qulice/pmd/PmdExclusionTest.java
+++ b/src/test/java/com/qulice/pmd/PmdExclusionTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s short-circuit when every
  * source file is excluded (issue #759). PMD must not be invoked
  * on the excluded file and must report no violations.
+ *
  * @since 0.25.1
  */
 final class PmdExclusionTest {

--- a/src/test/java/com/qulice/pmd/PmdFilesCreateFileTest.java
+++ b/src/test/java/com/qulice/pmd/PmdFilesCreateFileTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link PmdValidator}'s rule that forbids
  * {@code Files.createFile} inside tests but allows it elsewhere.
+ *
  * @since 0.25.1
  */
 final class PmdFilesCreateFileTest {

--- a/src/test/java/com/qulice/pmd/PmdInnerClassConstantsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdInnerClassConstantsTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s handling of private
  * constants that are used only from within an inner class —
  * they must not be reported as unused.
+ *
  * @since 0.25.1
  */
 final class PmdInnerClassConstantsTest {

--- a/src/test/java/com/qulice/pmd/PmdLooseCouplingTest.java
+++ b/src/test/java/com/qulice/pmd/PmdLooseCouplingTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
  * types declared with concrete collection implementations
  * such as {@code ConcurrentHashMap} or {@code HashMap} must
  * be reported (issue #734).
+ *
  * @since 0.25.1
  */
 final class PmdLooseCouplingTest {

--- a/src/test/java/com/qulice/pmd/PmdMethodNamingConventionsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdMethodNamingConventionsTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Test case for {@link PmdValidator}'s rejection of unicode
  * characters inside method names under the
  * {@code MethodNamingConventions} rule.
+ *
  * @since 0.25.1
  */
 final class PmdMethodNamingConventionsTest {

--- a/src/test/java/com/qulice/pmd/PmdMethodReferencesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdMethodReferencesTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s recognition of method
  * references so that referenced private methods are not flagged
  * as {@code UnusedPrivateMethod}.
+ *
  * @since 0.25.1
  */
 final class PmdMethodReferencesTest {

--- a/src/test/java/com/qulice/pmd/PmdMissingOverrideTest.java
+++ b/src/test/java/com/qulice/pmd/PmdMissingOverrideTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s handling of the
  * {@code MissingOverride} rule when an interface method is
  * implemented without the annotation (issue #770).
+ *
  * @since 0.25.1
  */
 final class PmdMissingOverrideTest {

--- a/src/test/java/com/qulice/pmd/PmdPublicStaticMethodTest.java
+++ b/src/test/java/com/qulice/pmd/PmdPublicStaticMethodTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s rule prohibiting public
  * static methods, with the exceptions for {@code public static
  * void main} and JUnit lifecycle/parameterization hooks.
+ *
  * @since 0.25.1
  */
 final class PmdPublicStaticMethodTest {

--- a/src/test/java/com/qulice/pmd/PmdRecordClassesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdRecordClassesTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.condition.JRE;
  * Test case for {@link PmdValidator}'s support for Java record
  * classes (parsed cleanly and not flagged as public-static-method
  * violations).
+ *
  * @since 0.25.1
  */
 final class PmdRecordClassesTest {

--- a/src/test/java/com/qulice/pmd/PmdSimplifiedTernaryTest.java
+++ b/src/test/java/com/qulice/pmd/PmdSimplifiedTernaryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link PmdValidator}'s handling of the
  * {@code SimplifiedTernary} rule.
+ *
  * @since 0.25.1
  */
 final class PmdSimplifiedTernaryTest {

--- a/src/test/java/com/qulice/pmd/PmdStaticAccessTest.java
+++ b/src/test/java/com/qulice/pmd/PmdStaticAccessTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s rule that static fields and
  * methods must be accessed via the class name, not via an instance
  * or {@code this}.
+ *
  * @since 0.25.1
  */
 final class PmdStaticAccessTest {

--- a/src/test/java/com/qulice/pmd/PmdSwaggerAnnotationsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdSwaggerAnnotationsTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
  * Test case for {@link PmdValidator}'s tolerance of Swagger
  * annotations (no {@code RuleSetReferenceId} warnings must be
  * produced).
+ *
  * @since 0.25.1
  */
 final class PmdSwaggerAnnotationsTest {

--- a/src/test/java/com/qulice/pmd/PmdTestClassWithoutTestCasesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTestClassWithoutTestCasesTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
  * {@code io.github.artsok.RepeatedIfExceptionsTest} annotation
  * as a test method, so the class is not flagged under
  * {@code TestClassWithoutTestCases}.
+ *
  * @since 0.25.1
  */
 final class PmdTestClassWithoutTestCasesTest {

--- a/src/test/java/com/qulice/pmd/PmdTooManyFieldsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyFieldsTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
  * Mojo.
  * Regression test for https://github.com/yegor256/qulice/issues/1767
  * and https://github.com/yegor256/qulice/issues/1775
+ *
  * @since 1.0
  */
 final class PmdTooManyFieldsTest {

--- a/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTooManyMethodsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * https://github.com/yegor256/qulice/issues/1647,
  * https://github.com/yegor256/qulice/issues/1656
  * and https://github.com/yegor256/qulice/issues/1667
+ *
  * @since 1.0
  */
 final class PmdTooManyMethodsTest {

--- a/src/test/java/com/qulice/pmd/PmdTransientFieldsTest.java
+++ b/src/test/java/com/qulice/pmd/PmdTransientFieldsTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
  * non-transient fields (the {@code BeanMembersShouldSerialize} /
  * {@code NonTransientFieldInSerializableClass} rule is disabled
  * for qulice-style code).
+ *
  * @since 0.25.1
  */
 final class PmdTransientFieldsTest {

--- a/src/test/java/com/qulice/pmd/PmdUnnecessaryFinalModifierTest.java
+++ b/src/test/java/com/qulice/pmd/PmdUnnecessaryFinalModifierTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link PmdValidator}'s handling of the
  * {@code UnnecessaryFinalModifier} rule.
+ *
  * @since 0.25.1
  */
 final class PmdUnnecessaryFinalModifierTest {

--- a/src/test/java/com/qulice/pmd/PmdUnnecessaryWarningSuppressionTest.java
+++ b/src/test/java/com/qulice/pmd/PmdUnnecessaryWarningSuppressionTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
  * {@code UnnecessaryWarningSuppression} rule must not report
  * {@code @SuppressWarnings("PMD.UnnecessaryWarningSuppression")}
  * as an unused suppression of itself.
+ *
  * @since 0.25.1
  */
 final class PmdUnnecessaryWarningSuppressionTest {

--- a/src/test/java/com/qulice/pmd/PmdUnusedPrivateFieldTest.java
+++ b/src/test/java/com/qulice/pmd/PmdUnusedPrivateFieldTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
  * {@code UnusedPrivateField} rule, including the suppression for
  * fields referenced through a fully-qualified outer-class path
  * inside a lambda (issue #1520).
+ *
  * @since 0.25.1
  */
 final class PmdUnusedPrivateFieldTest {

--- a/src/test/java/com/qulice/pmd/PmdUseDiamondOperatorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdUseDiamondOperatorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link PmdValidator}'s handling of the
  * {@code UseDiamondOperator} rule.
+ *
  * @since 1.0
  */
 final class PmdUseDiamondOperatorTest {

--- a/src/test/java/com/qulice/pmd/PmdUseStringIsEmptyNpeTest.java
+++ b/src/test/java/com/qulice/pmd/PmdUseStringIsEmptyNpeTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
  * Regression test for {@link UseStringIsEmptyRule}: the rule
  * must not throw a {@code NullPointerException} when it
  * encounters a pattern-matching expression.
+ *
  * @since 0.25.1
  */
 final class PmdUseStringIsEmptyNpeTest {

--- a/src/test/java/com/qulice/pmd/PmdUselessParenthesesTest.java
+++ b/src/test/java/com/qulice/pmd/PmdUselessParenthesesTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link PmdValidator}'s handling of the
  * {@code UselessParentheses} rule.
+ *
  * @since 0.25.1
  */
 final class PmdUselessParenthesesTest {

--- a/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
  * Test case for general {@link PmdValidator} behavior that is
  * not tied to a single PMD rule. Per-rule coverage lives in the
  * dedicated {@code Pmd*Test.java} files in this package.
+ *
  * @since 0.3
  */
 final class PmdValidatorTest {

--- a/src/test/java/com/qulice/pmd/ProhibitFormatInLoggerRuleTest.java
+++ b/src/test/java/com/qulice/pmd/ProhibitFormatInLoggerRuleTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link com.qulice.pmd.rules.ProhibitFormatInLoggerRule}.
+ *
  * @since 0.26.0
  */
 final class ProhibitFormatInLoggerRuleTest {

--- a/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UnnecessaryLocalRuleTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for UnnecessaryLocalRule.
+ *
  * @since 0.24
  */
 final class UnnecessaryLocalRuleTest {

--- a/src/test/java/com/qulice/pmd/UnusedImportsRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UnusedImportsRuleTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for LocalVariableCouldBeFinal.
+ *
  * @since 0.18
  */
 final class UnusedImportsRuleTest {
@@ -17,6 +18,7 @@ final class UnusedImportsRuleTest {
     /**
      * UnusedImport can detect when the class has an unused import line and
      * show error message correctly.
+     *
      * @throws Exception If something goes wrong
      */
     @Test

--- a/src/test/java/com/qulice/pmd/UseCollectionsSingletonListRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UseCollectionsSingletonListRuleTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link com.qulice.pmd.rules.UseCollectionsSingletonListRule}.
+ *
  * @since 0.26.0
  */
 final class UseCollectionsSingletonListRuleTest {

--- a/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
+++ b/src/test/java/com/qulice/pmd/UseStringIsEmptyRuleTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link com.qulice.pmd.rules.UseStringIsEmptyRule}.
+ *
  * @since 0.18
  */
 final class UseStringIsEmptyRuleTest {
@@ -22,6 +23,7 @@ final class UseStringIsEmptyRuleTest {
     /**
      * UseStringIsEmpty can detect when used String.length(), when checking for
      * empty string.
+     *
      * @param file File name
      * @throws Exception If something goes wrong.
      */
@@ -52,6 +54,7 @@ final class UseStringIsEmptyRuleTest {
      * {@code isEmpty()} equivalent, such as {@code length()} checks against
      * {@code 1} (single-character strings) or the always-true
      * {@code length() >= 0}.
+     *
      * @param file File name
      * @throws Exception If something goes wrong.
      */
@@ -75,6 +78,7 @@ final class UseStringIsEmptyRuleTest {
     /**
      * UseStringIsEmpty not detect when used String[].length, when checking for
      * empty string.
+     *
      * @throws Exception If something goes wrong.
      */
     @Test

--- a/src/test/java/com/qulice/pmd/package-info.java
+++ b/src/test/java/com/qulice/pmd/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Tests of PMD validator.
+ *
  * @since 0.3
  */
 package com.qulice.pmd;

--- a/src/test/java/com/qulice/spi/BinaryTest.java
+++ b/src/test/java/com/qulice/spi/BinaryTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link Binary}.
+ *
  * @since 0.24
  */
 final class BinaryTest {

--- a/src/test/java/com/qulice/spi/EnvironmentTest.java
+++ b/src/test/java/com/qulice/spi/EnvironmentTest.java
@@ -14,12 +14,14 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Environment}.
+ *
  * @since 0.3
  */
 final class EnvironmentTest {
 
     /**
      * Environment interface can be mocked/instantiated with Mocker.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -36,6 +38,7 @@ final class EnvironmentTest {
 
     /**
      * EnvironmentMocker can create file.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -53,6 +56,7 @@ final class EnvironmentTest {
 
     /**
      * EnvironmentMocker can write bytearray too.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -71,6 +75,7 @@ final class EnvironmentTest {
 
     /**
      * EnvironmentMocker can set classpath for the mock.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -86,6 +91,7 @@ final class EnvironmentTest {
      * Environment.files() should skip binary files so validators never see
      * them (see <a href="https://github.com/yegor256/qulice/issues/1264">
      * issue #1264</a>).
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test
@@ -132,6 +138,7 @@ final class EnvironmentTest {
 
     /**
      * EnvironmentMocker can mock params.
+     *
      * @throws Exception If something wrong happens inside.
      */
     @Test

--- a/src/test/java/com/qulice/spi/IgnoredTest.java
+++ b/src/test/java/com/qulice/spi/IgnoredTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link Ignored}.
+ *
  * @since 1.0
  */
 final class IgnoredTest {

--- a/src/test/java/com/qulice/spi/RelativeTest.java
+++ b/src/test/java/com/qulice/spi/RelativeTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link Relative}.
+ *
  * @since 0.24
  */
 final class RelativeTest {

--- a/src/test/java/com/qulice/spi/ViolationTest.java
+++ b/src/test/java/com/qulice/spi/ViolationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Violation}.
+ *
  * @since 0.24
  */
 final class ViolationTest {

--- a/src/test/java/com/qulice/spi/package-info.java
+++ b/src/test/java/com/qulice/spi/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Service provider interface, tests.
+ *
  * @since 0.3
  */
 package com.qulice.spi;

--- a/src/test/resources/com/qulice/checkstyle/AnnotationConstant.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationConstant.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class AnnotationConstant {
@@ -53,6 +54,7 @@ public final class AnnotationConstant {
 
     /**
      * Some data.
+     *
      * @return Some data
      */
     @SuppressWarnings(AnnotationConstant.TEXT1)
@@ -62,6 +64,7 @@ public final class AnnotationConstant {
 
     /**
      * Some other data.
+     *
      * @return Some other data
      */
     @SuppressWarnings(value = AnnotationConstant.TEXT2)
@@ -71,6 +74,7 @@ public final class AnnotationConstant {
 
     /**
      * Some other data.
+     *
      * @return Some other data
      */
     @SuppressWarnings({ AnnotationConstant.TEXT3, AnnotationConstant.TEXT4})
@@ -80,6 +84,7 @@ public final class AnnotationConstant {
 
     /**
      * Some other data.
+     *
      * @return Some other data
      */
     @SuppressWarnings(
@@ -91,6 +96,7 @@ public final class AnnotationConstant {
 
     /**
      * All texts together, so that no constant is used only once.
+     *
      * @return All of them
      */
     public static String all() {

--- a/src/test/resources/com/qulice/checkstyle/AnnotationConstantField.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationConstantField.java
@@ -7,6 +7,7 @@ import java.util.Random;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 @SuppressWarnings(AnnotationConstantField.TEXT1)
@@ -53,6 +54,7 @@ public final class AnnotationConstantField {
 
     /**
      * Some data.
+     *
      * @return Some data
      */
     public int data() {
@@ -61,6 +63,7 @@ public final class AnnotationConstantField {
 
     /**
      * All texts together, so that no constant is used only once.
+     *
      * @return All of them
      */
     public static String all() {
@@ -73,6 +76,7 @@ public final class AnnotationConstantField {
 
     /**
      * Some inner class.
+     *
      * @since 1.0
      */
     @SuppressWarnings(AnnotationConstantField.TEXT4)
@@ -85,6 +89,7 @@ public final class AnnotationConstantField {
 
         /**
          * Returns dummy.
+         *
          * @return Dummy
          */
         public int dummy() {

--- a/src/test/resources/com/qulice/checkstyle/AnnotationIndentation.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationIndentation.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 @SuppressWarnings({

--- a/src/test/resources/com/qulice/checkstyle/AnnotationIndentationNegative.java
+++ b/src/test/resources/com/qulice/checkstyle/AnnotationIndentationNegative.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 @SuppressWarnings(

--- a/src/test/resources/com/qulice/checkstyle/AtClauseOrder.java
+++ b/src/test/resources/com/qulice/checkstyle/AtClauseOrder.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Correct Javadoc for class {@link AtClauseOrder}.
+ *
  * @see AtClauseOrder
  * @serial Serial
  * @serialField
@@ -17,6 +18,7 @@ public final class AtClauseOrder {
 
     /**
      * Empty constructor.
+     *
      * @checkstyle Suppression
      * @todo Puzzle
      */
@@ -25,6 +27,7 @@ public final class AtClauseOrder {
 
     /**
      * Just a method with valid Javadoc.
+     *
      * @param input Valid parameter
      * @return Some value
      * @throws  Exception If fails
@@ -42,6 +45,7 @@ public final class AtClauseOrder {
 
     /**
      * Just a method with invalid Javadoc.
+     *
      * @see AtClauseOrder
      * @return Some value
      */
@@ -51,6 +55,7 @@ public final class AtClauseOrder {
 
     /**
      * Just a class with invalid Javadoc.
+     *
      * @since 1.0
      */
     private class Class {

--- a/src/test/resources/com/qulice/checkstyle/BlankLinesInsideMethodsFail.java
+++ b/src/test/resources/com/qulice/checkstyle/BlankLinesInsideMethodsFail.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class BlankLinesInsideMethodsFail {

--- a/src/test/resources/com/qulice/checkstyle/BlankLinesOutsideMethodsPass.java
+++ b/src/test/resources/com/qulice/checkstyle/BlankLinesOutsideMethodsPass.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class BlankLinesOutsideMethodsPass {

--- a/src/test/resources/com/qulice/checkstyle/CascadeAfterClosingBracket.java
+++ b/src/test/resources/com/qulice/checkstyle/CascadeAfterClosingBracket.java
@@ -9,6 +9,7 @@ import java.util.function.BinaryOperator;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class CascadeAfterClosingBracket {
@@ -25,6 +26,7 @@ public final class CascadeAfterClosingBracket {
 
     /**
      * Ctor.
+     *
      * @param red Reducer
      * @param list Items
      */
@@ -36,6 +38,7 @@ public final class CascadeAfterClosingBracket {
 
     /**
      * Take it.
+     *
      * @return The value
      * @throws Exception If fails
      */

--- a/src/test/resources/com/qulice/checkstyle/CatchParameterNames.java
+++ b/src/test/resources/com/qulice/checkstyle/CatchParameterNames.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class CatchParameterNames {

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineBeforeTagCheck/Invalid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineBeforeTagCheck/Invalid.java
@@ -5,14 +5,12 @@ package com.qulice.checkstyle;
 
 /**
  * Single-paragraph class Javadoc.
- *
  * @since 0.27.0
  */
 public final class Invalid {
 
     /**
      * Single-paragraph field Javadoc.
-     *
      * @since 0.27.0
      */
     private static final int X = 0;
@@ -20,7 +18,7 @@ public final class Invalid {
     /**
      * First paragraph of the Javadoc.
      *
-     * <p>Second paragraph of the Javadoc.
+     * <p>Second paragraph of the Javadoc.</p>
      * @since 0.27.0
      */
     public Invalid() {
@@ -28,7 +26,6 @@ public final class Invalid {
 
     /**
      * Single-paragraph method Javadoc.
-     *
      * @param param Some value
      * @return The same value
      */
@@ -39,7 +36,7 @@ public final class Invalid {
     /**
      * First paragraph of the Javadoc.
      *
-     * <p>Second paragraph.
+     * <p>Second paragraph.</p>
      * @param param Some value
      * @return The same value
      */

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineBeforeTagCheck/Valid.java
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineBeforeTagCheck/Valid.java
@@ -1,23 +1,26 @@
 /*
- * All Javadocs below follow the rule: single-paragraph body has no empty
- * line before at-clauses; multi-paragraph body requires one.
+ * All Javadocs below follow the rule: the block of at-clauses is always
+ * preceded by an empty Javadoc line.
  */
 package com.qulice.checkstyle;
 
 /**
  * Single-paragraph class Javadoc.
+ *
  * @since 0.27.0
  */
 public final class Valid {
 
     /**
      * Single-paragraph field Javadoc.
+     *
      * @since 0.27.0
      */
     private static final int X = 0;
 
     /**
      * Single-paragraph ctor Javadoc.
+     *
      * @param value Any value
      */
     public Valid(final int value) {
@@ -25,6 +28,7 @@ public final class Valid {
 
     /**
      * Single-paragraph method Javadoc.
+     *
      * @param param Some value
      * @return The same value
      */
@@ -35,7 +39,7 @@ public final class Valid {
     /**
      * First paragraph of the Javadoc.
      *
-     * <p>Second paragraph of the Javadoc.
+     * <p>Second paragraph of the Javadoc.</p>
      *
      * @param param Some value
      * @return The same value
@@ -53,8 +57,16 @@ public final class Valid {
     /**
      * Body with no tags but multiple paragraphs.
      *
-     * <p>Second par.
+     * <p>Second par.</p>
      */
     public void noTagsMultiple() {
+    }
+
+    /**
+     * @param param Some value
+     * @return The same value
+     */
+    public String noBody(final String param) {
+        return param;
     }
 }

--- a/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineBeforeTagCheck/violations.txt
+++ b/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocEmptyLineBeforeTagCheck/violations.txt
@@ -1,5 +1,5 @@
-8:Empty Javadoc line before at-clauses is not allowed, since the description is a single paragraph
-15:Empty Javadoc line before at-clauses is not allowed, since the description is a single paragraph
-24:Empty Javadoc line required before at-clauses, since the description has multiple paragraphs
-31:Empty Javadoc line before at-clauses is not allowed, since the description is a single paragraph
-43:Empty Javadoc line required before at-clauses, since the description has multiple paragraphs
+8:Empty Javadoc line required before the block of at-clauses
+14:Empty Javadoc line required before the block of at-clauses
+22:Empty Javadoc line required before the block of at-clauses
+29:Empty Javadoc line required before the block of at-clauses
+40:Empty Javadoc line required before the block of at-clauses

--- a/src/test/resources/com/qulice/checkstyle/ConstantUsedBeforeDeclaration.java
+++ b/src/test/resources/com/qulice/checkstyle/ConstantUsedBeforeDeclaration.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ConstantUsedBeforeDeclaration {

--- a/src/test/resources/com/qulice/checkstyle/ConstructorParams.java
+++ b/src/test/resources/com/qulice/checkstyle/ConstructorParams.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ConstructorParams {
@@ -15,6 +16,7 @@ public final class ConstructorParams {
 
     /**
      * Constructor.
+     *
      * @param number Some nice number
      */
     public ConstructorParams(final int number) {
@@ -23,6 +25,7 @@ public final class ConstructorParams {
 
     /**
      * Add an external number to internal one.
+     *
      * @param number Number to add
      * @return Sum of numbers
      */

--- a/src/test/resources/com/qulice/checkstyle/DefaultMethods.java
+++ b/src/test/resources/com/qulice/checkstyle/DefaultMethods.java
@@ -8,18 +8,21 @@ import java.util.function.Consumer;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public interface DefaultMethods {
 
     /**
      * Some data.
+     *
      * @return Some data
      */
     List<String> data();
 
     /**
      * Some default method.
+     *
      * @param action Value to print
      */
     default void forEach(final Consumer<String> action) {

--- a/src/test/resources/com/qulice/checkstyle/DiamondUsageNotNeeded.java
+++ b/src/test/resources/com/qulice/checkstyle/DiamondUsageNotNeeded.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 /**
  * Some comment.
+ *
  * @since 1.0
  */
 public final class DiamondUsageNotNeeded {

--- a/src/test/resources/com/qulice/checkstyle/DisabledUnknownSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/DisabledUnknownSuppression.java
@@ -7,6 +7,7 @@ package foo;
 
 /**
  * Sample class disabling a check that does not exist at all.
+ *
  * @since 1.0
  */
 public interface DisabledUnknownSuppression {

--- a/src/test/resources/com/qulice/checkstyle/DoNotUseCharEncoding.java
+++ b/src/test/resources/com/qulice/checkstyle/DoNotUseCharEncoding.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.CharEncoding;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class DoNotUseCharEncoding {

--- a/src/test/resources/com/qulice/checkstyle/DoubleWhitespaceFieldDecl.java
+++ b/src/test/resources/com/qulice/checkstyle/DoubleWhitespaceFieldDecl.java
@@ -6,6 +6,7 @@ package foo;
 /**
  * Demonstrates a field declaration with multiple whitespace characters
  * between tokens, which must be rejected.
+ *
  * @since 1.0
  */
 public final class DoubleWhitespaceFieldDecl {
@@ -18,6 +19,7 @@ public final class DoubleWhitespaceFieldDecl {
 
     /**
      * Greet.
+     *
      * @return Greeting
      */
     public String greet() {

--- a/src/test/resources/com/qulice/checkstyle/EnhancedSwitch.java
+++ b/src/test/resources/com/qulice/checkstyle/EnhancedSwitch.java
@@ -7,11 +7,13 @@ package foo;
  * Class with a classic switch statement that Checkstyle's
  * {@code UseEnhancedSwitch} suggests rewriting into arrow-switch syntax,
  * which only compiles under Java 14+.
+ *
  * @since 1.0
  */
 public final class EnhancedSwitch {
     /**
      * Describe the given type using a classic switch.
+     *
      * @param type The type
      * @return Human readable name
      */

--- a/src/test/resources/com/qulice/checkstyle/ExtraSemicolon.java
+++ b/src/test/resources/com/qulice/checkstyle/ExtraSemicolon.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ExtraSemicolon {

--- a/src/test/resources/com/qulice/checkstyle/ExtraSemicolonInDeclaration.java
+++ b/src/test/resources/com/qulice/checkstyle/ExtraSemicolonInDeclaration.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Sample with unnecessary semicolons.
+ *
  * @since 1.0
  */
 public final class ExtraSemicolonInDeclaration {
@@ -21,6 +22,7 @@ public final class ExtraSemicolonInDeclaration {
 
     /**
      * Method ending with a stray semicolon.
+     *
      * @return Dummy
      */
     public int act() {

--- a/src/test/resources/com/qulice/checkstyle/FakeLibrary.java
+++ b/src/test/resources/com/qulice/checkstyle/FakeLibrary.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Extends a type named Library that comes from nowhere near JNA.
+ *
  * @since 1.0
  */
 public interface FakeLibrary extends Library {
 
     /**
      * The code of the last error.
+     *
      * @return The code
      */
     int GetLastError();

--- a/src/test/resources/com/qulice/checkstyle/FileLengthCheck.java
+++ b/src/test/resources/com/qulice/checkstyle/FileLengthCheck.java
@@ -6,6 +6,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 0.24.2
  * @checkstyle NonStaticMethodCheck (1500 lines)
  * @checkstyle MethodNameCheck (1500 lines)

--- a/src/test/resources/com/qulice/checkstyle/FourAttributes.java
+++ b/src/test/resources/com/qulice/checkstyle/FourAttributes.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Class with four attributes.
+ *
  * @since 1.0
  */
 public final class FourAttributes {
@@ -31,6 +32,7 @@ public final class FourAttributes {
 
     /**
      * Constructor.
+     *
      * @param one First number
      * @param two Second number
      * @param three Third number
@@ -45,6 +47,7 @@ public final class FourAttributes {
 
     /**
      * Sum of all numbers.
+     *
      * @return The sum
      */
     public int sum() {

--- a/src/test/resources/com/qulice/checkstyle/FourParameters.java
+++ b/src/test/resources/com/qulice/checkstyle/FourParameters.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Class with a method of four parameters.
+ *
  * @since 1.0
  */
 public final class FourParameters {
 
     /**
      * Sum of all numbers.
+     *
      * @param one First number
      * @param two Second number
      * @param three Third number

--- a/src/test/resources/com/qulice/checkstyle/GuavaNewArrayList.java
+++ b/src/test/resources/com/qulice/checkstyle/GuavaNewArrayList.java
@@ -8,12 +8,14 @@ import java.util.List;
 
 /**
  * Sample class for testing Guava Lists.newArrayList() detection.
+ *
  * @since 1.0
  */
 public final class GuavaNewArrayList {
 
     /**
      * Build a list using Guava helper without size.
+     *
      * @return An empty list
      */
     public List<String> build() {

--- a/src/test/resources/com/qulice/checkstyle/HexLiteralCase.java
+++ b/src/test/resources/com/qulice/checkstyle/HexLiteralCase.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Hexadecimal literals spell their letters in lower case.
+ *
  * @since 1.0
  */
 public final class HexLiteralCase {
 
     /**
      * Magic bytes that open a PNG file.
+     *
      * @return Header of eight bytes
      */
     public byte[] header() {

--- a/src/test/resources/com/qulice/checkstyle/HiddenParameter.java
+++ b/src/test/resources/com/qulice/checkstyle/HiddenParameter.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Hidden parameter test.
+ *
  * @since 1.0
  */
 class HiddenParameter {
@@ -13,6 +14,7 @@ class HiddenParameter {
 
     /**
      * Some documentation for the function.
+     *
      * @param test Test
      */
     void bar(final String test) { // error is here

--- a/src/test/resources/com/qulice/checkstyle/IdMethodName.java
+++ b/src/test/resources/com/qulice/checkstyle/IdMethodName.java
@@ -4,6 +4,7 @@
 package foo;
 /**
  * Allows 'id' as a method name.
+ *
  * @since 1.0
  */
 public final class IdMethodName {
@@ -15,6 +16,7 @@ public final class IdMethodName {
 
     /**
      * Ctor.
+     *
      * @param num The id value
      */
     public IdMethodName(final int num) {
@@ -23,6 +25,7 @@ public final class IdMethodName {
 
     /**
      * Returns the id of this object.
+     *
      * @return The id
      */
     public int id() {

--- a/src/test/resources/com/qulice/checkstyle/InstanceMethodRef.java
+++ b/src/test/resources/com/qulice/checkstyle/InstanceMethodRef.java
@@ -4,6 +4,7 @@
 package foo;
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class InstanceMethodRef {

--- a/src/test/resources/com/qulice/checkstyle/InterfaceTypeParameterName.java
+++ b/src/test/resources/com/qulice/checkstyle/InterfaceTypeParameterName.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Interface with wrong parameter name.
+ *
  * @param <wRoNg> Very bad name for parameter
  * @since 1.0
  */

--- a/src/test/resources/com/qulice/checkstyle/InvalidAbbreviationAsWordInNameXML.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidAbbreviationAsWordInNameXML.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Uppercase abbreviation XML in class name is not allowed.
+ *
  * @since 1.0
  */
 public class InvalidAbbreviationAsWordInNameXML {

--- a/src/test/resources/com/qulice/checkstyle/InvalidDiamondsUsage.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidDiamondsUsage.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 /**
  * Better to use diamond operator where possible.
+ *
  * @since 1.0
  */
 public final class InvalidDiamondsUsage {
@@ -30,12 +31,14 @@ public final class InvalidDiamondsUsage {
 
     /**
      * Simple interface, used as wrapper.
+     *
      * @since 1.0.0
      */
     interface SimpleInterface {
 
         /**
          * Inner class with generic parameter.
+         *
          * @param <E> Generic parameter
          * @since 1.0.0
          */

--- a/src/test/resources/com/qulice/checkstyle/InvalidEnhancedForColon.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidEnhancedForColon.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class InvalidEnhancedForColon {
@@ -18,6 +19,7 @@ public final class InvalidEnhancedForColon {
 
     /**
      * Ctor.
+     *
      * @param start Starting value
      */
     public InvalidEnhancedForColon(final int start) {
@@ -26,6 +28,7 @@ public final class InvalidEnhancedForColon {
 
     /**
      * Sum with base.
+     *
      * @param numbers Numbers
      * @return Total
      */

--- a/src/test/resources/com/qulice/checkstyle/InvalidEnumValues.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidEnumValues.java
@@ -6,6 +6,7 @@ package foo;
 /**
  * Declares enum constants with names that violate the required
  * upper-case, underscore-separated convention.
+ *
  * @since 1.0
  */
 public enum InvalidEnumValues {

--- a/src/test/resources/com/qulice/checkstyle/InvalidFluentCallFormatting.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidFluentCallFormatting.java
@@ -7,11 +7,13 @@ import java.util.stream.Stream;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class InvalidFluentCallFormatting {
     /**
      * Returns something.
+     *
      * @return Something
      */
     public String make() {

--- a/src/test/resources/com/qulice/checkstyle/InvalidIfThenThrowElse.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidIfThenThrowElse.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Samples with an else clause after a throwing then branch.
+ *
  * @since 1.0
  */
 public final class InvalidIfThenThrowElse {
@@ -16,6 +17,7 @@ public final class InvalidIfThenThrowElse {
 
     /**
      * Constructor.
+     *
      * @param name The label
      */
     public InvalidIfThenThrowElse(final String name) {
@@ -24,6 +26,7 @@ public final class InvalidIfThenThrowElse {
 
     /**
      * Braced then-throw with else block.
+     *
      * @param num A number
      */
     public void braced(final int num) {
@@ -36,6 +39,7 @@ public final class InvalidIfThenThrowElse {
 
     /**
      * Unbraced then-throw with else block.
+     *
      * @param num A number
      */
     public void unbraced(final int num) {
@@ -48,6 +52,7 @@ public final class InvalidIfThenThrowElse {
 
     /**
      * Both branches throw, still prohibited.
+     *
      * @param num A number
      */
     public void both(final int num) {

--- a/src/test/resources/com/qulice/checkstyle/InvalidLeadingComma.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidLeadingComma.java
@@ -6,12 +6,14 @@ package foo;
 /**
  * Demonstrates a comma placed at the beginning of a line, which is
  * disallowed by the Google Java Style Guide.
+ *
  * @since 1.0
  */
 public final class InvalidLeadingComma {
 
     /**
      * Format a name into a greeting.
+     *
      * @param name The name
      * @return The formatted text
      */

--- a/src/test/resources/com/qulice/checkstyle/InvalidMethodDoc.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidMethodDoc.java
@@ -6,6 +6,7 @@ package foo;
 /**
  * The {@code InvalidMethodDoc#method} comment isn't javadoc, but it's not a reason
  * to fail {@code MultilineJavadocTagsCheck} validation with an unhandled exception.
+ *
  * @foo bar
  */
 class InvalidMethodDoc {

--- a/src/test/resources/com/qulice/checkstyle/InvalidMethodName.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidMethodName.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Rejects a two-letter name that is not an English word.
+ *
  * @since 1.0
  */
 public final class InvalidMethodName {
@@ -16,6 +17,7 @@ public final class InvalidMethodName {
 
     /**
      * Ctor.
+     *
      * @param txt The text
      */
     public InvalidMethodName(final String txt) {
@@ -24,6 +26,7 @@ public final class InvalidMethodName {
 
     /**
      * The text.
+     *
      * @return The text
      */
     public String zz() {

--- a/src/test/resources/com/qulice/checkstyle/InvalidTypeParamDescription.java
+++ b/src/test/resources/com/qulice/checkstyle/InvalidTypeParamDescription.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Description of the class.
+ *
  * @param <T> type of the items
  * @since 1.0
  */
@@ -12,6 +13,7 @@ public interface InvalidTypeParamDescription<T> {
 
     /**
      * Take an element.
+     *
      * @param <E> type of the element
      * @return The element
      */

--- a/src/test/resources/com/qulice/checkstyle/JavadocLeadingAsteriskAlign.java
+++ b/src/test/resources/com/qulice/checkstyle/JavadocLeadingAsteriskAlign.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Leading asterisks drift out of alignment.
+ *
  * @since 1.0
  */
 public final class JavadocLeadingAsteriskAlign {
 
     /**
     * Name of the thing.
+    *
     * @return Name of it
     */
     public String name() {

--- a/src/test/resources/com/qulice/checkstyle/JnaDirectBinding.java
+++ b/src/test/resources/com/qulice/checkstyle/JnaDirectBinding.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Binding to a native library, mapped directly.
+ *
  * @since 1.0
  */
 public final class JnaDirectBinding implements com.sun.jna.Library {
 
     /**
      * Open a file.
+     *
      * @param name The name of the file
      * @param access The access mask
      * @param mode The sharing mode
@@ -21,6 +23,7 @@ public final class JnaDirectBinding implements com.sun.jna.Library {
 
     /**
      * The code of the last error.
+     *
      * @return The code
      */
     public native int GetLastError();

--- a/src/test/resources/com/qulice/checkstyle/JnaMappedLibrary.java
+++ b/src/test/resources/com/qulice/checkstyle/JnaMappedLibrary.java
@@ -7,12 +7,14 @@ import com.sun.jna.Library;
 
 /**
  * Binding to a native library, mapped as an interface.
+ *
  * @since 1.0
  */
 public interface JnaMappedLibrary extends Library {
 
     /**
      * Open a file.
+     *
      * @param name The name of the file
      * @param access The access mask
      * @param mode The sharing mode
@@ -23,6 +25,7 @@ public interface JnaMappedLibrary extends Library {
 
     /**
      * The code of the last error.
+     *
      * @return The code
      */
     int GetLastError();

--- a/src/test/resources/com/qulice/checkstyle/JnaStdCallBinding.java
+++ b/src/test/resources/com/qulice/checkstyle/JnaStdCallBinding.java
@@ -7,12 +7,14 @@ import com.sun.jna.win32.StdCallLibrary;
 
 /**
  * Binding to a native library of Windows.
+ *
  * @since 1.0
  */
 public interface JnaStdCallBinding extends StdCallLibrary {
 
     /**
      * Open a file.
+     *
      * @param name The name of the file
      * @param access The access mask
      * @param mode The sharing mode
@@ -23,6 +25,7 @@ public interface JnaStdCallBinding extends StdCallLibrary {
 
     /**
      * The code of the last error.
+     *
      * @return The code
      */
     int GetLastError();

--- a/src/test/resources/com/qulice/checkstyle/KnownSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/KnownSuppression.java
@@ -10,6 +10,7 @@ package foo;
 /**
  * Sample class mentioning @checkstyle in prose and suppressing
  * a configured check by its short name and by its full name.
+ *
  * @since 1.0
  */
 public interface KnownSuppression {

--- a/src/test/resources/com/qulice/checkstyle/LineWrapPackage.java
+++ b/src/test/resources/com/qulice/checkstyle/LineWrapPackage.java
@@ -6,11 +6,13 @@ package foo
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public interface LineWrapPackage {
     /**
      * Some data.
+     *
      * @return Some data
      */
     Integer data();

--- a/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
+++ b/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  * @checkstyle HiddenField (100 lines)
  */
@@ -29,6 +30,7 @@ public final class LocalVariableNames {
 
     /**
      * Just a valid method.
+     *
      * @param id
      *  A valid parameter with name 'id'
      * @return Some value
@@ -39,6 +41,7 @@ public final class LocalVariableNames {
 
     /**
      * Another valid method.
+     *
      * @param parametername Another parameter that's valid
      */
     static void validtwo(final int parametername) {
@@ -86,6 +89,7 @@ public final class LocalVariableNames {
 
     /**
      * Just an invalid method that test all cases.
+     *
      * @param it
      *  An invalid parameter with name 'it'
      * @return Some value

--- a/src/test/resources/com/qulice/checkstyle/LongLambdaInBody.java
+++ b/src/test/resources/com/qulice/checkstyle/LongLambdaInBody.java
@@ -7,12 +7,14 @@ import java.util.function.Supplier;
 
 /**
  * Simple.
+ *
  * @since 0.24.2
  */
 public final class LongLambdaInBody {
 
     /**
      * Build a supplier.
+     *
      * @return The supplier
      */
     public Supplier<Integer> build() {

--- a/src/test/resources/com/qulice/checkstyle/MavenParameters.java
+++ b/src/test/resources/com/qulice/checkstyle/MavenParameters.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Mojo with parameters injected by Maven.
+ *
  * @since 1.0
  */
 public abstract class MavenParameters {

--- a/src/test/resources/com/qulice/checkstyle/MissingJavadocTest.java
+++ b/src/test/resources/com/qulice/checkstyle/MissingJavadocTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 class MissingJavadocTest {

--- a/src/test/resources/com/qulice/checkstyle/NestedClosingBrackets.java
+++ b/src/test/resources/com/qulice/checkstyle/NestedClosingBrackets.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class NestedClosingBrackets {
@@ -25,6 +26,7 @@ public final class NestedClosingBrackets {
 
     /**
      * Ctor.
+     *
      * @param masks Globs
      * @param names Files
      */
@@ -36,6 +38,7 @@ public final class NestedClosingBrackets {
 
     /**
      * Filter them.
+     *
      * @return The files
      */
     public Collection<String> filtered() {
@@ -48,6 +51,7 @@ public final class NestedClosingBrackets {
 
     /**
      * Join them.
+     *
      * @return The text
      */
     public String joined() {

--- a/src/test/resources/com/qulice/checkstyle/NonAsciiLineLength.java
+++ b/src/test/resources/com/qulice/checkstyle/NonAsciiLineLength.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Non-ASCII characters must not be double-counted by LineLengthCheck.
+ *
  * @since 1.0
  */
 public final class NonAsciiLineLength {

--- a/src/test/resources/com/qulice/checkstyle/ParametrizedClass.java
+++ b/src/test/resources/com/qulice/checkstyle/ParametrizedClass.java
@@ -7,11 +7,13 @@ import java.util.List;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public interface ParametrizedClass<T> {
     /**
      * Some data.
+     *
      * @return Some data
      */
     List<T> data();

--- a/src/test/resources/com/qulice/checkstyle/PrivateFourParameters.java
+++ b/src/test/resources/com/qulice/checkstyle/PrivateFourParameters.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Class with a private method of four parameters.
+ *
  * @since 1.0
  */
 public final class PrivateFourParameters {
@@ -16,6 +17,7 @@ public final class PrivateFourParameters {
 
     /**
      * Ctor.
+     *
      * @param num The base
      */
     public PrivateFourParameters(final int num) {
@@ -24,6 +26,7 @@ public final class PrivateFourParameters {
 
     /**
      * Sum of a few numbers.
+     *
      * @return The sum
      */
     public int total() {

--- a/src/test/resources/com/qulice/checkstyle/ReturnCount.java
+++ b/src/test/resources/com/qulice/checkstyle/ReturnCount.java
@@ -5,11 +5,13 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ReturnCount {
     /**
      * Method with two {@code return} statements.
+     *
      * @param number Some nice number
      */
     public int methodWithTwoReturns(final int number) {

--- a/src/test/resources/com/qulice/checkstyle/ShortMethodNames.java
+++ b/src/test/resources/com/qulice/checkstyle/ShortMethodNames.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 
 /**
  * Allows short English words as method names.
+ *
  * @since 1.0
  */
 public final class ShortMethodNames {
@@ -19,6 +20,7 @@ public final class ShortMethodNames {
 
     /**
      * Ctor.
+     *
      * @param txt The text
      */
     public ShortMethodNames(final String txt) {
@@ -27,6 +29,7 @@ public final class ShortMethodNames {
 
     /**
      * The text as a string.
+     *
      * @return The text
      */
     public String as() {
@@ -35,6 +38,7 @@ public final class ShortMethodNames {
 
     /**
      * The character at the given position.
+     *
      * @param position The position
      * @return The character
      */
@@ -44,6 +48,7 @@ public final class ShortMethodNames {
 
     /**
      * The text sorted by the given comparator.
+     *
      * @param order The comparator
      * @return The text
      */
@@ -53,6 +58,7 @@ public final class ShortMethodNames {
 
     /**
      * Move forward.
+     *
      * @return The text
      */
     public String go() {
@@ -61,6 +67,7 @@ public final class ShortMethodNames {
 
     /**
      * The identity of this object.
+     *
      * @return The text
      */
     public String id() {
@@ -69,6 +76,7 @@ public final class ShortMethodNames {
 
     /**
      * Is the text present in the given line?
+     *
      * @param line The line
      * @return True if present
      */
@@ -78,6 +86,7 @@ public final class ShortMethodNames {
 
     /**
      * Is the text empty?
+     *
      * @return True if empty
      */
     public boolean is() {
@@ -86,6 +95,7 @@ public final class ShortMethodNames {
 
     /**
      * The text itself.
+     *
      * @return The text
      */
     public String it() {
@@ -94,6 +104,7 @@ public final class ShortMethodNames {
 
     /**
      * The text of the given length.
+     *
      * @param length The length
      * @return The text
      */
@@ -103,6 +114,7 @@ public final class ShortMethodNames {
 
     /**
      * React on the given event.
+     *
      * @param event The event
      * @return The text
      */
@@ -112,6 +124,7 @@ public final class ShortMethodNames {
 
     /**
      * The text or the given alternative.
+     *
      * @param alternative The alternative
      * @return The text
      */
@@ -121,6 +134,7 @@ public final class ShortMethodNames {
 
     /**
      * The text converted to the given charset.
+     *
      * @param charset The charset
      * @return The text
      */
@@ -130,6 +144,7 @@ public final class ShortMethodNames {
 
     /**
      * The text in upper case.
+     *
      * @return The text
      */
     public String up() {

--- a/src/test/resources/com/qulice/checkstyle/SuppressConditionalRegexpMultilineInComment.java
+++ b/src/test/resources/com/qulice/checkstyle/SuppressConditionalRegexpMultilineInComment.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 
 /**
  * Sample class for testing ConditionalRegexpMultilineCheck suppression.
+ *
  * @since 1.0
  */
 public final class SuppressConditionalRegexpMultilineInComment {
@@ -19,6 +20,7 @@ public final class SuppressConditionalRegexpMultilineInComment {
 
     /**
      * Primary constructor.
+     *
      * @param sze Size to store
      */
     public SuppressConditionalRegexpMultilineInComment(final int sze) {
@@ -27,6 +29,7 @@ public final class SuppressConditionalRegexpMultilineInComment {
 
     /**
      * Build a collection without size.
+     *
      * @return An empty collection sized to this object
      * @checkstyle ConditionalRegexpMultilineCheck (5 lines)
      */

--- a/src/test/resources/com/qulice/checkstyle/SuppressLineLengthInComment.java
+++ b/src/test/resources/com/qulice/checkstyle/SuppressLineLengthInComment.java
@@ -9,6 +9,7 @@ package foo;
 
 /**
  * Sample class for testing LineLength suppression in comments.
+ *
  * @since 1.0
  */
 public interface SuppressLineLengthInComment {

--- a/src/test/resources/com/qulice/checkstyle/SuppressedMethodName.java
+++ b/src/test/resources/com/qulice/checkstyle/SuppressedMethodName.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Suppresses the method name check by its short name.
+ *
  * @since 1.0
  */
 public interface SuppressedMethodName {
 
     /**
      * The code of the last error.
+     *
      * @return The code
      * @checkstyle MethodName (2 lines)
      */

--- a/src/test/resources/com/qulice/checkstyle/TooLongLines.java
+++ b/src/test/resources/com/qulice/checkstyle/TooLongLines.java
@@ -5,6 +5,7 @@ package foo.bar;
 
 /**
  * Very long lines.
+ *
  * @deprecated Very very very very very very very very very very very long reason, extended line length.
  */
 @Deprecated

--- a/src/test/resources/com/qulice/checkstyle/TwinClosingBrackets.java
+++ b/src/test/resources/com/qulice/checkstyle/TwinClosingBrackets.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class TwinClosingBrackets {
@@ -25,6 +26,7 @@ public final class TwinClosingBrackets {
 
     /**
      * Ctor.
+     *
      * @param masks Globs
      * @param names Files
      */
@@ -36,6 +38,7 @@ public final class TwinClosingBrackets {
 
     /**
      * Filter them.
+     *
      * @return The files
      */
     public Collection<String> filtered() {

--- a/src/test/resources/com/qulice/checkstyle/Underscored_Name.java
+++ b/src/test/resources/com/qulice/checkstyle/Underscored_Name.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Production class with an underscore in its name.
+ *
  * @since 1.0
  */
 public final class Underscored_Name {
 
     /**
      * Any action.
+     *
      * @return Any string
      */
     public String action() {

--- a/src/test/resources/com/qulice/checkstyle/Underscored_NameIT.java
+++ b/src/test/resources/com/qulice/checkstyle/Underscored_NameIT.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Integration test class with an underscore in its name.
+ *
  * @since 1.0
  */
 public final class Underscored_NameIT {
 
     /**
      * Any action.
+     *
      * @return Any string
      */
     public String action() {

--- a/src/test/resources/com/qulice/checkstyle/Underscored_NameTest.java
+++ b/src/test/resources/com/qulice/checkstyle/Underscored_NameTest.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Unit test class with an underscore in its name.
+ *
  * @since 1.0
  */
 public final class Underscored_NameTest {
 
     /**
      * Any action.
+     *
      * @return Any string
      */
     public String action() {

--- a/src/test/resources/com/qulice/checkstyle/UnknownSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/UnknownSuppression.java
@@ -7,6 +7,7 @@ package foo;
 
 /**
  * Sample class suppressing a check that is absent from checks.xml.
+ *
  * @since 1.0
  * @checkstyle ClassDataAbstractionCoupling (2 lines)
  */

--- a/src/test/resources/com/qulice/checkstyle/UnnecessaryJavaLang.java
+++ b/src/test/resources/com/qulice/checkstyle/UnnecessaryJavaLang.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 
 /**
  * Simple.
+ *
  * @see java.lang.Object
  * @since 1.0
  */
@@ -19,6 +20,7 @@ public final class UnnecessaryJavaLang {
 
     /**
      * Ctor.
+     *
      * @param txt Text
      * @throws java.lang.Exception If a problem occurs
      */
@@ -28,6 +30,7 @@ public final class UnnecessaryJavaLang {
 
     /**
      * Act.
+     *
      * @return Size
      */
     public int act() {
@@ -37,6 +40,7 @@ public final class UnnecessaryJavaLang {
 
     /**
      * Xpath query used as test data.
+     *
      * @return Query string
      */
     public String xpath() {
@@ -45,6 +49,7 @@ public final class UnnecessaryJavaLang {
 
     /**
      * Xpath query kept in a text block.
+     *
      * @return Query string
      */
     public String snippet() {

--- a/src/test/resources/com/qulice/checkstyle/UnusedDisableSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/UnusedDisableSuppression.java
@@ -6,6 +6,7 @@ package foo;
 
 /**
  * Sample class whose disable/enable suppression covers no violation.
+ *
  * @since 1.0
  */
 public interface UnusedDisableSuppression {

--- a/src/test/resources/com/qulice/checkstyle/UnusedSuppression.java
+++ b/src/test/resources/com/qulice/checkstyle/UnusedSuppression.java
@@ -8,6 +8,7 @@ package foo;
 /**
  * Sample class whose suppression names a configured check but covers no
  * violation of it, so the suppression has no effect.
+ *
  * @since 1.0
  */
 public interface UnusedSuppression {

--- a/src/test/resources/com/qulice/checkstyle/UrlInLongLine.java
+++ b/src/test/resources/com/qulice/checkstyle/UrlInLongLine.java
@@ -6,6 +6,7 @@ package foo;
 /**
  * Very long lines.
  * https://very-long.net/thisUrlIsVeryLong?AndItHasQueryParams=1&url%2encoding#withHashTags
+ *
  * @since 1.0
  */
 public interface UrlInLongLine {

--- a/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
@@ -7,6 +7,7 @@ package foo;
  * Classname contains no abbreviations.
  * Contains overridden method for which otherwise invalid uppercase use is
  * allowed.
+ *
  * @since 1.0
  */
 public class ValidAbbreviationAsWordInName extends SomeClass {
@@ -25,6 +26,7 @@ public class ValidAbbreviationAsWordInName extends SomeClass {
 
     /**
      * The constant, so that it is not used only once.
+     *
      * @return The constant
      */
     public static String constant() {
@@ -38,6 +40,7 @@ public class ValidAbbreviationAsWordInName extends SomeClass {
 
     /**
      * ValidInnerHtml example class having the abbreviation in camelcase.
+     *
      * @since 1.0
      */
     public class ValidInnerHtml {

--- a/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Uppercase abbreviation IT in class name is allowed.
+ *
  * @since 1.0
  */
 public class ValidAbbreviationAsWordInNameIT {
 
     /**
      * Valid name on inner class, because the IT abbreviation is allowed.
+     *
      * @since 1.0
      */
     class ValidInnerIT {

--- a/src/test/resources/com/qulice/checkstyle/ValidDiamondsUsage.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidDiamondsUsage.java
@@ -11,6 +11,7 @@ import org.cactoos.map.MapOf;
 
 /**
  * Better to use diamond operator where possible.
+ *
  * @since 1.0
  */
 public final class ValidDiamondsUsage {
@@ -56,12 +57,14 @@ public final class ValidDiamondsUsage {
 
     /**
      * Simple interface, used as wrapper.
+     *
      * @since 1.0
      */
     interface SimpleInterface {
 
         /**
          * Inner class with generic parameter.
+         *
          * @param <E> Generic parameter
          * @since 1.0
          */

--- a/src/test/resources/com/qulice/checkstyle/ValidEnhancedForColon.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidEnhancedForColon.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ValidEnhancedForColon {
@@ -18,6 +19,7 @@ public final class ValidEnhancedForColon {
 
     /**
      * Ctor.
+     *
      * @param start Starting value
      */
     public ValidEnhancedForColon(final int start) {
@@ -26,6 +28,7 @@ public final class ValidEnhancedForColon {
 
     /**
      * Sum with base.
+     *
      * @param numbers Numbers
      * @return Total
      */

--- a/src/test/resources/com/qulice/checkstyle/ValidEnumValues.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidEnumValues.java
@@ -6,6 +6,7 @@ package foo;
 /**
  * Declares enum constants with names that follow the required
  * upper-case, underscore-separated convention.
+ *
  * @since 1.0
  */
 public enum ValidEnumValues {

--- a/src/test/resources/com/qulice/checkstyle/ValidEqualityOperatorWrap.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidEqualityOperatorWrap.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ValidEqualityOperatorWrap {
@@ -16,6 +17,7 @@ public final class ValidEqualityOperatorWrap {
 
     /**
      * Ctor.
+     *
      * @param val Value
      */
     public ValidEqualityOperatorWrap(final int val) {
@@ -24,6 +26,7 @@ public final class ValidEqualityOperatorWrap {
 
     /**
      * Returns something.
+     *
      * @param other Other
      * @return True if matches
      */

--- a/src/test/resources/com/qulice/checkstyle/ValidFluentCallFormatting.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidFluentCallFormatting.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ValidFluentCallFormatting {
@@ -19,6 +20,7 @@ public final class ValidFluentCallFormatting {
 
     /**
      * Ctor.
+     *
      * @param sep Separator
      */
     public ValidFluentCallFormatting(final String sep) {
@@ -27,6 +29,7 @@ public final class ValidFluentCallFormatting {
 
     /**
      * Returns something.
+     *
      * @return Something
      */
     public String make() {
@@ -38,6 +41,7 @@ public final class ValidFluentCallFormatting {
 
     /**
      * Returns something else.
+     *
      * @return Something else
      */
     public String pick() {

--- a/src/test/resources/com/qulice/checkstyle/ValidIT.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidIT.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public class ValidIT {
 
     /**
      * Any action.
+     *
      * @return Any string
      */
     public final String action() {

--- a/src/test/resources/com/qulice/checkstyle/ValidITCase.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidITCase.java
@@ -5,12 +5,14 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public class ValidITCase {
 
     /**
      * Any action.
+     *
      * @return Any string
      */
     public final String action() {

--- a/src/test/resources/com/qulice/checkstyle/ValidIfThenThrowElse.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidIfThenThrowElse.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Samples where the if/throw/else pattern is absent.
+ *
  * @since 1.0
  */
 public final class ValidIfThenThrowElse {
@@ -16,6 +17,7 @@ public final class ValidIfThenThrowElse {
 
     /**
      * Constructor.
+     *
      * @param name The label
      */
     public ValidIfThenThrowElse(final String name) {
@@ -24,6 +26,7 @@ public final class ValidIfThenThrowElse {
 
     /**
      * Throw without any else is allowed.
+     *
      * @param num A number
      */
     public void guard(final int num) {
@@ -35,6 +38,7 @@ public final class ValidIfThenThrowElse {
 
     /**
      * Else allowed when then branch does not throw.
+     *
      * @param num A number
      */
     public void plain(final int num) {
@@ -47,6 +51,7 @@ public final class ValidIfThenThrowElse {
 
     /**
      * Throw not at the tail of the then branch: still allowed.
+     *
      * @param num A number
      */
     public void tail(final int num) {

--- a/src/test/resources/com/qulice/checkstyle/ValidIndentation.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidIndentation.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ValidIndentation {
@@ -16,6 +17,7 @@ public final class ValidIndentation {
 
     /**
      * Ctor.
+     *
      * @param txt Name
      */
     public ValidIndentation(final String txt) {
@@ -24,6 +26,7 @@ public final class ValidIndentation {
 
     /**
      * Do something.
+     *
      * @return The size
      */
     public int doit() {

--- a/src/test/resources/com/qulice/checkstyle/ValidLambdaAndGenericsAtEndOfLine.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidLambdaAndGenericsAtEndOfLine.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ValidLambdaAndGenericsAtEndOfLine {

--- a/src/test/resources/com/qulice/checkstyle/ValidLambdaIndentation.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidLambdaIndentation.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ValidLambdaIndentation {
@@ -18,6 +19,7 @@ public final class ValidLambdaIndentation {
 
     /**
      * Ctor.
+     *
      * @param value Value
      */
     public ValidLambdaIndentation(final float value) {
@@ -30,6 +32,7 @@ public final class ValidLambdaIndentation {
 
     /**
      * Ctor.
+     *
      * @param wrapped Wrapped
      */
     private ValidLambdaIndentation(final Supplier<Supplier<Float>> wrapped) {
@@ -38,6 +41,7 @@ public final class ValidLambdaIndentation {
 
     /**
      * Value.
+     *
      * @return Float
      */
     public Float val() {
@@ -46,6 +50,7 @@ public final class ValidLambdaIndentation {
 
     /**
      * Boxed.
+     *
      * @param <T> Type
      * @since 1.0
      */
@@ -58,6 +63,7 @@ public final class ValidLambdaIndentation {
 
         /**
          * Ctor.
+         *
          * @param spr Supplier
          */
         Boxed(final Supplier<T> spr) {
@@ -66,6 +72,7 @@ public final class ValidLambdaIndentation {
 
         /**
          * Value.
+         *
          * @return Value
          */
         public T value() {

--- a/src/test/resources/com/qulice/checkstyle/ValidLiteralComparisonCheck.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidLiteralComparisonCheck.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ValidLiteralComparisonCheck {
@@ -16,6 +17,7 @@ public final class ValidLiteralComparisonCheck {
 
     /**
      * Constructor.
+     *
      * @param txt Some text
      */
     public ValidLiteralCheck(final String txt) {

--- a/src/test/resources/com/qulice/checkstyle/ValidRecord.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidRecord.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Defines a simple record type.
+ *
  * @since 1.0
  */
 public final class ValidRecord {
@@ -18,6 +19,7 @@ public final class ValidRecord {
 
     /**
      * Just a record type which should be successfully parsed.
+     *
      * @param hello Some field
      * @param world Another field
      * @since 1.0

--- a/src/test/resources/com/qulice/checkstyle/ValidSemicolon.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidSemicolon.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Simple.
+ *
  * @since 1.0
  */
 public final class ValidSemicolon {

--- a/src/test/resources/com/qulice/checkstyle/ValidSingleLineCommentCheck.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidSingleLineCommentCheck.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Correct Javadoc for class {@link AtClauseOrder}.
+ *
  * @since 1.0
  */
 public final class ValidSingleLineCommentCheck {

--- a/src/test/resources/com/qulice/checkstyle/ValidTypeParamDescription.java
+++ b/src/test/resources/com/qulice/checkstyle/ValidTypeParamDescription.java
@@ -5,6 +5,7 @@ package foo;
 
 /**
  * Description of the class.
+ *
  * @param <T> Type of the items
  * @since 1.0
  */
@@ -12,6 +13,7 @@ public interface ValidTypeParamDescription<T> {
 
     /**
      * Take an element.
+     *
      * @param <E> Type of the element
      * @return The element
      */

--- a/src/test/resources/com/qulice/checkstyle/WindowsEol.java
+++ b/src/test/resources/com/qulice/checkstyle/WindowsEol.java
@@ -6,6 +6,7 @@
 package foo;
 /**
  * Simple class.
+ *
  * @since 1.0
  */
 public class WindowsEol { }

--- a/src/test/resources/com/qulice/checkstyle/WindowsEolLinux.java
+++ b/src/test/resources/com/qulice/checkstyle/WindowsEolLinux.java
@@ -6,6 +6,7 @@
 package foo;
 /**
  * Just a simple class.
+ *
  * @since 1.0
  */
 public class WindowsEolLinux { }


### PR DESCRIPTION
Closes #1810

`JavadocEmptyLineBeforeTagCheck` used to make the empty line before the at-clause block **conditional** on the shape of the description: required when it spanned more than one paragraph, forbidden when it was a single paragraph. That is the conditional rule #1563 complained about, and it is why both of these passed:

```java
/**
 * Auto name for abstract object,
 * which works just great.
 * @since 0.57.4
 */
```

```java
/**
 * Auto name for abstract object,
 * which works just great.
 *
 * @since 0.57.4
 */
```

Now only the second one passes. The check demands the empty line in every case and reports a single message, `Empty Javadoc line required before the block of at-clauses`.

## What changed

* `JavadocEmptyLineBeforeTagCheck` drops the paragraph-counting logic (the whole `inspect` method) in favour of one condition: if a Javadoc block has at-clauses and a description above them, the line right before the first at-clause must be an empty Javadoc line.
* `RECORD_DEF` and `COMPACT_CTOR_DEF` join the token list, so the rule covers records alongside packages, classes, interfaces, enums, enum constants, annotations, annotation fields, fields, constructors and methods.
* Two shapes are still left alone, as before: a block with no at-clauses at all, and a block whose very first line already is an at-clause.
* The stock `RequireEmptyLineBeforeBlockTagGroup` stays at `severity=ignore` — it now demands exactly the same thing, so enabling it would report every mistake twice. Its comment in `checks.xml` says that instead of describing the old contradiction.
* `Invalid.java` / `Valid.java` / `violations.txt` for the check are rewritten for the new rule, and `Valid.java` gains a body-less Javadoc case.

## Reformatting

Qulice validates Qulice, so the new rule applies to this repository too. Reformatted mechanically, with the same algorithm the check uses:

* 458 insertions across `src/main/java` and `src/test/java`
* 206 insertions across the test resources that are validated with the full config
* 47 insertions across the invoker projects under `src/it`

The `ChecksTest` per-check resource trees are deliberately untouched — each runs with only its own check enabled, and their `violations.txt` files pin line numbers. The expected line numbers in the 21 tests that assert positions inside reformatted resources are shifted to match.

## Also: the four violations left by #1617

The `mvn verify -Pqulice` step has been red on `master` since the merge of #1617 ([run](https://github.com/yegor256/qulice/actions/runs/33722541341); `fe34b7d` before it was green), which blocked every PR in the repo, this one included. Since this PR has to be green, those are fixed here too — all four are in the same two files:

* `CloseInlineResourceRule` gets Javadoc on its constructor, matching `ExcessiveParameterListRule`, `TooManyMethodsRule` and `UnnecessaryLocalRule` (`MissingJavadocMethodCheck`).
* `closedDirectly` uses a pattern-matching `instanceof` — ErrorProne's own suggestion — and drops the separate cast (`PatternMatchingInstanceof`). The `parent` local stays so the `Node` import is still used.
* `CloseInlineResourceRuleTest` inlines the `PATH` constant at its only usage, which clears both `SingleUseConstantCheck` and `InlineFormatString` in one change.

Kept as a separate commit (`83e7c69`) from the Javadoc work, so it can be reviewed or split off on its own.

## Verification

* `mvn install` — 532 unit tests pass, 18 invoker ITs pass
* `mvn verify -Pqulice -DskipTests -DskipITs` — **no violations at all**, green for the first time since #1617 was merged
* Re-running the reformatter over the result inserts nothing, so the rule and the reformatting agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6vqrkxYrxTStnnzHDqwCp
